### PR TITLE
Refine litsearch handling and improve trial mapping

### DIFF
--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -100,6 +100,8 @@ LM.App.Wpf.ViewModels.SearchViewModel.SaveSearchCommand.get -> System.Windows.In
 LM.App.Wpf.ViewModels.SearchViewModel.SearchViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IWorkSpaceService! ws) -> void
 LM.App.Wpf.ViewModels.SearchViewModel.SelectedDatabase.get -> LM.Core.Models.SearchDatabase
 LM.App.Wpf.ViewModels.SearchViewModel.SelectedDatabase.set -> void
+LM.App.Wpf.ViewModels.SearchViewModel.SelectedPreviousRun.get -> LM.HubSpoke.Models.LitSearchRun?
+LM.App.Wpf.ViewModels.SearchViewModel.SelectedPreviousRun.set -> void
 LM.App.Wpf.ViewModels.SearchViewModel.To.get -> System.DateTime?
 LM.App.Wpf.ViewModels.SearchViewModel.To.set -> void
 LM.App.Wpf.ViewModels.SearchDatabaseOption

--- a/src/LM.App.Wpf/Views/SearchView.xaml
+++ b/src/LM.App.Wpf/Views/SearchView.xaml
@@ -74,7 +74,9 @@
     <GroupBox Grid.Row="4" Header="Previous runs">
       <DataGrid ItemsSource="{Binding PreviousRuns}"
                 AutoGenerateColumns="False"
-                IsReadOnly="True">
+                IsReadOnly="True"
+                SelectionMode="Single"
+                SelectedItem="{Binding SelectedPreviousRun, Mode=TwoWay}">
         <DataGrid.Columns>
           <DataGridTextColumn Header="When"
                                Binding="{Binding RunUtc, StringFormat=\{0:yyyy-MM-dd HH:mm\}}"
@@ -82,6 +84,9 @@
           <DataGridTextColumn Header="Provider"
                                Binding="{Binding Provider}"
                                Width="100" />
+          <DataGridTextColumn Header="Query"
+                               Binding="{Binding Query}"
+                               Width="*" />
           <DataGridTextColumn Header="From"
                                Binding="{Binding From, StringFormat=\{0:yyyy-MM-dd\}}"
                                Width="120" />

--- a/src/LM.HubAndSpoke/Entries/HubSpokeStore.cs
+++ b/src/LM.HubAndSpoke/Entries/HubSpokeStore.cs
@@ -103,12 +103,14 @@ namespace LM.HubSpoke.Entries
 
             // 2) Hub
             var isPublication = entry.Type == EntryType.Publication;
+            var isLitSearch = string.Equals(entry.Source, "LitSearch", StringComparison.OrdinalIgnoreCase);
             var hub = new EntryHub
             {
                 EntryId = entryId,
                 DisplayTitle = entry.Title ?? entry.DisplayName ?? string.Empty,
                 CreatedUtc = entry.AddedOnUtc == default ? now : entry.AddedOnUtc,
                 UpdatedUtc = now,
+                CreationMethod = isLitSearch ? CreationMethod.Search : CreationMethod.Manual,
                 Origin = entry.IsInternal ? EntryOrigin.Internal : EntryOrigin.External,
                 PrimaryPurpose = isPublication ? EntryPurpose.Manuscript : EntryPurpose.Document,
                 PrimaryPurposeSource = PurposeSource.Inferred,
@@ -116,7 +118,8 @@ namespace LM.HubSpoke.Entries
                 Hooks = new EntryHooks
                 {
                     Article = isPublication ? "hooks/article.json" : null,
-                    Document = !isPublication ? "hooks/document.json" : null
+                    Document = !isPublication && !isLitSearch ? "hooks/document.json" : null,
+                    LitSearch = isLitSearch ? "litsearch/litsearch.json" : null
                 }
             };
             await HubJsonStore.SaveAsync(_ws, hub, ct);

--- a/src/LM.HubAndSpoke/Models/EntryHub.cs
+++ b/src/LM.HubAndSpoke/Models/EntryHub.cs
@@ -93,6 +93,9 @@ namespace LM.HubSpoke.Models
         [JsonPropertyName("article")]
         public string? Article { get; init; }            // "hooks/article.json"
 
+        [JsonPropertyName("lit_search")]
+        public string? LitSearch { get; init; }          // "litsearch/litsearch.json"
+
         [JsonPropertyName("trial")]
         public string? Trial { get; init; }              // "hooks/trial.json"
 

--- a/src/LM.HubAndSpoke/Models/LitSearchHook.cs
+++ b/src/LM.HubAndSpoke/Models/LitSearchHook.cs
@@ -42,6 +42,12 @@ namespace LM.HubSpoke.Models
         [JsonPropertyName("keywords")]
         public IReadOnlyList<string> Keywords { get; init; } = Array.Empty<string>();
 
+        [JsonPropertyName("notes")]
+        public string? Notes { get; init; }
+
+        [JsonPropertyName("derivedFromEntryId")]
+        public string? DerivedFromEntryId { get; init; }
+
         [JsonPropertyName("runs")]
         public List<LitSearchRun> Runs { get; init; } = new();
     }
@@ -74,6 +80,9 @@ namespace LM.HubSpoke.Models
 
         [JsonPropertyName("totalHits")]
         public int TotalHits { get; init; }
