### PR TITLE
Add search save prompt and restore search indicators

### DIFF
--- a/src/LM.App.Wpf/App.xaml.cs
+++ b/src/LM.App.Wpf/App.xaml.cs
@@ -70,7 +70,8 @@ namespace LM.App.Wpf
             // ViewModels
             var libraryVm = new LibraryViewModel(services.Store, ws);
             var addVm = new AddViewModel(services.Pipeline);
-            var searchVm = new SearchViewModel(services.Store, services.Storage, ws);
+            var searchPrompt = new SearchSavePrompt();
+            var searchVm = new SearchViewModel(services.Store, services.Storage, ws, searchPrompt);
 
             // Bind
             if (shell.LibraryViewControl != null) shell.LibraryViewControl.DataContext = libraryVm;

--- a/src/LM.App.Wpf/Common/ISearchSavePrompt.cs
+++ b/src/LM.App.Wpf/Common/ISearchSavePrompt.cs
@@ -1,0 +1,22 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using LM.Core.Models;
+
+namespace LM.App.Wpf.Common
+{
+    public interface ISearchSavePrompt
+    {
+        Task<SearchSavePromptResult?> RequestAsync(SearchSavePromptContext context);
+    }
+
+    public sealed record SearchSavePromptContext(
+        string Query,
+        SearchDatabase Database,
+        DateTime? From,
+        DateTime? To,
+        string DefaultName,
+        string DefaultNotes);
+
+    public sealed record SearchSavePromptResult(string Name, string Notes);
+}

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -11,6 +11,20 @@ LM.App.Wpf.Common.AsyncRelayCommand.CanExecute(object? parameter) -> bool
 LM.App.Wpf.Common.AsyncRelayCommand.CanExecuteChanged -> System.EventHandler?
 LM.App.Wpf.Common.AsyncRelayCommand.Execute(object? parameter) -> void
 LM.App.Wpf.Common.AsyncRelayCommand.RaiseCanExecuteChanged() -> void
+LM.App.Wpf.Common.ISearchSavePrompt
+LM.App.Wpf.Common.ISearchSavePrompt.RequestAsync(LM.App.Wpf.Common.SearchSavePromptContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.SearchSavePromptResult?>!
+LM.App.Wpf.Common.SearchSavePromptContext
+LM.App.Wpf.Common.SearchSavePromptContext.SearchSavePromptContext(string! Query, LM.Core.Models.SearchDatabase Database, System.DateTime? From, System.DateTime? To, string! DefaultName, string! DefaultNotes) -> void
+LM.App.Wpf.Common.SearchSavePromptContext.Database.get -> LM.Core.Models.SearchDatabase
+LM.App.Wpf.Common.SearchSavePromptContext.DefaultName.get -> string!
+LM.App.Wpf.Common.SearchSavePromptContext.DefaultNotes.get -> string!
+LM.App.Wpf.Common.SearchSavePromptContext.From.get -> System.DateTime?
+LM.App.Wpf.Common.SearchSavePromptContext.Query.get -> string!
+LM.App.Wpf.Common.SearchSavePromptContext.To.get -> System.DateTime?
+LM.App.Wpf.Common.SearchSavePromptResult
+LM.App.Wpf.Common.SearchSavePromptResult.SearchSavePromptResult(string! Name, string! Notes) -> void
+LM.App.Wpf.Common.SearchSavePromptResult.Name.get -> string!
+LM.App.Wpf.Common.SearchSavePromptResult.Notes.get -> string!
 LM.App.Wpf.Common.RelayCommand
 LM.App.Wpf.Common.RelayCommand.CanExecute(object? parameter) -> bool
 LM.App.Wpf.Common.RelayCommand.CanExecuteChanged -> System.EventHandler?
@@ -87,7 +101,6 @@ LM.App.Wpf.ViewModels.SearchItemViewModel.Vm.get -> LM.App.Wpf.ViewModels.Librar
 LM.App.Wpf.ViewModels.SearchViewModel
 LM.App.Wpf.ViewModels.SearchViewModel.Databases.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.SearchDatabaseOption!>!
 LM.App.Wpf.ViewModels.SearchViewModel.ExportSearchCommand.get -> System.Windows.Input.ICommand!
-LM.App.Wpf.ViewModels.SearchViewModel.HasSelectedRun.get -> bool
 LM.App.Wpf.ViewModels.SearchViewModel.From.get -> System.DateTime?
 LM.App.Wpf.ViewModels.SearchViewModel.From.set -> void
 LM.App.Wpf.ViewModels.SearchViewModel.IsBusy.get -> bool
@@ -98,15 +111,12 @@ LM.App.Wpf.ViewModels.SearchViewModel.Query.set -> void
 LM.App.Wpf.ViewModels.SearchViewModel.Results.get -> System.Collections.ObjectModel.ObservableCollection<LM.Core.Models.SearchHit!>!
 LM.App.Wpf.ViewModels.SearchViewModel.RunSearchCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.SearchViewModel.SaveSearchCommand.get -> System.Windows.Input.ICommand!
-LM.App.Wpf.ViewModels.SearchViewModel.SearchViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IWorkSpaceService! ws) -> void
+LM.App.Wpf.ViewModels.SearchViewModel.SearchViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IWorkSpaceService! ws, LM.App.Wpf.Common.ISearchSavePrompt! savePrompt) -> void
 LM.App.Wpf.ViewModels.SearchViewModel.SelectedDatabase.get -> LM.Core.Models.SearchDatabase
 LM.App.Wpf.ViewModels.SearchViewModel.SelectedDatabase.set -> void
 LM.App.Wpf.ViewModels.SearchViewModel.SelectedPreviousRun.get -> LM.HubSpoke.Models.LitSearchRun?
 LM.App.Wpf.ViewModels.SearchViewModel.SelectedPreviousRun.set -> void
