### PR TITLE
Fix lit search entry tags mapping

### DIFF
--- a/src/LM.HubAndSpoke/Spokes/LitSearchSpokeHandler.cs
+++ b/src/LM.HubAndSpoke/Spokes/LitSearchSpokeHandler.cs
@@ -4,6 +4,7 @@ using LM.Core.Models;
 using LM.HubSpoke.Abstractions;
 using LM.HubSpoke.Models;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -82,7 +83,8 @@ namespace LM.HubSpoke.Spokes
                 Source = "LitSearch",
                 AddedOnUtc = hook?.CreatedUtc ?? hub.CreatedUtc,
                 AddedBy = hook?.CreatedBy,
-                Notes = hook?.Notes
+                Notes = hook?.Notes,
+                Tags = hub.Tags?.ToList() ?? new List<string>()
             };
         }
 


### PR DESCRIPTION
## Summary
- ensure LitSearch entries loaded through the hub/spoke pipeline retain their tag metadata
- add the necessary collection import and copy hub tags onto the mapped Entry so downstream views see them

## Testing
- `dotnet test src/LM.HubSpoke.Tests/LM.HubSpoke.Tests.csproj` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd22bb3b80832bab4adfbce41514bf