### PR TITLE
Fix nullable compare invocation in search view model

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Search/SearchViewModel.cs
@@ -377,7 +377,7 @@ namespace LM.App.Wpf.ViewModels
                 // workspace not yet initialized
             }
 
-            items.Sort((a, b) => Nullable.Compare(b.run.RunUtc, a.run.RunUtc));
+            items.Sort((a, b) => DateTime.Compare(b.run.RunUtc, a.run.RunUtc));
 
             PreviousRuns.Clear();
             foreach (var (run, _) in items)


### PR DESCRIPTION
## Summary
- update the previous run sorter to use DateTime.Compare since RunUtc is non-nullable

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cad78e5c24832bbed708efb1678b57