### PR TITLE
Use static SHA256 hashing helper

### DIFF
--- a/src/LM.Core/Utils/Helpers.cs
+++ b/src/LM.Core/Utils/Helpers.cs
@@ -23,8 +23,8 @@ namespace LM.Core.Utils
         public static string Sha256File(string path)
         {
             using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            var sha = SHA256.Create().ComputeHash(fs);
-            return Convert.ToHexString(sha).ToLowerInvariant();
+            var hash = SHA256.HashData(fs);
+            return Convert.ToHexString(hash).ToLowerInvariant();
         }
         public static string Sha1(string input)
         {


### PR DESCRIPTION
## Summary
- use the static `SHA256.HashData` helper when hashing files so no disposable instance is created unnecessarily

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca9f972bdc832bac2ac0ac06f3650d