### PR TITLE
Fix BooleanToOpacityConverter for older C#

### DIFF
--- a/src/LM.App.Wpf/Common/BooleanToOpacityConverter.cs
+++ b/src/LM.App.Wpf/Common/BooleanToOpacityConverter.cs
@@ -12,12 +12,17 @@ namespace LM.App.Wpf.Common
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value switch
+            if (value is bool b)
             {
-                bool b => b ? TrueOpacity : FalseOpacity,
-                bool? nb => nb.GetValueOrDefault() ? TrueOpacity : FalseOpacity,
-                _ => FalseOpacity,
-            };
+                return b ? TrueOpacity : FalseOpacity;
+            }
+
+            if (value is bool? nullableBool)
+            {
+                return nullableBool.GetValueOrDefault() ? TrueOpacity : FalseOpacity;
+            }
+
+            return FalseOpacity;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
## Summary
- replace the switch expression with simple conditionals so the converter compiles with older C#

## Testing
- dotnet build *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cac66848c4832baab9b44a3a8031c2