### PR TITLE
Adjust search save flow and add notes hook

### DIFF
--- a/src/LM.App.Wpf/Views/SearchSaveDialog.xaml.cs
+++ b/src/LM.App.Wpf/Views/SearchSaveDialog.xaml.cs
@@ -20,12 +20,6 @@ namespace LM.App.Wpf.Views
             QueryText.Text = context.Query;
             DatabaseText.Text = context.Database == SearchDatabase.PubMed ? "PubMed" : "ClinicalTrials.gov";
             RangeText.Text = FormatRange(context.From, context.To);
-            NameBox.Text = context.DefaultName ?? string.Empty;
-            NotesBox.Text = context.DefaultNotes ?? string.Empty;
-            TagsBox.Text = context.DefaultTags is null || context.DefaultTags.Count == 0
-                ? string.Empty
-                : string.Join(", ", context.DefaultTags);
-
             Loaded += (_, _) =>
             {
                 NameBox.Focus();


### PR DESCRIPTION
## Summary
- stop pre-populating the save search dialog inputs and skip the prompt when re-saving an unchanged query
- carry forward prior metadata when auto-saving and only persist notes when the user provides them
- attach a notes.md hook for lit search entries whenever notes are present

## Testing
- dotnet test KnowledgeWorks_20250820_082416.sln *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2c0d36ec832b80f69fc9d677308f