### PR TITLE
Define LitSearch hook models used by spoke handler

### DIFF
--- a/CombinedPublicAPI.txt
+++ b/CombinedPublicAPI.txt
@@ -597,3 +597,601 @@ static LM.Core.Utils.IdGen.NewId() -> string!
 static LM.Core.Utils.JsonEx.Deserialize<T>(string! s) -> T?
 static LM.Core.Utils.JsonEx.Serialize<T>(T v) -> string!
 static readonly LM.Core.Utils.JsonEx.Options -> System.Text.Json.JsonSerializerOptions!
+---------- LM.Core ----------
+#nullable enable
+#nullable enable
+IPublicationLookup
+IPublicationLookup.TryGetByDoiAsync(string! doi, bool includeCitedBy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<LM.Core.Models.PublicationRecord?>!
+LM.Core.Abstractions.IContentExtractor
+LM.Core.Abstractions.IContentExtractor.ExtractTextAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IEntryStore
+LM.Core.Abstractions.IEntryStore.EnumerateAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<LM.Core.Models.Entry!>!
+LM.Core.Abstractions.IEntryStore.FindByHashAsync(string! sha256, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.FindByIdsAsync(string? doi, string? pmid, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.FindSimilarByNameYearAsync(string! title, int? year, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Core.Abstractions.IEntryStore.GetByIdAsync(string! id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IEntryStore.SaveAsync(LM.Core.Models.Entry! entry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IEntryStore.SearchAsync(LM.Core.Models.Filters.EntryFilter! filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Core.Abstractions.IFileStorageRepository
+LM.Core.Abstractions.IFileStorageRepository.SaveNewAsync(string! sourcePath, string! relativeTargetDir, string? preferredFileName = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IHasher
+LM.Core.Abstractions.IHasher.ComputeSha256Async(string! filePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IMetadataDebugSlideExporter
+LM.Core.Abstractions.IMetadataDebugSlideExporter.ExportAsync(System.Collections.Generic.IEnumerable<LM.Core.Models.FileMetadata!>! items, string! outputPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IMetadataExtractor
+LM.Core.Abstractions.IMetadataExtractor.ExtractAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.FileMetadata!>!
+LM.Core.Abstractions.IPmidNormalizer
+LM.Core.Abstractions.IPmidNormalizer.Normalize(string? raw) -> string?
+LM.Core.Abstractions.ISimilarityService
+LM.Core.Abstractions.ISimilarityService.ComputeFileSimilarityAsync(string! filePathA, string! filePathB, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<double>!
+LM.Core.Abstractions.IWorkSpaceService
+LM.Core.Abstractions.IWorkSpaceService.EnsureWorkspaceAsync(string! absoluteWorkspacePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IWorkSpaceService.GetAbsolutePath(string! relativePath) -> string!
+LM.Core.Abstractions.IWorkSpaceService.GetLocalDbPath() -> string!
+LM.Core.Abstractions.IWorkSpaceService.GetWorkspaceRoot() -> string!
+LM.Core.Abstractions.IWorkSpaceService.WorkspacePath.get -> string?
+LM.Core.Abstractions.IDoiNormalizer
+LM.Core.Abstractions.IDoiNormalizer.Normalize(string? raw) -> string?
+LM.Core.Models.AbstractSection
+LM.Core.Models.AbstractSection.Label.get -> string?
+LM.Core.Models.AbstractSection.Label.init -> void
+LM.Core.Models.AbstractSection.Text.get -> string?
+LM.Core.Models.AbstractSection.Text.init -> void
+LM.Core.Models.Attachment
+LM.Core.Models.Attachment.Attachment() -> void
+LM.Core.Models.Attachment.Id.get -> string!
+LM.Core.Models.Attachment.Id.set -> void
+LM.Core.Models.Attachment.Notes.get -> string?
+LM.Core.Models.Attachment.Notes.set -> void
+LM.Core.Models.Attachment.RelativePath.get -> string!
+LM.Core.Models.Attachment.RelativePath.set -> void
+LM.Core.Models.Attachment.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Attachment.Tags.set -> void
+LM.Core.Models.AuthorName
+LM.Core.Models.AuthorName.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.AuthorName.Affiliations.init -> void
+LM.Core.Models.AuthorName.CollectiveName.get -> string?
+LM.Core.Models.AuthorName.CollectiveName.init -> void
+LM.Core.Models.AuthorName.Family.get -> string?
+LM.Core.Models.AuthorName.Family.init -> void
+LM.Core.Models.AuthorName.Given.get -> string?
+LM.Core.Models.AuthorName.Given.init -> void
+LM.Core.Models.AuthorName.LastFromLiteral() -> string?
+LM.Core.Models.AuthorName.Literal.get -> string?
+LM.Core.Models.AuthorName.Literal.init -> void
+LM.Core.Models.AuthorName.Orcid.get -> string?
+LM.Core.Models.AuthorName.Orcid.init -> void
+LM.Core.Models.AuthorName.ToCsvPart() -> string!
+LM.Core.Models.Entry
+LM.Core.Models.Entry.AddedBy.get -> string?
+LM.Core.Models.Entry.AddedBy.set -> void
+LM.Core.Models.Entry.AddedOnUtc.get -> System.DateTime
+LM.Core.Models.Entry.AddedOnUtc.set -> void
+LM.Core.Models.Entry.Attachments.get -> System.Collections.Generic.List<LM.Core.Models.Attachment!>!
+LM.Core.Models.Entry.Attachments.set -> void
+LM.Core.Models.Entry.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Authors.set -> void
+LM.Core.Models.Entry.DisplayName.get -> string?
+LM.Core.Models.Entry.DisplayName.set -> void
+LM.Core.Models.Entry.Doi.get -> string?
+LM.Core.Models.Entry.Doi.set -> void
+LM.Core.Models.Entry.Entry() -> void
+LM.Core.Models.Entry.Id.get -> string!
+LM.Core.Models.Entry.Id.set -> void
+LM.Core.Models.Entry.InternalId.get -> string?
+LM.Core.Models.Entry.InternalId.set -> void
+LM.Core.Models.Entry.IsInternal.get -> bool
+LM.Core.Models.Entry.IsInternal.set -> void
+LM.Core.Models.Entry.Links.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Links.set -> void
+LM.Core.Models.Entry.MainFileHashSha256.get -> string?
+LM.Core.Models.Entry.MainFileHashSha256.set -> void
+LM.Core.Models.Entry.MainFilePath.get -> string!
+LM.Core.Models.Entry.MainFilePath.set -> void
+LM.Core.Models.Entry.Nct.get -> string?
+LM.Core.Models.Entry.Nct.set -> void
+LM.Core.Models.Entry.Notes.get -> string?
+LM.Core.Models.Entry.Notes.set -> void
+LM.Core.Models.Entry.OriginalFileName.get -> string?
+LM.Core.Models.Entry.OriginalFileName.set -> void
+LM.Core.Models.Entry.Pmid.get -> string?
+LM.Core.Models.Entry.Pmid.set -> void
+LM.Core.Models.Entry.Relations.get -> System.Collections.Generic.List<LM.Core.Models.Relation!>!
+LM.Core.Models.Entry.Relations.set -> void
+LM.Core.Models.Entry.ShortTitle.get -> string?
+LM.Core.Models.Entry.ShortTitle.set -> void
+LM.Core.Models.Entry.Source.get -> string?
+LM.Core.Models.Entry.Source.set -> void
+LM.Core.Models.Entry.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Tags.set -> void
+LM.Core.Models.Entry.Title.get -> string!
+LM.Core.Models.Entry.Title.set -> void
+LM.Core.Models.Entry.Type.get -> LM.Core.Models.EntryType
+LM.Core.Models.Entry.Type.set -> void
+LM.Core.Models.Entry.Version.get -> int
+LM.Core.Models.Entry.Version.set -> void
+LM.Core.Models.Entry.Year.get -> int?
+LM.Core.Models.Entry.Year.set -> void
+LM.Core.Models.EntryDocument
+LM.Core.Models.EntryDocument.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.EntryDocument.Authors.set -> void
+LM.Core.Models.EntryDocument.CreatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.EntryDocument.CreatedUtc.set -> void
+LM.Core.Models.EntryDocument.Doi.get -> string?
+LM.Core.Models.EntryDocument.Doi.set -> void
+LM.Core.Models.EntryDocument.EntryDocument() -> void
+LM.Core.Models.EntryDocument.Files.get -> System.Collections.Generic.List<LM.Core.Models.EntryFile!>!
+LM.Core.Models.EntryDocument.Files.set -> void
+LM.Core.Models.EntryDocument.Id.get -> string!
+LM.Core.Models.EntryDocument.Id.set -> void
+LM.Core.Models.EntryDocument.Internal.get -> bool
+LM.Core.Models.EntryDocument.Internal.set -> void
+LM.Core.Models.EntryDocument.Pmid.get -> string?
+LM.Core.Models.EntryDocument.Pmid.set -> void
+LM.Core.Models.EntryDocument.Source.get -> string?
+LM.Core.Models.EntryDocument.Source.set -> void
+LM.Core.Models.EntryDocument.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.EntryDocument.Tags.set -> void
+LM.Core.Models.EntryDocument.Title.get -> string?
+LM.Core.Models.EntryDocument.Title.set -> void
+LM.Core.Models.EntryDocument.UpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.EntryDocument.UpdatedUtc.set -> void
+LM.Core.Models.EntryDocument.Year.get -> int?
+LM.Core.Models.EntryDocument.Year.set -> void
+LM.Core.Models.EntryFile
+LM.Core.Models.EntryFile.EntryFile() -> void
+LM.Core.Models.EntryFile.Hash.get -> string!
+LM.Core.Models.EntryFile.Hash.set -> void
+LM.Core.Models.EntryFile.MimeType.get -> string!
+LM.Core.Models.EntryFile.MimeType.set -> void
+LM.Core.Models.EntryFile.OriginalFileName.get -> string!
+LM.Core.Models.EntryFile.OriginalFileName.set -> void
+LM.Core.Models.EntryFile.RelativePath.get -> string!
+LM.Core.Models.EntryFile.RelativePath.set -> void
+LM.Core.Models.EntryFile.SizeBytes.get -> long
+LM.Core.Models.EntryFile.SizeBytes.set -> void
+LM.Core.Models.EntryFile.StoredFileName.get -> string!
+LM.Core.Models.EntryFile.StoredFileName.set -> void
+LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Other = 5 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Presentation = 1 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Publication = 0 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Report = 4 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.SlideDeck = 3 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.WhitePaper = 2 -> LM.Core.Models.EntryType
+LM.Core.Models.FileMetadata
+LM.Core.Models.FileMetadata.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.FileMetadata.Authors.set -> void
+LM.Core.Models.FileMetadata.Doi.get -> string?
+LM.Core.Models.FileMetadata.Doi.set -> void
+LM.Core.Models.FileMetadata.FileMetadata() -> void
+LM.Core.Models.FileMetadata.Pmid.get -> string?
+LM.Core.Models.FileMetadata.Pmid.set -> void
+LM.Core.Models.FileMetadata.Source.get -> string?
+LM.Core.Models.FileMetadata.Source.set -> void
+LM.Core.Models.FileMetadata.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.FileMetadata.Tags.set -> void
+LM.Core.Models.FileMetadata.Title.get -> string?
+LM.Core.Models.FileMetadata.Title.set -> void
+LM.Core.Models.FileMetadata.Year.get -> int?
+LM.Core.Models.FileMetadata.Year.set -> void
+LM.Core.Models.Filters.EntryFilter
+LM.Core.Models.Filters.EntryFilter.AuthorContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.AuthorContains.set -> void
+LM.Core.Models.Filters.EntryFilter.EntryFilter() -> void
+LM.Core.Models.Filters.EntryFilter.IsInternal.get -> bool?
+LM.Core.Models.Filters.EntryFilter.IsInternal.set -> void
+LM.Core.Models.Filters.EntryFilter.TagsAny.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Filters.EntryFilter.TagsAny.set -> void
+LM.Core.Models.Filters.EntryFilter.TitleContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.TitleContains.set -> void
+LM.Core.Models.Filters.EntryFilter.TypesAny.get -> LM.Core.Models.EntryType[]?
+LM.Core.Models.Filters.EntryFilter.TypesAny.set -> void
+LM.Core.Models.Filters.EntryFilter.YearFrom.get -> int?
+LM.Core.Models.Filters.EntryFilter.YearFrom.set -> void
+LM.Core.Models.Filters.EntryFilter.YearTo.get -> int?
+LM.Core.Models.Filters.EntryFilter.YearTo.set -> void
+LM.Core.Models.GrantInfo
+LM.Core.Models.GrantInfo.Agency.get -> string?
+LM.Core.Models.GrantInfo.Agency.init -> void
+LM.Core.Models.GrantInfo.Country.get -> string?
+LM.Core.Models.GrantInfo.Country.init -> void
+LM.Core.Models.GrantInfo.GrantId.get -> string?
+LM.Core.Models.GrantInfo.GrantId.init -> void
+LM.Core.Models.PublicationRecord
+LM.Core.Models.PublicationRecord.AbstractPlain.get -> string?
+LM.Core.Models.PublicationRecord.AbstractPlain.init -> void
+LM.Core.Models.PublicationRecord.AbstractSections.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AbstractSection!>!
+LM.Core.Models.PublicationRecord.AbstractSections.init -> void
+LM.Core.Models.PublicationRecord.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.Affiliations.init -> void
+LM.Core.Models.PublicationRecord.Authors.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AuthorName!>!
+LM.Core.Models.PublicationRecord.Authors.init -> void
+LM.Core.Models.PublicationRecord.AuthorsCsv.get -> string!
+LM.Core.Models.PublicationRecord.CitedByCount.get -> int?
+LM.Core.Models.PublicationRecord.CitedByCount.init -> void
+LM.Core.Models.PublicationRecord.CitedByPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.CitedByPmids.init -> void
+LM.Core.Models.PublicationRecord.CommentsCorrections.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.CommentsCorrections.init -> void
+LM.Core.Models.PublicationRecord.Country.get -> string?
+LM.Core.Models.PublicationRecord.Country.init -> void
+LM.Core.Models.PublicationRecord.Doi.get -> string?
+LM.Core.Models.PublicationRecord.Doi.init -> void
+LM.Core.Models.PublicationRecord.FirstAuthorLast.get -> string!
+LM.Core.Models.PublicationRecord.Grants.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.GrantInfo!>!
+LM.Core.Models.PublicationRecord.Grants.init -> void
+LM.Core.Models.PublicationRecord.Issue.get -> string?
+LM.Core.Models.PublicationRecord.Issue.init -> void
+LM.Core.Models.PublicationRecord.JournalIsoAbbrev.get -> string?
+LM.Core.Models.PublicationRecord.JournalIsoAbbrev.init -> void
+LM.Core.Models.PublicationRecord.JournalTitle.get -> string?
+LM.Core.Models.PublicationRecord.JournalTitle.init -> void
+LM.Core.Models.PublicationRecord.Keywords.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.Keywords.init -> void
+LM.Core.Models.PublicationRecord.Language.get -> string?
+LM.Core.Models.PublicationRecord.Language.init -> void
+LM.Core.Models.PublicationRecord.MeshHeadings.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.MeshHeadings.init -> void
+LM.Core.Models.PublicationRecord.Pages.get -> string?
+LM.Core.Models.PublicationRecord.Pages.init -> void
+LM.Core.Models.PublicationRecord.Pmcid.get -> string?
+LM.Core.Models.PublicationRecord.Pmcid.init -> void
+LM.Core.Models.PublicationRecord.Pmid.get -> string?
+LM.Core.Models.PublicationRecord.Pmid.init -> void
+LM.Core.Models.PublicationRecord.PublicationTypes.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.PublicationTypes.init -> void
+LM.Core.Models.PublicationRecord.PublishedEpub.get -> System.DateOnly?
+LM.Core.Models.PublicationRecord.PublishedEpub.init -> void
+LM.Core.Models.PublicationRecord.PublishedPrint.get -> System.DateOnly?
+LM.Core.Models.PublicationRecord.PublishedPrint.init -> void
+LM.Core.Models.PublicationRecord.ReferencedPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.ReferencedPmids.init -> void
+LM.Core.Models.PublicationRecord.Title.get -> string?
+LM.Core.Models.PublicationRecord.Title.init -> void
+LM.Core.Models.PublicationRecord.UrlPubMed.get -> string?
+LM.Core.Models.PublicationRecord.UrlPubMed.init -> void
+LM.Core.Models.PublicationRecord.Volume.get -> string?
+LM.Core.Models.PublicationRecord.Volume.init -> void
+LM.Core.Models.PublicationRecord.Year.get -> int?
+LM.Core.Models.PublicationRecord.Year.init -> void
+LM.Core.Models.Relation
+LM.Core.Models.Relation.Relation() -> void
+LM.Core.Models.Relation.TargetEntryId.get -> string!
+LM.Core.Models.Relation.TargetEntryId.set -> void
+LM.Core.Models.Relation.Type.get -> string!
+LM.Core.Models.Relation.Type.set -> void
+LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchDatabase.ClinicalTrialsGov = 1 -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchDatabase.PubMed = 0 -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchHit
+LM.Core.Models.SearchHit.AlreadyInDb.get -> bool
+LM.Core.Models.SearchHit.AlreadyInDb.set -> void
+LM.Core.Models.SearchHit.Authors.get -> string!
+LM.Core.Models.SearchHit.Authors.init -> void
+LM.Core.Models.SearchHit.Doi.get -> string?
+LM.Core.Models.SearchHit.Doi.init -> void
+LM.Core.Models.SearchHit.ExternalId.get -> string!
+LM.Core.Models.SearchHit.ExternalId.init -> void
+LM.Core.Models.SearchHit.JournalOrSource.get -> string?
+LM.Core.Models.SearchHit.JournalOrSource.init -> void
+LM.Core.Models.SearchHit.SearchHit() -> void
+LM.Core.Models.SearchHit.Selected.get -> bool
+LM.Core.Models.SearchHit.Selected.set -> void
+LM.Core.Models.SearchHit.Source.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchHit.Source.init -> void
+LM.Core.Models.SearchHit.Title.get -> string!
+LM.Core.Models.SearchHit.Title.init -> void
+LM.Core.Models.SearchHit.Url.get -> string?
+LM.Core.Models.SearchHit.Url.init -> void
+LM.Core.Models.SearchHit.Year.get -> int?
+LM.Core.Models.SearchHit.Year.init -> void
+LM.Core.Utils.Hashes
+LM.Core.Utils.IdGen
+LM.Core.Utils.JsonEx
+static LM.Core.Utils.Hashes.Sha1(string! input) -> string!
+static LM.Core.Utils.Hashes.Sha256File(string! path) -> string!
+static LM.Core.Utils.IdGen.NewId() -> string!
+static LM.Core.Utils.JsonEx.Deserialize<T>(string! s) -> T?
+static LM.Core.Utils.JsonEx.Serialize<T>(T v) -> string!
+static readonly LM.Core.Utils.JsonEx.Options -> System.Text.Json.JsonSerializerOptions!
+---------- LM.Core ----------
+#nullable enable
+#nullable enable
+IPublicationLookup
+IPublicationLookup.TryGetByDoiAsync(string! doi, bool includeCitedBy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<LM.Core.Models.PublicationRecord?>!
+LM.Core.Abstractions.IContentExtractor
+LM.Core.Abstractions.IContentExtractor.ExtractTextAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IEntryStore
+LM.Core.Abstractions.IEntryStore.EnumerateAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<LM.Core.Models.Entry!>!
+LM.Core.Abstractions.IEntryStore.FindByHashAsync(string! sha256, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.FindByIdsAsync(string? doi, string? pmid, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.FindSimilarByNameYearAsync(string! title, int? year, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Core.Abstractions.IEntryStore.GetByIdAsync(string! id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IEntryStore.SaveAsync(LM.Core.Models.Entry! entry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IEntryStore.SearchAsync(LM.Core.Models.Filters.EntryFilter! filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Core.Abstractions.IFileStorageRepository
+LM.Core.Abstractions.IFileStorageRepository.SaveNewAsync(string! sourcePath, string! relativeTargetDir, string? preferredFileName = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IHasher
+LM.Core.Abstractions.IHasher.ComputeSha256Async(string! filePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IMetadataDebugSlideExporter
+LM.Core.Abstractions.IMetadataDebugSlideExporter.ExportAsync(System.Collections.Generic.IEnumerable<LM.Core.Models.FileMetadata!>! items, string! outputPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IMetadataExtractor
+LM.Core.Abstractions.IMetadataExtractor.ExtractAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.FileMetadata!>!
+LM.Core.Abstractions.IPmidNormalizer
+LM.Core.Abstractions.IPmidNormalizer.Normalize(string? raw) -> string?
+LM.Core.Abstractions.ISimilarityService
+LM.Core.Abstractions.ISimilarityService.ComputeFileSimilarityAsync(string! filePathA, string! filePathB, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<double>!
+LM.Core.Abstractions.IWorkSpaceService
+LM.Core.Abstractions.IWorkSpaceService.EnsureWorkspaceAsync(string! absoluteWorkspacePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IWorkSpaceService.GetAbsolutePath(string! relativePath) -> string!
+LM.Core.Abstractions.IWorkSpaceService.GetLocalDbPath() -> string!
+LM.Core.Abstractions.IWorkSpaceService.GetWorkspaceRoot() -> string!
+LM.Core.Abstractions.IWorkSpaceService.WorkspacePath.get -> string?
+LM.Core.Abstractions.IDoiNormalizer
+LM.Core.Abstractions.IDoiNormalizer.Normalize(string? raw) -> string?
+LM.Core.Models.AbstractSection
+LM.Core.Models.AbstractSection.Label.get -> string?
+LM.Core.Models.AbstractSection.Label.init -> void
+LM.Core.Models.AbstractSection.Text.get -> string?
+LM.Core.Models.AbstractSection.Text.init -> void
+LM.Core.Models.Attachment
+LM.Core.Models.Attachment.Attachment() -> void
+LM.Core.Models.Attachment.Id.get -> string!
+LM.Core.Models.Attachment.Id.set -> void
+LM.Core.Models.Attachment.Notes.get -> string?
+LM.Core.Models.Attachment.Notes.set -> void
+LM.Core.Models.Attachment.RelativePath.get -> string!
+LM.Core.Models.Attachment.RelativePath.set -> void
+LM.Core.Models.Attachment.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Attachment.Tags.set -> void
+LM.Core.Models.AuthorName
+LM.Core.Models.AuthorName.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.AuthorName.Affiliations.init -> void
+LM.Core.Models.AuthorName.CollectiveName.get -> string?
+LM.Core.Models.AuthorName.CollectiveName.init -> void
+LM.Core.Models.AuthorName.Family.get -> string?
+LM.Core.Models.AuthorName.Family.init -> void
+LM.Core.Models.AuthorName.Given.get -> string?
+LM.Core.Models.AuthorName.Given.init -> void
+LM.Core.Models.AuthorName.LastFromLiteral() -> string?
+LM.Core.Models.AuthorName.Literal.get -> string?
+LM.Core.Models.AuthorName.Literal.init -> void
+LM.Core.Models.AuthorName.Orcid.get -> string?
+LM.Core.Models.AuthorName.Orcid.init -> void
+LM.Core.Models.AuthorName.ToCsvPart() -> string!
+LM.Core.Models.Entry
+LM.Core.Models.Entry.AddedBy.get -> string?
+LM.Core.Models.Entry.AddedBy.set -> void
+LM.Core.Models.Entry.AddedOnUtc.get -> System.DateTime
+LM.Core.Models.Entry.AddedOnUtc.set -> void
+LM.Core.Models.Entry.Attachments.get -> System.Collections.Generic.List<LM.Core.Models.Attachment!>!
+LM.Core.Models.Entry.Attachments.set -> void
+LM.Core.Models.Entry.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Authors.set -> void
+LM.Core.Models.Entry.DisplayName.get -> string?
+LM.Core.Models.Entry.DisplayName.set -> void
+LM.Core.Models.Entry.Doi.get -> string?
+LM.Core.Models.Entry.Doi.set -> void
+LM.Core.Models.Entry.Entry() -> void
+LM.Core.Models.Entry.Id.get -> string!
+LM.Core.Models.Entry.Id.set -> void
+LM.Core.Models.Entry.InternalId.get -> string?
+LM.Core.Models.Entry.InternalId.set -> void
+LM.Core.Models.Entry.IsInternal.get -> bool
+LM.Core.Models.Entry.IsInternal.set -> void
+LM.Core.Models.Entry.Links.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Links.set -> void
+LM.Core.Models.Entry.MainFileHashSha256.get -> string?
+LM.Core.Models.Entry.MainFileHashSha256.set -> void
+LM.Core.Models.Entry.MainFilePath.get -> string!
+LM.Core.Models.Entry.MainFilePath.set -> void
+LM.Core.Models.Entry.Nct.get -> string?
+LM.Core.Models.Entry.Nct.set -> void
+LM.Core.Models.Entry.Notes.get -> string?
+LM.Core.Models.Entry.Notes.set -> void
+LM.Core.Models.Entry.OriginalFileName.get -> string?
+LM.Core.Models.Entry.OriginalFileName.set -> void
+LM.Core.Models.Entry.Pmid.get -> string?
+LM.Core.Models.Entry.Pmid.set -> void
+LM.Core.Models.Entry.Relations.get -> System.Collections.Generic.List<LM.Core.Models.Relation!>!
+LM.Core.Models.Entry.Relations.set -> void
+LM.Core.Models.Entry.ShortTitle.get -> string?
+LM.Core.Models.Entry.ShortTitle.set -> void
+LM.Core.Models.Entry.Source.get -> string?
+LM.Core.Models.Entry.Source.set -> void
+LM.Core.Models.Entry.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Tags.set -> void
+LM.Core.Models.Entry.Title.get -> string!
+LM.Core.Models.Entry.Title.set -> void
+LM.Core.Models.Entry.Type.get -> LM.Core.Models.EntryType
+LM.Core.Models.Entry.Type.set -> void
+LM.Core.Models.Entry.Version.get -> int
+LM.Core.Models.Entry.Version.set -> void
+LM.Core.Models.Entry.Year.get -> int?
+LM.Core.Models.Entry.Year.set -> void
+LM.Core.Models.EntryDocument
+LM.Core.Models.EntryDocument.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.EntryDocument.Authors.set -> void
+LM.Core.Models.EntryDocument.CreatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.EntryDocument.CreatedUtc.set -> void
+LM.Core.Models.EntryDocument.Doi.get -> string?
+LM.Core.Models.EntryDocument.Doi.set -> void
+LM.Core.Models.EntryDocument.EntryDocument() -> void
+LM.Core.Models.EntryDocument.Files.get -> System.Collections.Generic.List<LM.Core.Models.EntryFile!>!
+LM.Core.Models.EntryDocument.Files.set -> void
+LM.Core.Models.EntryDocument.Id.get -> string!
+LM.Core.Models.EntryDocument.Id.set -> void
+LM.Core.Models.EntryDocument.Internal.get -> bool
+LM.Core.Models.EntryDocument.Internal.set -> void
+LM.Core.Models.EntryDocument.Pmid.get -> string?
+LM.Core.Models.EntryDocument.Pmid.set -> void
+LM.Core.Models.EntryDocument.Source.get -> string?
+LM.Core.Models.EntryDocument.Source.set -> void
+LM.Core.Models.EntryDocument.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.EntryDocument.Tags.set -> void
+LM.Core.Models.EntryDocument.Title.get -> string?
+LM.Core.Models.EntryDocument.Title.set -> void
+LM.Core.Models.EntryDocument.UpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.EntryDocument.UpdatedUtc.set -> void
+LM.Core.Models.EntryDocument.Year.get -> int?
+LM.Core.Models.EntryDocument.Year.set -> void
+LM.Core.Models.EntryFile
+LM.Core.Models.EntryFile.EntryFile() -> void
+LM.Core.Models.EntryFile.Hash.get -> string!
+LM.Core.Models.EntryFile.Hash.set -> void
+LM.Core.Models.EntryFile.MimeType.get -> string!
+LM.Core.Models.EntryFile.MimeType.set -> void
+LM.Core.Models.EntryFile.OriginalFileName.get -> string!
+LM.Core.Models.EntryFile.OriginalFileName.set -> void
+LM.Core.Models.EntryFile.RelativePath.get -> string!
+LM.Core.Models.EntryFile.RelativePath.set -> void
+LM.Core.Models.EntryFile.SizeBytes.get -> long
+LM.Core.Models.EntryFile.SizeBytes.set -> void
+LM.Core.Models.EntryFile.StoredFileName.get -> string!
+LM.Core.Models.EntryFile.StoredFileName.set -> void
+LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Other = 5 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Presentation = 1 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Publication = 0 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Report = 4 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.SlideDeck = 3 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.WhitePaper = 2 -> LM.Core.Models.EntryType
+LM.Core.Models.FileMetadata
+LM.Core.Models.FileMetadata.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.FileMetadata.Authors.set -> void
+LM.Core.Models.FileMetadata.Doi.get -> string?
+LM.Core.Models.FileMetadata.Doi.set -> void
+LM.Core.Models.FileMetadata.FileMetadata() -> void
+LM.Core.Models.FileMetadata.Pmid.get -> string?
+LM.Core.Models.FileMetadata.Pmid.set -> void
+LM.Core.Models.FileMetadata.Source.get -> string?
+LM.Core.Models.FileMetadata.Source.set -> void
+LM.Core.Models.FileMetadata.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.FileMetadata.Tags.set -> void
+LM.Core.Models.FileMetadata.Title.get -> string?
+LM.Core.Models.FileMetadata.Title.set -> void
+LM.Core.Models.FileMetadata.Year.get -> int?
+LM.Core.Models.FileMetadata.Year.set -> void
+LM.Core.Models.Filters.EntryFilter
+LM.Core.Models.Filters.EntryFilter.AuthorContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.AuthorContains.set -> void
+LM.Core.Models.Filters.EntryFilter.EntryFilter() -> void
+LM.Core.Models.Filters.EntryFilter.IsInternal.get -> bool?
+LM.Core.Models.Filters.EntryFilter.IsInternal.set -> void
+LM.Core.Models.Filters.EntryFilter.TagsAny.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Filters.EntryFilter.TagsAny.set -> void
+LM.Core.Models.Filters.EntryFilter.TitleContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.TitleContains.set -> void
+LM.Core.Models.Filters.EntryFilter.TypesAny.get -> LM.Core.Models.EntryType[]?
+LM.Core.Models.Filters.EntryFilter.TypesAny.set -> void
+LM.Core.Models.Filters.EntryFilter.YearFrom.get -> int?
+LM.Core.Models.Filters.EntryFilter.YearFrom.set -> void
+LM.Core.Models.Filters.EntryFilter.YearTo.get -> int?
+LM.Core.Models.Filters.EntryFilter.YearTo.set -> void
+LM.Core.Models.GrantInfo
+LM.Core.Models.GrantInfo.Agency.get -> string?
+LM.Core.Models.GrantInfo.Agency.init -> void
+LM.Core.Models.GrantInfo.Country.get -> string?
+LM.Core.Models.GrantInfo.Country.init -> void
+LM.Core.Models.GrantInfo.GrantId.get -> string?
+LM.Core.Models.GrantInfo.GrantId.init -> void
+LM.Core.Models.PublicationRecord
+LM.Core.Models.PublicationRecord.AbstractPlain.get -> string?
+LM.Core.Models.PublicationRecord.AbstractPlain.init -> void
+LM.Core.Models.PublicationRecord.AbstractSections.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AbstractSection!>!
+LM.Core.Models.PublicationRecord.AbstractSections.init -> void
+LM.Core.Models.PublicationRecord.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.Affiliations.init -> void
+LM.Core.Models.PublicationRecord.Authors.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AuthorName!>!
+LM.Core.Models.PublicationRecord.Authors.init -> void
+LM.Core.Models.PublicationRecord.AuthorsCsv.get -> string!
+LM.Core.Models.PublicationRecord.CitedByCount.get -> int?
+LM.Core.Models.PublicationRecord.CitedByCount.init -> void
+LM.Core.Models.PublicationRecord.CitedByPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.CitedByPmids.init -> void
+LM.Core.Models.PublicationRecord.CommentsCorrections.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.CommentsCorrections.init -> void
+LM.Core.Models.PublicationRecord.Country.get -> string?
+LM.Core.Models.PublicationRecord.Country.init -> void
+LM.Core.Models.PublicationRecord.Doi.get -> string?
+LM.Core.Models.PublicationRecord.Doi.init -> void
+LM.Core.Models.PublicationRecord.FirstAuthorLast.get -> string!
+LM.Core.Models.PublicationRecord.Grants.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.GrantInfo!>!
+LM.Core.Models.PublicationRecord.Grants.init -> void
+LM.Core.Models.PublicationRecord.Issue.get -> string?
+LM.Core.Models.PublicationRecord.Issue.init -> void
+LM.Core.Models.PublicationRecord.JournalIsoAbbrev.get -> string?
+LM.Core.Models.PublicationRecord.JournalIsoAbbrev.init -> void
+LM.Core.Models.PublicationRecord.JournalTitle.get -> string?
+LM.Core.Models.PublicationRecord.JournalTitle.init -> void
+LM.Core.Models.PublicationRecord.Keywords.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.Keywords.init -> void
+LM.Core.Models.PublicationRecord.Language.get -> string?
+LM.Core.Models.PublicationRecord.Language.init -> void
+LM.Core.Models.PublicationRecord.MeshHeadings.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.MeshHeadings.init -> void
+LM.Core.Models.PublicationRecord.Pages.get -> string?
+LM.Core.Models.PublicationRecord.Pages.init -> void
+LM.Core.Models.PublicationRecord.Pmcid.get -> string?
+LM.Core.Models.PublicationRecord.Pmcid.init -> void
+LM.Core.Models.PublicationRecord.Pmid.get -> string?
+LM.Core.Models.PublicationRecord.Pmid.init -> void
+LM.Core.Models.PublicationRecord.PublicationTypes.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.PublicationTypes.init -> void
+LM.Core.Models.PublicationRecord.PublishedEpub.get -> System.DateOnly?
+LM.Core.Models.PublicationRecord.PublishedEpub.init -> void
+LM.Core.Models.PublicationRecord.PublishedPrint.get -> System.DateOnly?
+LM.Core.Models.PublicationRecord.PublishedPrint.init -> void
+LM.Core.Models.PublicationRecord.ReferencedPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.ReferencedPmids.init -> void
+LM.Core.Models.PublicationRecord.Title.get -> string?
+LM.Core.Models.PublicationRecord.Title.init -> void
+LM.Core.Models.PublicationRecord.UrlPubMed.get -> string?
+LM.Core.Models.PublicationRecord.UrlPubMed.init -> void
+LM.Core.Models.PublicationRecord.Volume.get -> string?
+LM.Core.Models.PublicationRecord.Volume.init -> void
+LM.Core.Models.PublicationRecord.Year.get -> int?
+LM.Core.Models.PublicationRecord.Year.init -> void
+LM.Core.Models.Relation
+LM.Core.Models.Relation.Relation() -> void
+LM.Core.Models.Relation.TargetEntryId.get -> string!
+LM.Core.Models.Relation.TargetEntryId.set -> void
+LM.Core.Models.Relation.Type.get -> string!
+LM.Core.Models.Relation.Type.set -> void
+LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchDatabase.ClinicalTrialsGov = 1 -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchDatabase.PubMed = 0 -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchHit
+LM.Core.Models.SearchHit.AlreadyInDb.get -> bool
+LM.Core.Models.SearchHit.AlreadyInDb.set -> void
+LM.Core.Models.SearchHit.Authors.get -> string!
+LM.Core.Models.SearchHit.Authors.init -> void
+LM.Core.Models.SearchHit.Doi.get -> string?
+LM.Core.Models.SearchHit.Doi.init -> void
+LM.Core.Models.SearchHit.ExternalId.get -> string!
+LM.Core.Models.SearchHit.ExternalId.init -> void
+LM.Core.Models.SearchHit.JournalOrSource.get -> string?
+LM.Core.Models.SearchHit.JournalOrSource.init -> void
+LM.Core.Models.SearchHit.SearchHit() -> void
+LM.Core.Models.SearchHit.Selected.get -> bool
+LM.Core.Models.SearchHit.Selected.set -> void
+LM.Core.Models.SearchHit.Source.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchHit.Source.init -> void
+LM.Core.Models.SearchHit.Title.get -> string!
+LM.Core.Models.SearchHit.Title.init -> void
+LM.Core.Models.SearchHit.Url.get -> string?
+LM.Core.Models.SearchHit.Url.init -> void
+LM.Core.Models.SearchHit.Year.get -> int?
+LM.Core.Models.SearchHit.Year.init -> void
+LM.Core.Utils.Hashes
+LM.Core.Utils.IdGen
+LM.Core.Utils.JsonEx
+static LM.Core.Utils.Hashes.Sha1(string! input) -> string!
+static LM.Core.Utils.Hashes.Sha256File(string! path) -> string!
+static LM.Core.Utils.IdGen.NewId() -> string!
+static LM.Core.Utils.JsonEx.Deserialize<T>(string! s) -> T?
+static LM.Core.Utils.JsonEx.Serialize<T>(T v) -> string!
+static readonly LM.Core.Utils.JsonEx.Options -> System.Text.Json.JsonSerializerOptions!

--- a/CombinedPublicAPI.txt
+++ b/CombinedPublicAPI.txt
@@ -298,3 +298,302 @@ static LM.Core.Utils.IdGen.NewId() -> string!
 static LM.Core.Utils.JsonEx.Deserialize<T>(string! s) -> T?
 static LM.Core.Utils.JsonEx.Serialize<T>(T v) -> string!
 static readonly LM.Core.Utils.JsonEx.Options -> System.Text.Json.JsonSerializerOptions!
+---------- LM.Core ----------
+#nullable enable
+#nullable enable
+IPublicationLookup
+IPublicationLookup.TryGetByDoiAsync(string! doi, bool includeCitedBy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<LM.Core.Models.PublicationRecord?>!
+LM.Core.Abstractions.IContentExtractor
+LM.Core.Abstractions.IContentExtractor.ExtractTextAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IEntryStore
+LM.Core.Abstractions.IEntryStore.EnumerateAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<LM.Core.Models.Entry!>!
+LM.Core.Abstractions.IEntryStore.FindByHashAsync(string! sha256, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.FindByIdsAsync(string? doi, string? pmid, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.FindSimilarByNameYearAsync(string! title, int? year, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Core.Abstractions.IEntryStore.GetByIdAsync(string! id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IEntryStore.SaveAsync(LM.Core.Models.Entry! entry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IEntryStore.SearchAsync(LM.Core.Models.Filters.EntryFilter! filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Core.Abstractions.IFileStorageRepository
+LM.Core.Abstractions.IFileStorageRepository.SaveNewAsync(string! sourcePath, string! relativeTargetDir, string? preferredFileName = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IHasher
+LM.Core.Abstractions.IHasher.ComputeSha256Async(string! filePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IMetadataDebugSlideExporter
+LM.Core.Abstractions.IMetadataDebugSlideExporter.ExportAsync(System.Collections.Generic.IEnumerable<LM.Core.Models.FileMetadata!>! items, string! outputPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IMetadataExtractor
+LM.Core.Abstractions.IMetadataExtractor.ExtractAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.FileMetadata!>!
+LM.Core.Abstractions.IPmidNormalizer
+LM.Core.Abstractions.IPmidNormalizer.Normalize(string? raw) -> string?
+LM.Core.Abstractions.ISimilarityService
+LM.Core.Abstractions.ISimilarityService.ComputeFileSimilarityAsync(string! filePathA, string! filePathB, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<double>!
+LM.Core.Abstractions.IWorkSpaceService
+LM.Core.Abstractions.IWorkSpaceService.EnsureWorkspaceAsync(string! absoluteWorkspacePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IWorkSpaceService.GetAbsolutePath(string! relativePath) -> string!
+LM.Core.Abstractions.IWorkSpaceService.GetLocalDbPath() -> string!
+LM.Core.Abstractions.IWorkSpaceService.GetWorkspaceRoot() -> string!
+LM.Core.Abstractions.IWorkSpaceService.WorkspacePath.get -> string?
+LM.Core.Abstractions.IDoiNormalizer
+LM.Core.Abstractions.IDoiNormalizer.Normalize(string? raw) -> string?
+LM.Core.Models.AbstractSection
+LM.Core.Models.AbstractSection.Label.get -> string?
+LM.Core.Models.AbstractSection.Label.init -> void
+LM.Core.Models.AbstractSection.Text.get -> string?
+LM.Core.Models.AbstractSection.Text.init -> void
+LM.Core.Models.Attachment
+LM.Core.Models.Attachment.Attachment() -> void
+LM.Core.Models.Attachment.Id.get -> string!
+LM.Core.Models.Attachment.Id.set -> void
+LM.Core.Models.Attachment.Notes.get -> string?
+LM.Core.Models.Attachment.Notes.set -> void
+LM.Core.Models.Attachment.RelativePath.get -> string!
+LM.Core.Models.Attachment.RelativePath.set -> void
+LM.Core.Models.Attachment.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Attachment.Tags.set -> void
+LM.Core.Models.AuthorName
+LM.Core.Models.AuthorName.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.AuthorName.Affiliations.init -> void
+LM.Core.Models.AuthorName.CollectiveName.get -> string?
+LM.Core.Models.AuthorName.CollectiveName.init -> void
+LM.Core.Models.AuthorName.Family.get -> string?
+LM.Core.Models.AuthorName.Family.init -> void
+LM.Core.Models.AuthorName.Given.get -> string?
+LM.Core.Models.AuthorName.Given.init -> void
+LM.Core.Models.AuthorName.LastFromLiteral() -> string?
+LM.Core.Models.AuthorName.Literal.get -> string?
+LM.Core.Models.AuthorName.Literal.init -> void
+LM.Core.Models.AuthorName.Orcid.get -> string?
+LM.Core.Models.AuthorName.Orcid.init -> void
+LM.Core.Models.AuthorName.ToCsvPart() -> string!
+LM.Core.Models.Entry
+LM.Core.Models.Entry.AddedBy.get -> string?
+LM.Core.Models.Entry.AddedBy.set -> void
+LM.Core.Models.Entry.AddedOnUtc.get -> System.DateTime
+LM.Core.Models.Entry.AddedOnUtc.set -> void
+LM.Core.Models.Entry.Attachments.get -> System.Collections.Generic.List<LM.Core.Models.Attachment!>!
+LM.Core.Models.Entry.Attachments.set -> void
+LM.Core.Models.Entry.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Authors.set -> void
+LM.Core.Models.Entry.DisplayName.get -> string?
+LM.Core.Models.Entry.DisplayName.set -> void
+LM.Core.Models.Entry.Doi.get -> string?
+LM.Core.Models.Entry.Doi.set -> void
+LM.Core.Models.Entry.Entry() -> void
+LM.Core.Models.Entry.Id.get -> string!
+LM.Core.Models.Entry.Id.set -> void
+LM.Core.Models.Entry.InternalId.get -> string?
+LM.Core.Models.Entry.InternalId.set -> void
+LM.Core.Models.Entry.IsInternal.get -> bool
+LM.Core.Models.Entry.IsInternal.set -> void
+LM.Core.Models.Entry.Links.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Links.set -> void
+LM.Core.Models.Entry.MainFileHashSha256.get -> string?
+LM.Core.Models.Entry.MainFileHashSha256.set -> void
+LM.Core.Models.Entry.MainFilePath.get -> string!
+LM.Core.Models.Entry.MainFilePath.set -> void
+LM.Core.Models.Entry.Nct.get -> string?
+LM.Core.Models.Entry.Nct.set -> void
+LM.Core.Models.Entry.Notes.get -> string?
+LM.Core.Models.Entry.Notes.set -> void
+LM.Core.Models.Entry.OriginalFileName.get -> string?
+LM.Core.Models.Entry.OriginalFileName.set -> void
+LM.Core.Models.Entry.Pmid.get -> string?
+LM.Core.Models.Entry.Pmid.set -> void
+LM.Core.Models.Entry.Relations.get -> System.Collections.Generic.List<LM.Core.Models.Relation!>!
+LM.Core.Models.Entry.Relations.set -> void
+LM.Core.Models.Entry.ShortTitle.get -> string?
+LM.Core.Models.Entry.ShortTitle.set -> void
+LM.Core.Models.Entry.Source.get -> string?
+LM.Core.Models.Entry.Source.set -> void
+LM.Core.Models.Entry.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Tags.set -> void
+LM.Core.Models.Entry.Title.get -> string!
+LM.Core.Models.Entry.Title.set -> void
+LM.Core.Models.Entry.Type.get -> LM.Core.Models.EntryType
+LM.Core.Models.Entry.Type.set -> void
+LM.Core.Models.Entry.Version.get -> int
+LM.Core.Models.Entry.Version.set -> void
+LM.Core.Models.Entry.Year.get -> int?
+LM.Core.Models.Entry.Year.set -> void
+LM.Core.Models.EntryDocument
+LM.Core.Models.EntryDocument.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.EntryDocument.Authors.set -> void
+LM.Core.Models.EntryDocument.CreatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.EntryDocument.CreatedUtc.set -> void
+LM.Core.Models.EntryDocument.Doi.get -> string?
+LM.Core.Models.EntryDocument.Doi.set -> void
+LM.Core.Models.EntryDocument.EntryDocument() -> void
+LM.Core.Models.EntryDocument.Files.get -> System.Collections.Generic.List<LM.Core.Models.EntryFile!>!
+LM.Core.Models.EntryDocument.Files.set -> void
+LM.Core.Models.EntryDocument.Id.get -> string!
+LM.Core.Models.EntryDocument.Id.set -> void
+LM.Core.Models.EntryDocument.Internal.get -> bool
+LM.Core.Models.EntryDocument.Internal.set -> void
+LM.Core.Models.EntryDocument.Pmid.get -> string?
+LM.Core.Models.EntryDocument.Pmid.set -> void
+LM.Core.Models.EntryDocument.Source.get -> string?
+LM.Core.Models.EntryDocument.Source.set -> void
+LM.Core.Models.EntryDocument.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.EntryDocument.Tags.set -> void
+LM.Core.Models.EntryDocument.Title.get -> string?
+LM.Core.Models.EntryDocument.Title.set -> void
+LM.Core.Models.EntryDocument.UpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.EntryDocument.UpdatedUtc.set -> void
+LM.Core.Models.EntryDocument.Year.get -> int?
+LM.Core.Models.EntryDocument.Year.set -> void
+LM.Core.Models.EntryFile
+LM.Core.Models.EntryFile.EntryFile() -> void
+LM.Core.Models.EntryFile.Hash.get -> string!
+LM.Core.Models.EntryFile.Hash.set -> void
+LM.Core.Models.EntryFile.MimeType.get -> string!
+LM.Core.Models.EntryFile.MimeType.set -> void
+LM.Core.Models.EntryFile.OriginalFileName.get -> string!
+LM.Core.Models.EntryFile.OriginalFileName.set -> void
+LM.Core.Models.EntryFile.RelativePath.get -> string!
+LM.Core.Models.EntryFile.RelativePath.set -> void
+LM.Core.Models.EntryFile.SizeBytes.get -> long
+LM.Core.Models.EntryFile.SizeBytes.set -> void
+LM.Core.Models.EntryFile.StoredFileName.get -> string!
+LM.Core.Models.EntryFile.StoredFileName.set -> void
+LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Other = 5 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Presentation = 1 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Publication = 0 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Report = 4 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.SlideDeck = 3 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.WhitePaper = 2 -> LM.Core.Models.EntryType
+LM.Core.Models.FileMetadata
+LM.Core.Models.FileMetadata.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.FileMetadata.Authors.set -> void
+LM.Core.Models.FileMetadata.Doi.get -> string?
+LM.Core.Models.FileMetadata.Doi.set -> void
+LM.Core.Models.FileMetadata.FileMetadata() -> void
+LM.Core.Models.FileMetadata.Pmid.get -> string?
+LM.Core.Models.FileMetadata.Pmid.set -> void
+LM.Core.Models.FileMetadata.Source.get -> string?
+LM.Core.Models.FileMetadata.Source.set -> void
+LM.Core.Models.FileMetadata.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.FileMetadata.Tags.set -> void
+LM.Core.Models.FileMetadata.Title.get -> string?
+LM.Core.Models.FileMetadata.Title.set -> void
+LM.Core.Models.FileMetadata.Year.get -> int?
+LM.Core.Models.FileMetadata.Year.set -> void
+LM.Core.Models.Filters.EntryFilter
+LM.Core.Models.Filters.EntryFilter.AuthorContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.AuthorContains.set -> void
+LM.Core.Models.Filters.EntryFilter.EntryFilter() -> void
+LM.Core.Models.Filters.EntryFilter.IsInternal.get -> bool?
+LM.Core.Models.Filters.EntryFilter.IsInternal.set -> void
+LM.Core.Models.Filters.EntryFilter.TagsAny.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Filters.EntryFilter.TagsAny.set -> void
+LM.Core.Models.Filters.EntryFilter.TitleContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.TitleContains.set -> void
+LM.Core.Models.Filters.EntryFilter.TypesAny.get -> LM.Core.Models.EntryType[]?
+LM.Core.Models.Filters.EntryFilter.TypesAny.set -> void
+LM.Core.Models.Filters.EntryFilter.YearFrom.get -> int?
+LM.Core.Models.Filters.EntryFilter.YearFrom.set -> void
+LM.Core.Models.Filters.EntryFilter.YearTo.get -> int?
+LM.Core.Models.Filters.EntryFilter.YearTo.set -> void
+LM.Core.Models.GrantInfo
+LM.Core.Models.GrantInfo.Agency.get -> string?
+LM.Core.Models.GrantInfo.Agency.init -> void
+LM.Core.Models.GrantInfo.Country.get -> string?
+LM.Core.Models.GrantInfo.Country.init -> void
+LM.Core.Models.GrantInfo.GrantId.get -> string?
+LM.Core.Models.GrantInfo.GrantId.init -> void
+LM.Core.Models.PublicationRecord
+LM.Core.Models.PublicationRecord.AbstractPlain.get -> string?
+LM.Core.Models.PublicationRecord.AbstractPlain.init -> void
+LM.Core.Models.PublicationRecord.AbstractSections.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AbstractSection!>!
+LM.Core.Models.PublicationRecord.AbstractSections.init -> void
+LM.Core.Models.PublicationRecord.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.Affiliations.init -> void
+LM.Core.Models.PublicationRecord.Authors.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AuthorName!>!
+LM.Core.Models.PublicationRecord.Authors.init -> void
+LM.Core.Models.PublicationRecord.AuthorsCsv.get -> string!
+LM.Core.Models.PublicationRecord.CitedByCount.get -> int?
+LM.Core.Models.PublicationRecord.CitedByCount.init -> void
+LM.Core.Models.PublicationRecord.CitedByPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.CitedByPmids.init -> void
+LM.Core.Models.PublicationRecord.CommentsCorrections.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.CommentsCorrections.init -> void
+LM.Core.Models.PublicationRecord.Country.get -> string?
+LM.Core.Models.PublicationRecord.Country.init -> void
+LM.Core.Models.PublicationRecord.Doi.get -> string?
+LM.Core.Models.PublicationRecord.Doi.init -> void
+LM.Core.Models.PublicationRecord.FirstAuthorLast.get -> string!
+LM.Core.Models.PublicationRecord.Grants.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.GrantInfo!>!
+LM.Core.Models.PublicationRecord.Grants.init -> void
+LM.Core.Models.PublicationRecord.Issue.get -> string?
+LM.Core.Models.PublicationRecord.Issue.init -> void
+LM.Core.Models.PublicationRecord.JournalIsoAbbrev.get -> string?
+LM.Core.Models.PublicationRecord.JournalIsoAbbrev.init -> void
+LM.Core.Models.PublicationRecord.JournalTitle.get -> string?
+LM.Core.Models.PublicationRecord.JournalTitle.init -> void
+LM.Core.Models.PublicationRecord.Keywords.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.Keywords.init -> void
+LM.Core.Models.PublicationRecord.Language.get -> string?
+LM.Core.Models.PublicationRecord.Language.init -> void
+LM.Core.Models.PublicationRecord.MeshHeadings.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.MeshHeadings.init -> void
+LM.Core.Models.PublicationRecord.Pages.get -> string?
+LM.Core.Models.PublicationRecord.Pages.init -> void
+LM.Core.Models.PublicationRecord.Pmcid.get -> string?
+LM.Core.Models.PublicationRecord.Pmcid.init -> void
+LM.Core.Models.PublicationRecord.Pmid.get -> string?
+LM.Core.Models.PublicationRecord.Pmid.init -> void
+LM.Core.Models.PublicationRecord.PublicationTypes.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.PublicationTypes.init -> void
+LM.Core.Models.PublicationRecord.PublishedEpub.get -> System.DateOnly?
+LM.Core.Models.PublicationRecord.PublishedEpub.init -> void
+LM.Core.Models.PublicationRecord.PublishedPrint.get -> System.DateOnly?
+LM.Core.Models.PublicationRecord.PublishedPrint.init -> void
+LM.Core.Models.PublicationRecord.ReferencedPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.ReferencedPmids.init -> void
+LM.Core.Models.PublicationRecord.Title.get -> string?
+LM.Core.Models.PublicationRecord.Title.init -> void
+LM.Core.Models.PublicationRecord.UrlPubMed.get -> string?
+LM.Core.Models.PublicationRecord.UrlPubMed.init -> void
+LM.Core.Models.PublicationRecord.Volume.get -> string?
+LM.Core.Models.PublicationRecord.Volume.init -> void
+LM.Core.Models.PublicationRecord.Year.get -> int?
+LM.Core.Models.PublicationRecord.Year.init -> void
+LM.Core.Models.Relation
+LM.Core.Models.Relation.Relation() -> void
+LM.Core.Models.Relation.TargetEntryId.get -> string!
+LM.Core.Models.Relation.TargetEntryId.set -> void
+LM.Core.Models.Relation.Type.get -> string!
+LM.Core.Models.Relation.Type.set -> void
+LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchDatabase.ClinicalTrialsGov = 1 -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchDatabase.PubMed = 0 -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchHit
+LM.Core.Models.SearchHit.AlreadyInDb.get -> bool
+LM.Core.Models.SearchHit.AlreadyInDb.set -> void
+LM.Core.Models.SearchHit.Authors.get -> string!
+LM.Core.Models.SearchHit.Authors.init -> void
+LM.Core.Models.SearchHit.Doi.get -> string?
+LM.Core.Models.SearchHit.Doi.init -> void
+LM.Core.Models.SearchHit.ExternalId.get -> string!
+LM.Core.Models.SearchHit.ExternalId.init -> void
+LM.Core.Models.SearchHit.JournalOrSource.get -> string?
+LM.Core.Models.SearchHit.JournalOrSource.init -> void
+LM.Core.Models.SearchHit.SearchHit() -> void
+LM.Core.Models.SearchHit.Selected.get -> bool
+LM.Core.Models.SearchHit.Selected.set -> void
+LM.Core.Models.SearchHit.Source.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchHit.Source.init -> void
+LM.Core.Models.SearchHit.Title.get -> string!
+LM.Core.Models.SearchHit.Title.init -> void
+LM.Core.Models.SearchHit.Url.get -> string?
+LM.Core.Models.SearchHit.Url.init -> void
+LM.Core.Models.SearchHit.Year.get -> int?
+LM.Core.Models.SearchHit.Year.init -> void
+LM.Core.Utils.Hashes
+LM.Core.Utils.IdGen
+LM.Core.Utils.JsonEx
+static LM.Core.Utils.Hashes.Sha1(string! input) -> string!
+static LM.Core.Utils.Hashes.Sha256File(string! path) -> string!
+static LM.Core.Utils.IdGen.NewId() -> string!
+static LM.Core.Utils.JsonEx.Deserialize<T>(string! s) -> T?
+static LM.Core.Utils.JsonEx.Serialize<T>(T v) -> string!
+static readonly LM.Core.Utils.JsonEx.Options -> System.Text.Json.JsonSerializerOptions!

--- a/src/LM.HubAndSpoke/Models/LitSearchHook.cs
+++ b/src/LM.HubAndSpoke/Models/LitSearchHook.cs
@@ -1,22 +1,84 @@
-﻿#nullable enable
+#nullable enable
 using System;
-using LM.Core.Models;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using LM.Core.Utils;
 
 namespace LM.HubSpoke.Models
 {
-    /// <summary>Provider-agnostic search row used in the Search tab UI.</summary>
-    public sealed class SearchHit
+    /// <summary>
+    /// Hook payload persisted alongside LitSearch entries. Captures the query definition
+    /// and a history of executed runs so the hub/spoke pipeline can rebuild entries later.
+    /// </summary>
+    public sealed class LitSearchHook
     {
-        public SearchDatabase Source { get; init; }
-        public string ExternalId { get; init; } = "";   // PMID or NCT
-        public string? Doi { get; init; }
-        public string Title { get; init; } = "";
-        public string Authors { get; init; } = "";
-        public string? JournalOrSource { get; init; }
-        public int? Year { get; init; }
-        public string? Url { get; init; }
+        [JsonPropertyName("schemaVersion")]
+        public string SchemaVersion { get; init; } = "1.0";
 
-        public bool AlreadyInDb { get; set; }    // computed in VM
-        public bool Selected { get; set; } = true;
+        [JsonPropertyName("title")]
+        public string Title { get; init; } = string.Empty;
+
+        [JsonPropertyName("query")]
+        public string Query { get; init; } = string.Empty;
+
+        [JsonPropertyName("provider")]
+        public string Provider { get; init; } = string.Empty;
+
+        [JsonPropertyName("from")]
+        [JsonConverter(typeof(NullableUtcDateTimeConverter))]
+        public DateTime? From { get; init; }
+
+        [JsonPropertyName("to")]
+        [JsonConverter(typeof(NullableUtcDateTimeConverter))]
+        public DateTime? To { get; init; }
+
+        [JsonPropertyName("createdBy")]
+        public string? CreatedBy { get; init; }
+
+        [JsonPropertyName("createdUtc")]
+        [JsonConverter(typeof(UtcDateTimeConverter))]
+        public DateTime CreatedUtc { get; init; } = DateTime.UtcNow;
+
+        [JsonPropertyName("keywords")]
+        public IReadOnlyList<string> Keywords { get; init; } = Array.Empty<string>();
+
+        [JsonPropertyName("runs")]
+        public List<LitSearchRun> Runs { get; init; } = new();
+    }
+
+    /// <summary>
+    /// Snapshot of a single literature search execution.
+    /// </summary>
+    public sealed class LitSearchRun
+    {
+        [JsonPropertyName("runId")]
+        public string RunId { get; init; } = IdGen.NewId();
+
+        [JsonPropertyName("provider")]
+        public string Provider { get; init; } = string.Empty;
+
+        [JsonPropertyName("query")]
+        public string Query { get; init; } = string.Empty;
+
+        [JsonPropertyName("from")]
+        [JsonConverter(typeof(NullableUtcDateTimeConverter))]
+        public DateTime? From { get; init; }
+
+        [JsonPropertyName("to")]
+        [JsonConverter(typeof(NullableUtcDateTimeConverter))]
+        public DateTime? To { get; init; }
+
+        [JsonPropertyName("runUtc")]
+        [JsonConverter(typeof(UtcDateTimeConverter))]
+        public DateTime RunUtc { get; init; } = DateTime.UtcNow;
+
+        [JsonPropertyName("totalHits")]
+        public int TotalHits { get; init; }
+
+        [JsonPropertyName("rawAttachments")]
+        public List<string> RawAttachments { get; init; } = new();
+
+        [JsonPropertyName("importedEntryIds")]
+        public List<string> ImportedEntryIds { get; init; } = new();
     }
 }

--- a/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
+++ b/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
@@ -351,6 +351,48 @@ LM.HubSpoke.Models.JournalIssue.PubDate.init -> void
 LM.HubSpoke.Models.JournalIssue.Volume.get -> string?
 LM.HubSpoke.Models.JournalIssue.Volume.init -> void
 LM.HubSpoke.Models.JsonStd
+LM.HubSpoke.Models.LitSearchHook
+LM.HubSpoke.Models.LitSearchHook.CreatedBy.get -> string?
+LM.HubSpoke.Models.LitSearchHook.CreatedBy.init -> void
+LM.HubSpoke.Models.LitSearchHook.CreatedUtc.get -> System.DateTime
+LM.HubSpoke.Models.LitSearchHook.CreatedUtc.init -> void
+LM.HubSpoke.Models.LitSearchHook.From.get -> System.DateTime?
+LM.HubSpoke.Models.LitSearchHook.From.init -> void
+LM.HubSpoke.Models.LitSearchHook.Keywords.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.HubSpoke.Models.LitSearchHook.Keywords.init -> void
+LM.HubSpoke.Models.LitSearchHook.LitSearchHook() -> void
+LM.HubSpoke.Models.LitSearchHook.Provider.get -> string!
+LM.HubSpoke.Models.LitSearchHook.Provider.init -> void
+LM.HubSpoke.Models.LitSearchHook.Query.get -> string!
+LM.HubSpoke.Models.LitSearchHook.Query.init -> void
+LM.HubSpoke.Models.LitSearchHook.Runs.get -> System.Collections.Generic.List<LM.HubSpoke.Models.LitSearchRun!>!
+LM.HubSpoke.Models.LitSearchHook.Runs.init -> void
+LM.HubSpoke.Models.LitSearchHook.SchemaVersion.get -> string!
+LM.HubSpoke.Models.LitSearchHook.SchemaVersion.init -> void
+LM.HubSpoke.Models.LitSearchHook.Title.get -> string!
+LM.HubSpoke.Models.LitSearchHook.Title.init -> void
+LM.HubSpoke.Models.LitSearchHook.To.get -> System.DateTime?
+LM.HubSpoke.Models.LitSearchHook.To.init -> void
+LM.HubSpoke.Models.LitSearchRun
+LM.HubSpoke.Models.LitSearchRun.ImportedEntryIds.get -> System.Collections.Generic.List<string!>!
+LM.HubSpoke.Models.LitSearchRun.ImportedEntryIds.init -> void
+LM.HubSpoke.Models.LitSearchRun.LitSearchRun() -> void
+LM.HubSpoke.Models.LitSearchRun.Provider.get -> string!
+LM.HubSpoke.Models.LitSearchRun.Provider.init -> void
+LM.HubSpoke.Models.LitSearchRun.Query.get -> string!
+LM.HubSpoke.Models.LitSearchRun.Query.init -> void
+LM.HubSpoke.Models.LitSearchRun.RawAttachments.get -> System.Collections.Generic.List<string!>!
+LM.HubSpoke.Models.LitSearchRun.RawAttachments.init -> void
+LM.HubSpoke.Models.LitSearchRun.RunId.get -> string!
+LM.HubSpoke.Models.LitSearchRun.RunId.init -> void
+LM.HubSpoke.Models.LitSearchRun.RunUtc.get -> System.DateTime
+LM.HubSpoke.Models.LitSearchRun.RunUtc.init -> void
+LM.HubSpoke.Models.LitSearchRun.From.get -> System.DateTime?
+LM.HubSpoke.Models.LitSearchRun.From.init -> void
+LM.HubSpoke.Models.LitSearchRun.To.get -> System.DateTime?
+LM.HubSpoke.Models.LitSearchRun.To.init -> void
+LM.HubSpoke.Models.LitSearchRun.TotalHits.get -> int
+LM.HubSpoke.Models.LitSearchRun.TotalHits.init -> void
 LM.HubSpoke.Models.LitSearchSpokeHandler
 LM.HubSpoke.Models.LitSearchSpokeHandler.BuildHookAsync(LM.Core.Models.Entry! entry, LM.HubSpoke.Abstractions.CasResult primary, System.Collections.Generic.IEnumerable<string!>! attachmentRelPaths, System.Func<string!, System.Threading.CancellationToken, System.Threading.Tasks.Task<LM.HubSpoke.Abstractions.CasResult>!>! moveToCas, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<object?>!
 LM.HubSpoke.Models.LitSearchSpokeHandler.BuildIndex(LM.HubSpoke.Models.EntryHub! hub, object? hookObj, string? extractedFullText) -> LM.HubSpoke.Abstractions.SpokeIndexContribution
@@ -423,28 +465,6 @@ LM.HubSpoke.Models.PubStatus.Unknown = 0 -> LM.HubSpoke.Models.PubStatus
 LM.HubSpoke.Models.PurposeSource
 LM.HubSpoke.Models.PurposeSource.Inferred = 0 -> LM.HubSpoke.Models.PurposeSource
 LM.HubSpoke.Models.PurposeSource.Manual = 1 -> LM.HubSpoke.Models.PurposeSource
-LM.HubSpoke.Models.SearchHit
-LM.HubSpoke.Models.SearchHit.AlreadyInDb.get -> bool
-LM.HubSpoke.Models.SearchHit.AlreadyInDb.set -> void
-LM.HubSpoke.Models.SearchHit.Authors.get -> string!
-LM.HubSpoke.Models.SearchHit.Authors.init -> void
-LM.HubSpoke.Models.SearchHit.Doi.get -> string?
-LM.HubSpoke.Models.SearchHit.Doi.init -> void
-LM.HubSpoke.Models.SearchHit.ExternalId.get -> string!
-LM.HubSpoke.Models.SearchHit.ExternalId.init -> void
-LM.HubSpoke.Models.SearchHit.JournalOrSource.get -> string?
-LM.HubSpoke.Models.SearchHit.JournalOrSource.init -> void
-LM.HubSpoke.Models.SearchHit.SearchHit() -> void
-LM.HubSpoke.Models.SearchHit.Selected.get -> bool
-LM.HubSpoke.Models.SearchHit.Selected.set -> void
-LM.HubSpoke.Models.SearchHit.Source.get -> LM.Core.Models.SearchDatabase
-LM.HubSpoke.Models.SearchHit.Source.init -> void
-LM.HubSpoke.Models.SearchHit.Title.get -> string!
-LM.HubSpoke.Models.SearchHit.Title.init -> void
-LM.HubSpoke.Models.SearchHit.Url.get -> string?
-LM.HubSpoke.Models.SearchHit.Url.init -> void
-LM.HubSpoke.Models.SearchHit.Year.get -> int?
-LM.HubSpoke.Models.SearchHit.Year.init -> void
 LM.HubSpoke.Models.UtcDateTimeConverter
 LM.HubSpoke.Models.UtcDateTimeConverter.UtcDateTimeConverter() -> void
 LM.HubSpoke.Spokes.ArticleSpokeHandler


### PR DESCRIPTION
## Summary
- add LitSearchHook and LitSearchRun models so the spoke handler and WPF view model can share the same payload type
- register the new public API surface in `PublicAPI.Unshipped.txt` and remove the obsolete SearchHit entry

## Testing
- not run (dotnet CLI is unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68caae14adac832b835ac62cd97e07fe