### PR TITLE
Keep previous run selection after refresh

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Search/SearchViewModel.cs
@@ -379,6 +379,8 @@ namespace LM.App.Wpf.ViewModels
 
             items.Sort((a, b) => DateTime.Compare(b.run.RunUtc, a.run.RunUtc));
 
+            var previouslySelectedId = SelectedPreviousRun?.RunId;
+
             PreviousRuns.Clear();
             foreach (var (run, _) in items)
                 PreviousRuns.Add(run);
@@ -387,9 +389,20 @@ namespace LM.App.Wpf.ViewModels
             {
                 SelectedPreviousRun = null;
             }
-            else if (SelectedPreviousRun is null || !_runIndex.ContainsKey(SelectedPreviousRun.RunId))
+            else
             {
-                SelectedPreviousRun = PreviousRuns[0];
+                var match = previouslySelectedId is null
+                    ? null
+                    : PreviousRuns.FirstOrDefault(r => string.Equals(r.RunId, previouslySelectedId, StringComparison.Ordinal));
+
+                if (match is not null)
+                {
+                    SelectedPreviousRun = match;
+                }
+                else if (SelectedPreviousRun is null || !_runIndex.ContainsKey(SelectedPreviousRun.RunId))
+                {
+                    SelectedPreviousRun = PreviousRuns[0];
+                }
             }
 
             RaiseCanExec();


### PR DESCRIPTION
## Summary
- remember the previously selected run id when refreshing previous runs
- reselect the matching run instance after repopulating the list so selection can change reliably

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cae0f5dbd8832ba3ab457aced4d969