### PR TITLE
Improve search history usability

### DIFF
--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -106,6 +106,7 @@ LM.App.Wpf.ViewModels.SearchViewModel.From.set -> void
 LM.App.Wpf.ViewModels.SearchViewModel.IsBusy.get -> bool
 LM.App.Wpf.ViewModels.SearchViewModel.LoadSearchCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.SearchViewModel.PreviousRuns.get -> System.Collections.ObjectModel.ObservableCollection<LM.HubSpoke.Models.LitSearchRun!>!
+LM.App.Wpf.ViewModels.SearchViewModel.PreviousRunsCount.get -> int
 LM.App.Wpf.ViewModels.SearchViewModel.Query.get -> string!
 LM.App.Wpf.ViewModels.SearchViewModel.Query.set -> void
 LM.App.Wpf.ViewModels.SearchViewModel.Results.get -> System.Collections.ObjectModel.ObservableCollection<LM.Core.Models.SearchHit!>!
@@ -117,6 +118,7 @@ LM.App.Wpf.ViewModels.SearchViewModel.SelectedDatabase.set -> void
 LM.App.Wpf.ViewModels.SearchViewModel.SelectedPreviousRun.get -> LM.HubSpoke.Models.LitSearchRun?
 LM.App.Wpf.ViewModels.SearchViewModel.SelectedPreviousRun.set -> void
 LM.App.Wpf.ViewModels.SearchViewModel.StartPreviousRunCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.SearchViewModel.ShowRunDetailsCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.SearchViewModel.ToggleFavoriteCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.SearchViewModel.To.get -> System.DateTime?
 LM.App.Wpf.ViewModels.SearchViewModel.To.set -> void

--- a/src/LM.App.Wpf/Views/SearchView.xaml
+++ b/src/LM.App.Wpf/Views/SearchView.xaml
@@ -71,24 +71,29 @@
     </DataGrid>
 
     <!-- Previous runs (simple) -->
-    <GroupBox Grid.Row="4" Header="Previous runs">
+    <GroupBox Grid.Row="4">
+      <GroupBox.Header>
+        <TextBlock Text="{Binding PreviousRunsCount, StringFormat=Previous runs ({0})}" />
+      </GroupBox.Header>
       <DataGrid ItemsSource="{Binding PreviousRuns}"
                 AutoGenerateColumns="False"
                 IsReadOnly="True"
                 SelectionMode="Single"
                 SelectedItem="{Binding SelectedPreviousRun, Mode=TwoWay}">
+        <DataGrid.Resources>
+          <Style TargetType="DataGridRow">
+            <Setter Property="ContextMenu">
+              <Setter.Value>
+                <ContextMenu>
+                  <MenuItem Header="Show details"
+                            Command="{Binding DataContext.ShowRunDetailsCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                            CommandParameter="{Binding}" />
+                </ContextMenu>
+              </Setter.Value>
+            </Setter>
+          </Style>
+        </DataGrid.Resources>
         <DataGrid.Columns>
-          <DataGridTemplateColumn Header="Start" Width="80">
-            <DataGridTemplateColumn.CellTemplate>
-              <DataTemplate>
-                <Button Content="Start"
-                        Padding="8,2"
-                        HorizontalAlignment="Center"
-                        Command="{Binding DataContext.StartPreviousRunCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                        CommandParameter="{Binding}" />
-              </DataTemplate>
-            </DataGridTemplateColumn.CellTemplate>
-          </DataGridTemplateColumn>
           <DataGridTemplateColumn Header="★" Width="40">
             <DataGridTemplateColumn.CellTemplate>
               <DataTemplate>


### PR DESCRIPTION
## Summary
- remove the inline Start button from the previous runs table and replace the header with a live counter
- add a context menu entry so "Show details" opens a prettified JSON snapshot for the selected run
- surface the run-count property on the view-model to back the new header binding and detail command

## Testing
- dotnet build *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caf3845000832b98545e0dba85acb7