### PR TITLE
Fix WPF converter and public API build issues

### DIFF
--- a/src/LM.App.Wpf/Common/BooleanToOpacityConverter.cs
+++ b/src/LM.App.Wpf/Common/BooleanToOpacityConverter.cs
@@ -17,15 +17,10 @@ namespace LM.App.Wpf.Common
                 return b ? TrueOpacity : FalseOpacity;
             }
 
-            if (value is bool? nullableBool)
-            {
-                return nullableBool.GetValueOrDefault() ? TrueOpacity : FalseOpacity;
-            }
-
             return FalseOpacity;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-            => Binding.DoNothing;
+            => System.Windows.Data.Binding.DoNothing;
     }
 }

--- a/src/LM.App.Wpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Search/SearchViewModel.cs
@@ -312,5 +312,16 @@ namespace LM.App.Wpf.ViewModels
         }
     }
 
-    public sealed record SearchDatabaseOption(SearchDatabase Value, string DisplayName);
+    public sealed record SearchDatabaseOption
+    {
+        public SearchDatabaseOption(SearchDatabase value, string displayName)
+        {
+            Value = value;
+            DisplayName = displayName;
+        }
+
+        public SearchDatabase Value { get; }
+
+        public string DisplayName { get; }
+    }
 }


### PR DESCRIPTION
## Summary
- simplify the boolean-to-opacity converter to avoid nullable pattern usage and disambiguate the Binding reference
- implement SearchDatabaseOption with an explicit constructor and properties so it matches the documented public API

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cac872f32c832b8790c2d7dd378d64