+
+        [JsonPropertyName("executedBy")]
+        public string? ExecutedBy { get; init; }
 
         [JsonPropertyName("rawAttachments")]
         public List<string> RawAttachments { get; init; } = new();

--- a/src/LM.HubAndSpoke/Models/LitsearchSpokeHandler.cs
+++ b/src/LM.HubAndSpoke/Models/LitsearchSpokeHandler.cs
@@ -49,10 +49,12 @@ namespace LM.HubSpoke.Spokes
         public SpokeIndexContribution BuildIndex(EntryHub hub, object? hookObj, string? extractedFullText)
         {
             var hook = hookObj as LitSearchHook;
+            var abstractText = string.Join(Environment.NewLine,
+                new[] { hook?.Query, hook?.Notes }.Where(s => !string.IsNullOrWhiteSpace(s)));
             var keywords = hook?.Keywords ?? Array.Empty<string>();
             return new SpokeIndexContribution(
                 Title: hook?.Title ?? hub.DisplayTitle,
-                Abstract: hook?.Query,
+                Abstract: string.IsNullOrWhiteSpace(abstractText) ? null : abstractText,
                 Authors: Array.Empty<string>(),
                 Keywords: keywords,
                 Journal: null,
@@ -74,7 +76,9 @@ namespace LM.HubSpoke.Spokes
                 Title = hook?.Title ?? hub.DisplayTitle,
                 DisplayName = hook?.Title ?? hub.DisplayTitle,
                 Source = "LitSearch",
-                AddedOnUtc = hub.CreatedUtc
+                AddedOnUtc = hook?.CreatedUtc ?? hub.CreatedUtc,
+                AddedBy = hook?.CreatedBy,
+                Notes = hook?.Notes
             };
         }
 

--- a/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
+++ b/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
@@ -245,6 +245,8 @@ LM.HubSpoke.Models.DocumentType.Whitepaper = 4 -> LM.HubSpoke.Models.DocumentTyp
 LM.HubSpoke.Models.EntryHooks
 LM.HubSpoke.Models.EntryHooks.Article.get -> string?
 LM.HubSpoke.Models.EntryHooks.Article.init -> void
+LM.HubSpoke.Models.EntryHooks.LitSearch.get -> string?
+LM.HubSpoke.Models.EntryHooks.LitSearch.init -> void
 LM.HubSpoke.Models.EntryHooks.DataExtraction.get -> string?
 LM.HubSpoke.Models.EntryHooks.DataExtraction.init -> void
 LM.HubSpoke.Models.EntryHooks.Document.get -> string?
@@ -360,11 +362,15 @@ LM.HubSpoke.Models.LitSearchHook.From.get -> System.DateTime?
 LM.HubSpoke.Models.LitSearchHook.From.init -> void
 LM.HubSpoke.Models.LitSearchHook.Keywords.get -> System.Collections.Generic.IReadOnlyList<string!>!
 LM.HubSpoke.Models.LitSearchHook.Keywords.init -> void
+LM.HubSpoke.Models.LitSearchHook.DerivedFromEntryId.get -> string?
+LM.HubSpoke.Models.LitSearchHook.DerivedFromEntryId.init -> void
 LM.HubSpoke.Models.LitSearchHook.LitSearchHook() -> void
 LM.HubSpoke.Models.LitSearchHook.Provider.get -> string!
 LM.HubSpoke.Models.LitSearchHook.Provider.init -> void
 LM.HubSpoke.Models.LitSearchHook.Query.get -> string!
 LM.HubSpoke.Models.LitSearchHook.Query.init -> void
+LM.HubSpoke.Models.LitSearchHook.Notes.get -> string?
+LM.HubSpoke.Models.LitSearchHook.Notes.init -> void
 LM.HubSpoke.Models.LitSearchHook.Runs.get -> System.Collections.Generic.List<LM.HubSpoke.Models.LitSearchRun!>!
 LM.HubSpoke.Models.LitSearchHook.Runs.init -> void
 LM.HubSpoke.Models.LitSearchHook.SchemaVersion.get -> string!
@@ -387,6 +393,8 @@ LM.HubSpoke.Models.LitSearchRun.RunId.get -> string!
 LM.HubSpoke.Models.LitSearchRun.RunId.init -> void
 LM.HubSpoke.Models.LitSearchRun.RunUtc.get -> System.DateTime
 LM.HubSpoke.Models.LitSearchRun.RunUtc.init -> void
+LM.HubSpoke.Models.LitSearchRun.ExecutedBy.get -> string?
+LM.HubSpoke.Models.LitSearchRun.ExecutedBy.init -> void
 LM.HubSpoke.Models.LitSearchRun.From.get -> System.DateTime?
 LM.HubSpoke.Models.LitSearchRun.From.init -> void
 LM.HubSpoke.Models.LitSearchRun.To.get -> System.DateTime?


### PR DESCRIPTION
## Summary
- load and persist litsearch runs via a selectable history that tracks provenance and derivations
- treat litsearch data as a dedicated spoke with updated hub metadata and richer hook content
- correct ClinicalTrials.gov search mapping so investigator details populate authors instead of recruitment status

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cad11c65e8832b99aff5f77e4a66f6