### PR TITLE
Fix search query binding to enable command

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Search/SearchViewModel.cs
@@ -38,7 +38,18 @@ namespace LM.App.Wpf.ViewModels
             ExportSearchCommand = new AsyncRelayCommand(ExportSearchAsync, () => !IsBusy && Results.Any());
         }
 
-        public string Query { get; set; } = "";
+        private string _query = string.Empty;
+        public string Query
+        {
+            get => _query;
+            set
+            {
+                if (_query == value) return;
+                _query = value;
+                OnPropertyChanged();
+                RaiseCanExec();
+            }
+        }
         public SearchDatabase SelectedDatabase { get; set; } = SearchDatabase.PubMed;
         public DateTime? From { get; set; }
         public DateTime? To { get; set; }


### PR DESCRIPTION
## Summary
- add change notification to the search query so command availability updates when the text changes

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cac2139230832b9773acb6cc5f17a2