-LM.App.Wpf.ViewModels.SearchViewModel.SelectedRunDisplayName.get -> string!
-LM.App.Wpf.ViewModels.SearchViewModel.SelectedRunDisplayName.set -> void
-LM.App.Wpf.ViewModels.SearchViewModel.SelectedRunIsFavorite.get -> bool
-LM.App.Wpf.ViewModels.SearchViewModel.SelectedRunIsFavorite.set -> void
+LM.App.Wpf.ViewModels.SearchViewModel.StartPreviousRunCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.SearchViewModel.To.get -> System.DateTime?
 LM.App.Wpf.ViewModels.SearchViewModel.To.set -> void
 LM.App.Wpf.ViewModels.SearchDatabaseOption
@@ -171,6 +181,9 @@ LM.App.Wpf.Views.AddView.InitializeComponent() -> void
 LM.App.Wpf.Views.LibraryView
 LM.App.Wpf.Views.LibraryView.InitializeComponent() -> void
 LM.App.Wpf.Views.LibraryView.LibraryView() -> void
+LM.App.Wpf.Views.SearchSavePrompt
+LM.App.Wpf.Views.SearchSavePrompt.RequestAsync(LM.App.Wpf.Common.SearchSavePromptContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.SearchSavePromptResult?>!
+LM.App.Wpf.Views.SearchSavePrompt.SearchSavePrompt() -> void
 LM.App.Wpf.Views.SearchView
 LM.App.Wpf.Views.SearchView.InitializeComponent() -> void
 LM.App.Wpf.Views.SearchView.SearchView() -> void

--- a/src/LM.App.Wpf/Views/SearchSaveDialog.xaml
+++ b/src/LM.App.Wpf/Views/SearchSaveDialog.xaml
@@ -1,0 +1,97 @@
+<Window x:Class="LM.App.Wpf.Views.SearchSaveDialog"
+        x:ClassModifier="internal"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Save search"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        MinWidth="420">
+  <Grid Margin="16">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="8" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="12" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="8" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="12" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="Auto" />
+      <ColumnDefinition Width="*" />
+    </Grid.ColumnDefinitions>
+
+    <TextBlock Grid.Row="0"
+               Grid.ColumnSpan="2"
+               Text="Name this search run and capture any notes."
+               FontWeight="SemiBold" />
+
+    <TextBlock Grid.Row="2"
+               Grid.Column="0"
+               Margin="0,0,8,4"
+               Text="Query:" />
+    <TextBlock x:Name="QueryText"
+               Grid.Row="2"
+               Grid.Column="1"
+               TextWrapping="Wrap" />
+
+    <TextBlock Grid.Row="3"
+               Grid.Column="0"
+               Margin="0,0,8,4"
+               Text="Database:" />
+    <TextBlock x:Name="DatabaseText"
+               Grid.Row="3"
+               Grid.Column="1" />
+
+    <TextBlock Grid.Row="4"
+               Grid.Column="0"
+               Margin="0,0,8,0"
+               Text="Range:" />
+    <TextBlock x:Name="RangeText"
+               Grid.Row="4"
+               Grid.Column="1" />
+
+    <TextBlock Grid.Row="6"
+               Grid.Column="0"
+               Margin="0,0,8,0"
+               Text="Name:"
+               VerticalAlignment="Center" />
+    <TextBox x:Name="NameBox"
+             Grid.Row="6"
+             Grid.Column="1"
+             MinWidth="240" />
+
+    <TextBlock Grid.Row="8"
+               Grid.ColumnSpan="2"
+               Text="Notes:" />
+    <TextBox x:Name="NotesBox"
+             Grid.Row="9"
+             Grid.ColumnSpan="2"
+             Margin="0,4,0,0"
+             AcceptsReturn="True"
+             TextWrapping="Wrap"
+             Height="140"
+             VerticalScrollBarVisibility="Auto" />
+
+    <StackPanel Grid.Row="11"
+                Grid.ColumnSpan="2"
+                Orientation="Horizontal"
+                HorizontalAlignment="Right">
+      <Button Content="Cancel"
+              Margin="0,0,8,0"
+              MinWidth="80"
+              IsCancel="True"
+              Click="OnCancel" />
+      <Button Content="Save"
+              MinWidth="80"
+              IsDefault="True"
+              Click="OnSave" />
+    </StackPanel>
+  </Grid>
+</Window>

--- a/src/LM.App.Wpf/Views/SearchSaveDialog.xaml.cs
+++ b/src/LM.App.Wpf/Views/SearchSaveDialog.xaml.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using System;
+using System.Globalization;
+using System.Windows;
+using LM.App.Wpf.Common;
+using LM.Core.Models;
+
+namespace LM.App.Wpf.Views
+{
+    internal partial class SearchSaveDialog : Window
+    {
+        public string ResultName { get; private set; } = string.Empty;
+        public string ResultNotes { get; private set; } = string.Empty;
+
+        public SearchSaveDialog(SearchSavePromptContext context)
+        {
+            InitializeComponent();
+
+            QueryText.Text = context.Query;
+            DatabaseText.Text = context.Database == SearchDatabase.PubMed ? "PubMed" : "ClinicalTrials.gov";
+            RangeText.Text = FormatRange(context.From, context.To);
+            NameBox.Text = context.DefaultName ?? string.Empty;
+            NotesBox.Text = context.DefaultNotes ?? string.Empty;
+
+            Loaded += (_, _) =>
+            {
+                NameBox.Focus();
+                NameBox.SelectAll();
+            };
+        }
+
+        private static string FormatRange(DateTime? from, DateTime? to)
+        {
+            if (!from.HasValue && !to.HasValue)
+                return "–";
+
+            string Format(DateTime? date) => date?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "–";
+            return $"{Format(from)} → {Format(to)}";
+        }
+
+        private void OnSave(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(NameBox.Text))
+            {
+                MessageBox.Show(this, "Please enter a name for the search.", "Save search", MessageBoxButton.OK, MessageBoxImage.Warning);
+                NameBox.Focus();
+                return;
+            }
+
+            ResultName = NameBox.Text.Trim();
+            ResultNotes = NotesBox.Text.Trim();
+            DialogResult = true;
+        }
+
+        private void OnCancel(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/SearchSavePrompt.cs
+++ b/src/LM.App.Wpf/Views/SearchSavePrompt.cs
@@ -1,0 +1,43 @@
+#nullable enable
+using System.Threading.Tasks;
+using System.Windows;
+using LM.App.Wpf.Common;
+
+namespace LM.App.Wpf.Views
+{
+    public sealed class SearchSavePrompt : ISearchSavePrompt
+    {
+        public Task<SearchSavePromptResult?> RequestAsync(SearchSavePromptContext context)
+        {
+            var app = Application.Current;
+            if (app is null)
+            {
+                return Task.FromResult<SearchSavePromptResult?>(null);
+            }
+
+            if (app.Dispatcher.CheckAccess())
+            {
+                return Task.FromResult(ShowDialog(context));
+            }
+
+            return app.Dispatcher.InvokeAsync(() => ShowDialog(context)).Task;
+        }
+
+        private static SearchSavePromptResult? ShowDialog(SearchSavePromptContext context)
+        {
+            var dialog = new SearchSaveDialog(context);
+            if (Application.Current?.MainWindow is Window owner && owner.IsVisible)
+            {
+                dialog.Owner = owner;
+            }
+
+            var ok = dialog.ShowDialog();
+            if (ok == true)
+            {
+                return new SearchSavePromptResult(dialog.ResultName, dialog.ResultNotes);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/SearchView.xaml
+++ b/src/LM.App.Wpf/Views/SearchView.xaml
@@ -50,7 +50,7 @@
         <DataGridTemplateColumn Header="DB" Width="40">
           <DataGridTemplateColumn.CellTemplate>
             <DataTemplate>
-              <TextBlock Text=""
+              <TextBlock Text="&#xE105;"
                          FontFamily="Segoe MDL2 Assets"
                          HorizontalAlignment="Center"
                          Opacity="{Binding AlreadyInDb, Converter={StaticResource AlreadyInDbOpacityConverter}}"
@@ -72,76 +72,64 @@
 
     <!-- Previous runs (simple) -->
     <GroupBox Grid.Row="4" Header="Previous runs">
-      <Grid>
-        <Grid.RowDefinitions>
-          <RowDefinition Height="*" />
-          <RowDefinition Height="8" />
-          <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-
-        <DataGrid Grid.Row="0"
-                  ItemsSource="{Binding PreviousRuns}"
-                  AutoGenerateColumns="False"
-                  IsReadOnly="True"
-                  SelectionMode="Single"
-                  SelectedItem="{Binding SelectedPreviousRun, Mode=TwoWay}">
-          <DataGrid.Columns>
-            <DataGridTemplateColumn Header="★" Width="40">
-              <DataGridTemplateColumn.CellTemplate>
-                <DataTemplate>
-                  <TextBlock Text="★" HorizontalAlignment="Center" Foreground="Goldenrod">
-                    <TextBlock.Style>
-                      <Style TargetType="TextBlock">
-                        <Setter Property="Opacity" Value="0.2" />
-                        <Style.Triggers>
-                          <DataTrigger Binding="{Binding IsFavorite}" Value="True">
-                            <Setter Property="Opacity" Value="1" />
-                          </DataTrigger>
-                        </Style.Triggers>
-                      </Style>
-                    </TextBlock.Style>
-                  </TextBlock>
-                </DataTemplate>
-              </DataGridTemplateColumn.CellTemplate>
-            </DataGridTemplateColumn>
-            <DataGridTextColumn Header="When"
-                                 Binding="{Binding RunUtc, StringFormat=\{0:yyyy-MM-dd HH:mm\}}"
-                                 Width="160" />
-            <DataGridTextColumn Header="Provider"
-                                 Binding="{Binding Provider}"
-                                 Width="100" />
-            <DataGridTextColumn Header="Name"
-                                 Binding="{Binding DisplayName}"
-                                 Width="200" />
-            <DataGridTextColumn Header="Query"
-                                 Binding="{Binding Query}"
-                                 Width="*" />
-            <DataGridTextColumn Header="From"
-                                 Binding="{Binding From, StringFormat=\{0:yyyy-MM-dd\}}"
-                                 Width="120" />
-            <DataGridTextColumn Header="To"
-                                 Binding="{Binding To, StringFormat=\{0:yyyy-MM-dd\}}"
-                                 Width="120" />
-            <DataGridTextColumn Header="Total"
-                                 Binding="{Binding TotalHits}"
-                                 Width="80" />
-          </DataGrid.Columns>
-        </DataGrid>
-
-        <StackPanel Grid.Row="2"
-                    Orientation="Horizontal"
-                    VerticalAlignment="Center">
-          <TextBlock Text="Custom name:" VerticalAlignment="Center" />
-          <TextBox Width="240"
-                   Margin="8,0,0,0"
-                   IsEnabled="{Binding HasSelectedRun}"
-                   Text="{Binding SelectedRunDisplayName, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
-          <CheckBox Content="Favorite"
-                    Margin="12,0,0,0"
-                    IsEnabled="{Binding HasSelectedRun}"
-                    IsChecked="{Binding SelectedRunIsFavorite}" />
-        </StackPanel>
-      </Grid>
+      <DataGrid ItemsSource="{Binding PreviousRuns}"
+                AutoGenerateColumns="False"
+                IsReadOnly="True"
+                SelectionMode="Single"
+                SelectedItem="{Binding SelectedPreviousRun, Mode=TwoWay}">
+        <DataGrid.Columns>
+          <DataGridTemplateColumn Header="Start" Width="80">
+            <DataGridTemplateColumn.CellTemplate>
+              <DataTemplate>
+                <Button Content="Start"
+                        Padding="8,2"
+                        HorizontalAlignment="Center"
+                        Command="{Binding DataContext.StartPreviousRunCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                        CommandParameter="{Binding}" />
+              </DataTemplate>
+            </DataGridTemplateColumn.CellTemplate>
+          </DataGridTemplateColumn>
+          <DataGridTemplateColumn Header="★" Width="40">
+            <DataGridTemplateColumn.CellTemplate>
+              <DataTemplate>
+                <TextBlock Text="★" HorizontalAlignment="Center" Foreground="Goldenrod">
+                  <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                      <Setter Property="Opacity" Value="0.2" />
+                      <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsFavorite}" Value="True">
+                          <Setter Property="Opacity" Value="1" />
+                        </DataTrigger>
+                      </Style.Triggers>
+                    </Style>
+                  </TextBlock.Style>
+                </TextBlock>
+              </DataTemplate>
+            </DataGridTemplateColumn.CellTemplate>
+          </DataGridTemplateColumn>
+          <DataGridTextColumn Header="When"
+                               Binding="{Binding RunUtc, StringFormat=\{0:yyyy-MM-dd HH:mm\}}"
+                               Width="160" />
+          <DataGridTextColumn Header="Provider"
+                               Binding="{Binding Provider}"
+                               Width="100" />
+          <DataGridTextColumn Header="Name"
+                               Binding="{Binding DisplayName}"
+                               Width="200" />
+          <DataGridTextColumn Header="Query"
+                               Binding="{Binding Query}"
+                               Width="*" />
+          <DataGridTextColumn Header="From"
+                               Binding="{Binding From, StringFormat=\{0:yyyy-MM-dd\}}"
+                               Width="120" />
+          <DataGridTextColumn Header="To"
+                               Binding="{Binding To, StringFormat=\{0:yyyy-MM-dd\}}"
+                               Width="120" />
+          <DataGridTextColumn Header="Total"
+                               Binding="{Binding TotalHits}"
+                               Width="80" />
+        </DataGrid.Columns>
+      </DataGrid>
     </GroupBox>
   </Grid>
 </UserControl>

--- a/src/LM.Core/Models/SearchHit.cs
+++ b/src/LM.Core/Models/SearchHit.cs
@@ -4,7 +4,7 @@ using System;
 namespace LM.Core.Models
 {
     /// <summary>Provider-agnostic search row used in the Search tab UI.</summary>
-    public sealed class SearchHit
+    public sealed class SearchHit : System.ComponentModel.INotifyPropertyChanged
     {
         public SearchDatabase Source { get; init; }
         public string ExternalId { get; init; } = "";   // PMID or NCT
@@ -15,7 +15,35 @@ namespace LM.Core.Models
         public int? Year { get; init; }
         public string? Url { get; init; }
 
-        public bool AlreadyInDb { get; set; }    // computed in VM
-        public bool Selected { get; set; } = true;
+        private bool _alreadyInDb;    // computed in VM
+        public bool AlreadyInDb
+        {
+            get => _alreadyInDb;
+            set
+            {
+                if (_alreadyInDb == value)
+                    return;
+                _alreadyInDb = value;
+                OnPropertyChanged(nameof(AlreadyInDb));
+            }
+        }
+
+        private bool _selected = true;
+        public bool Selected
+        {
+            get => _selected;
+            set
+            {
+                if (_selected == value)
+                    return;
+                _selected = value;
+                OnPropertyChanged(nameof(Selected));
+            }
+        }
+
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+
+        private void OnPropertyChanged(string propertyName)
+            => PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
     }
 }

--- a/src/LM.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Core/PublicAPI.Unshipped.txt
@@ -286,6 +286,7 @@ LM.Core.Models.SearchHit.Url.get -> string?
 LM.Core.Models.SearchHit.Url.init -> void
 LM.Core.Models.SearchHit.Year.get -> int?
 LM.Core.Models.SearchHit.Year.init -> void
+LM.Core.Models.SearchHit.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
 LM.Core.Utils.Hashes
 LM.Core.Utils.IdGen
 LM.Core.Utils.JsonEx


### PR DESCRIPTION
## Summary
- add a dialog-driven prompt so saving a search captures a custom name and notes
- restore the database indicator by notifying UI when `AlreadyInDb` changes and update the glyph
- streamline the previous runs grid with an inline Start action instead of metadata editors

## Testing
- `dotnet build` *(fails: dotnet CLI not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cae7ac9408832b9f3b7ea3c4eb9a81