### PR TITLE
Fix ShellWindow bindings without generated fields

### DIFF
--- a/src/LM.App.Wpf/App.xaml.cs
+++ b/src/LM.App.Wpf/App.xaml.cs
@@ -73,10 +73,16 @@ namespace LM.App.Wpf
             var searchPrompt = new SearchSavePrompt();
             var searchVm = new SearchViewModel(services.Store, services.Storage, ws, searchPrompt);
 
-            // Bind
-            if (shell.LibraryViewControl != null) shell.LibraryViewControl.DataContext = libraryVm;
-            if (shell.AddViewControl != null) shell.AddViewControl.DataContext = addVm;
-            if (shell.SearchViewControl != null) shell.SearchViewControl.DataContext = searchVm;
+            // Bind – resolve the views by name because the generated fields are not
+            // available when building from the command line (designer-only feature).
+            if (shell.FindName("LibraryViewControl") is LibraryView libraryView)
+                libraryView.DataContext = libraryVm;
+
+            if (shell.FindName("AddViewControl") is AddView addView)
+                addView.DataContext = addVm;
+
+            if (shell.FindName("SearchViewControl") is SearchView searchView)
+                searchView.DataContext = searchVm;
 
         }
     }


### PR DESCRIPTION
## Summary
- resolve ShellWindow bindings by looking up the named child views at runtime instead of relying on generated fields
- bind the Library, Add, and Search tabs only when their views are found

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd42cb795c832bb06ffdbef2d10861