### PR TITLE
Expand library metadata filtering

### DIFF
--- a/src/LM.App.Wpf/ViewModels/LibraryViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/LibraryViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
@@ -19,6 +20,14 @@ namespace LM.App.Wpf.ViewModels
         private readonly IEntryStore _store;
         private readonly IWorkSpaceService _ws;
         private Entry? _selected;
+        private string? _sourceContains;
+        private string? _internalIdContains;
+        private string? _doiContains;
+        private string? _pmidContains;
+        private string? _nctContains;
+        private string? _addedByContains;
+        private DateTime? _addedOnFrom;
+        private DateTime? _addedOnTo;
 
         public LibraryViewModel(IEntryStore store, IWorkSpaceService ws)
         {
@@ -39,6 +48,102 @@ namespace LM.App.Wpf.ViewModels
         public bool? IsInternal { get; set; }
         public int? YearFrom { get; set; }
         public int? YearTo { get; set; }
+        public string? SourceContains
+        {
+            get => _sourceContains;
+            set
+            {
+                if (_sourceContains != value)
+                {
+                    _sourceContains = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        public string? InternalIdContains
+        {
+            get => _internalIdContains;
+            set
+            {
+                if (_internalIdContains != value)
+                {
+                    _internalIdContains = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        public string? DoiContains
+        {
+            get => _doiContains;
+            set
+            {
+                if (_doiContains != value)
+                {
+                    _doiContains = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        public string? PmidContains
+        {
+            get => _pmidContains;
+            set
+            {
+                if (_pmidContains != value)
+                {
+                    _pmidContains = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        public string? NctContains
+        {
+            get => _nctContains;
+            set
+            {
+                if (_nctContains != value)
+                {
+                    _nctContains = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        public string? AddedByContains
+        {
+            get => _addedByContains;
+            set
+            {
+                if (_addedByContains != value)
+                {
+                    _addedByContains = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        public DateTime? AddedOnFrom
+        {
+            get => _addedOnFrom;
+            set
+            {
+                if (_addedOnFrom != value)
+                {
+                    _addedOnFrom = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+        public DateTime? AddedOnTo
+        {
+            get => _addedOnTo;
+            set
+            {
+                if (_addedOnTo != value)
+                {
+                    _addedOnTo = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
         public EntryType[] Types { get; }
         public bool TypePublication { get; set; } = true;
         public bool TypePresentation { get; set; } = true;
@@ -78,11 +183,28 @@ namespace LM.App.Wpf.ViewModels
             {
                 Results.Clear();
 
+                static string? TrimOrNull(string? value)
+                    => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+                static DateTime? ToUtcStartOfDay(DateTime? localDate)
+                {
+                    if (!localDate.HasValue) return null;
+                    var local = DateTime.SpecifyKind(localDate.Value.Date, DateTimeKind.Local);
+                    return local.ToUniversalTime();
+                }
+
+                static DateTime? ToUtcEndOfDay(DateTime? localDate)
+                {
+                    if (!localDate.HasValue) return null;
+                    var local = DateTime.SpecifyKind(localDate.Value.Date.AddDays(1).AddTicks(-1), DateTimeKind.Local);
+                    return local.ToUniversalTime();
+                }
+
                 var filter = new EntryFilter
 
                 {
-                    TitleContains = string.IsNullOrWhiteSpace(TitleContains) ? null : TitleContains.Trim(),
-                    AuthorContains = string.IsNullOrWhiteSpace(AuthorContains) ? null : AuthorContains.Trim(),
+                    TitleContains = TrimOrNull(TitleContains),
+                    AuthorContains = TrimOrNull(AuthorContains),
                     TagsAny = string.IsNullOrWhiteSpace(TagsCsv)
                         ? new List<string>()
                         : TagsCsv.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(t => t.Trim()).ToList(),
@@ -91,8 +213,16 @@ namespace LM.App.Wpf.ViewModels
                         : null,   // only filter if user selected something
                     YearFrom = YearFrom,
                     YearTo = YearTo,
-                    IsInternal = IsInternal.HasValue ? IsInternal : null // only filter if user touched it
-                }; 
+                    IsInternal = IsInternal.HasValue ? IsInternal : null, // only filter if user touched it
+                    SourceContains = TrimOrNull(SourceContains),
+                    InternalIdContains = TrimOrNull(InternalIdContains),
+                    DoiContains = TrimOrNull(DoiContains),
+                    PmidContains = TrimOrNull(PmidContains),
+                    NctContains = TrimOrNull(NctContains),
+                    AddedByContains = TrimOrNull(AddedByContains),
+                    AddedOnFromUtc = ToUtcStartOfDay(AddedOnFrom),
+                    AddedOnToUtc = ToUtcEndOfDay(AddedOnTo)
+                };
 
                 Debug.WriteLine(
     $"Filter: Title='{filter.TitleContains}', Author='{filter.AuthorContains}', " +
@@ -137,6 +267,14 @@ namespace LM.App.Wpf.ViewModels
             TitleContains = AuthorContains = TagsCsv = null;
             IsInternal = null;
             YearFrom = YearTo = null;
+            SourceContains = null;
+            InternalIdContains = null;
+            DoiContains = null;
+            PmidContains = null;
+            NctContains = null;
+            AddedByContains = null;
+            AddedOnFrom = null;
+            AddedOnTo = null;
             TypePublication = TypePresentation = TypeWhitePaper = TypeSlideDeck = TypeReport = TypeOther = true;
             OnPropertyChanged(nameof(TitleContains));
             OnPropertyChanged(nameof(AuthorContains));
@@ -144,6 +282,14 @@ namespace LM.App.Wpf.ViewModels
             OnPropertyChanged(nameof(IsInternal));
             OnPropertyChanged(nameof(YearFrom));
             OnPropertyChanged(nameof(YearTo));
+            OnPropertyChanged(nameof(SourceContains));
+            OnPropertyChanged(nameof(InternalIdContains));
+            OnPropertyChanged(nameof(DoiContains));
+            OnPropertyChanged(nameof(PmidContains));
+            OnPropertyChanged(nameof(NctContains));
+            OnPropertyChanged(nameof(AddedByContains));
+            OnPropertyChanged(nameof(AddedOnFrom));
+            OnPropertyChanged(nameof(AddedOnTo));
             OnPropertyChanged(nameof(TypePublication));
             OnPropertyChanged(nameof(TypePresentation));
             OnPropertyChanged(nameof(TypeWhitePaper));

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -24,6 +24,24 @@
         <TextBlock Text="Tags (comma-separated)"/>
         <TextBox Text="{Binding TagsCsv, UpdateSourceTrigger=PropertyChanged}"/>
 
+        <TextBlock Text="Source contains"/>
+        <TextBox Text="{Binding SourceContains, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <TextBlock Text="Internal ID contains"/>
+        <TextBox Text="{Binding InternalIdContains, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <TextBlock Text="DOI contains"/>
+        <TextBox Text="{Binding DoiContains, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <TextBlock Text="PMID contains"/>
+        <TextBox Text="{Binding PmidContains, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <TextBlock Text="NCT contains"/>
+        <TextBox Text="{Binding NctContains, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <TextBlock Text="Added by contains"/>
+        <TextBox Text="{Binding AddedByContains, UpdateSourceTrigger=PropertyChanged}"/>
+
         <TextBlock Text="Type"/>
         <UniformGrid Columns="2" Margin="0,6,0,0">
           <CheckBox Content="Publication" IsChecked="{Binding TypePublication}"/>
@@ -39,6 +57,13 @@
           <TextBox Width="60" Text="{Binding YearFrom, UpdateSourceTrigger=PropertyChanged}"/>
           <TextBlock Text=" to " VerticalAlignment="Center" Margin="6,0,6,0"/>
           <TextBox Width="60" Text="{Binding YearTo, UpdateSourceTrigger=PropertyChanged}"/>
+        </DockPanel>
+
+        <TextBlock Text="Added on range"/>
+        <DockPanel>
+          <DatePicker Width="120" SelectedDate="{Binding AddedOnFrom, UpdateSourceTrigger=PropertyChanged}"/>
+          <TextBlock Text=" to " VerticalAlignment="Center" Margin="6,0,6,0"/>
+          <DatePicker Width="120" SelectedDate="{Binding AddedOnTo, UpdateSourceTrigger=PropertyChanged}"/>
         </DockPanel>
 
         <TextBlock Text="Visibility"/>
@@ -72,8 +97,15 @@
                 IsReadOnly="True">
         <DataGrid.Columns>
           <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="3*"/>
+          <DataGridTextColumn Header="Source" Binding="{Binding Source}" Width="2*"/>
           <DataGridTextColumn Header="Type" Binding="{Binding Type}" Width="1*"/>
           <DataGridTextColumn Header="Year" Binding="{Binding Year}" Width="0.8*"/>
+          <DataGridTextColumn Header="Added on" Binding="{Binding AddedOnUtc, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" Width="1.2*"/>
+          <DataGridTextColumn Header="Added by" Binding="{Binding AddedBy}" Width="1.2*"/>
+          <DataGridTextColumn Header="Internal ID" Binding="{Binding InternalId}" Width="1.5*"/>
+          <DataGridTextColumn Header="DOI" Binding="{Binding Doi}" Width="2*"/>
+          <DataGridTextColumn Header="PMID" Binding="{Binding Pmid}" Width="1.5*"/>
+          <DataGridTextColumn Header="NCT" Binding="{Binding Nct}" Width="1.5*"/>
           <DataGridTextColumn Header="Authors" Binding="{Binding Authors}" Width="2*"/>
           <DataGridTextColumn Header="Tags" Binding="{Binding Tags}" Width="2*"/>
           <DataGridTextColumn Header="Internal" Binding="{Binding IsInternal}" Width="0.8*"/>

--- a/src/LM.Core/Models/Filters.cs
+++ b/src/LM.Core/Models/Filters.cs
@@ -16,5 +16,13 @@ namespace LM.Core.Models.Filters
         public int? YearFrom { get; set; }
         public int? YearTo { get; set; }
         public bool? IsInternal { get; set; } // null = either
+        public string? SourceContains { get; set; }
+        public string? InternalIdContains { get; set; }
+        public string? DoiContains { get; set; }
+        public string? PmidContains { get; set; }
+        public string? NctContains { get; set; }
+        public string? AddedByContains { get; set; }
+        public DateTime? AddedOnFromUtc { get; set; }
+        public DateTime? AddedOnToUtc { get; set; }
     }
 }

--- a/src/LM.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Core/PublicAPI.Unshipped.txt
@@ -193,6 +193,22 @@ LM.Core.Models.Filters.EntryFilter.YearFrom.get -> int?
 LM.Core.Models.Filters.EntryFilter.YearFrom.set -> void
 LM.Core.Models.Filters.EntryFilter.YearTo.get -> int?
 LM.Core.Models.Filters.EntryFilter.YearTo.set -> void
+LM.Core.Models.Filters.EntryFilter.SourceContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.SourceContains.set -> void
+LM.Core.Models.Filters.EntryFilter.InternalIdContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.InternalIdContains.set -> void
+LM.Core.Models.Filters.EntryFilter.DoiContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.DoiContains.set -> void
+LM.Core.Models.Filters.EntryFilter.PmidContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.PmidContains.set -> void
+LM.Core.Models.Filters.EntryFilter.NctContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.NctContains.set -> void
+LM.Core.Models.Filters.EntryFilter.AddedByContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.AddedByContains.set -> void
+LM.Core.Models.Filters.EntryFilter.AddedOnFromUtc.get -> System.DateTime?
+LM.Core.Models.Filters.EntryFilter.AddedOnFromUtc.set -> void
+LM.Core.Models.Filters.EntryFilter.AddedOnToUtc.get -> System.DateTime?
+LM.Core.Models.Filters.EntryFilter.AddedOnToUtc.set -> void
 LM.Core.Models.GrantInfo
 LM.Core.Models.GrantInfo.Agency.get -> string?
 LM.Core.Models.GrantInfo.Agency.init -> void

--- a/src/LM.Infrastructure.Tests/JsonEntryStoreSearchTests.cs
+++ b/src/LM.Infrastructure.Tests/JsonEntryStoreSearchTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using LM.Core.Models;
+using LM.Core.Models.Filters;
+using LM.Infrastructure.Entries;
+using LM.Infrastructure.FileSystem;
+using Xunit;
+
+namespace LM.Infrastructure.Tests.Entries
+{
+    public sealed class JsonEntryStoreSearchTests
+    {
+        [Fact]
+        public async Task SearchAsync_FiltersByMetadataFields()
+        {
+            using var temp = new TempWorkspace();
+            var store = await CreateStoreAsync(temp.Path);
+
+            var included = new Entry
+            {
+                Id = "included",
+                Title = "Alpha",
+                Source = "Science Journal",
+                InternalId = "KW-001",
+                Doi = "10.1000/alpha",
+                Pmid = "12345678",
+                Nct = "NCT0001",
+                AddedBy = "alice",
+                AddedOnUtc = new DateTime(2024, 1, 10, 12, 30, 0, DateTimeKind.Utc),
+                Type = EntryType.Publication,
+                Year = 2024,
+                Tags = new List<string> { "immunology" }
+            };
+
+            var excluded = new Entry
+            {
+                Id = "excluded",
+                Title = "Beta",
+                Source = "Other Source",
+                InternalId = "KW-999",
+                Doi = "10.9999/beta",
+                Pmid = "00000000",
+                Nct = "NCT0999",
+                AddedBy = "bob",
+                AddedOnUtc = new DateTime(2023, 12, 1, 8, 0, 0, DateTimeKind.Utc),
+                Type = EntryType.Report,
+                Year = 2023,
+                Tags = new List<string> { "oncology" }
+            };
+
+            await store.SaveAsync(included);
+            await store.SaveAsync(excluded);
+
+            var filter = new EntryFilter
+            {
+                SourceContains = "science",
+                InternalIdContains = "001",
+                DoiContains = "ALPHA",
+                PmidContains = "3456",
+                NctContains = "0001",
+                AddedByContains = "ali",
+                AddedOnFromUtc = new DateTime(2024, 1, 10, 0, 0, 0, DateTimeKind.Utc),
+                AddedOnToUtc = new DateTime(2024, 1, 10, 23, 59, 59, DateTimeKind.Utc)
+            };
+
+            var results = await store.SearchAsync(filter);
+
+            var entry = Assert.Single(results);
+            Assert.Equal("included", entry.Id);
+        }
+
+        [Fact]
+        public async Task SearchAsync_OrdersBySourceThenAddedOnAndId()
+        {
+            using var temp = new TempWorkspace();
+            var store = await CreateStoreAsync(temp.Path);
+
+            var earlyAlpha = new Entry
+            {
+                Id = "alpha-early",
+                Title = "Shared",
+                Source = "Alpha Journal",
+                AddedOnUtc = new DateTime(2024, 1, 1, 8, 0, 0, DateTimeKind.Utc),
+                Type = EntryType.Publication,
+                Year = 2024
+            };
+
+            var lateAlpha = new Entry
+            {
+                Id = "alpha-late",
+                Title = "Shared",
+                Source = "Alpha Journal",
+                AddedOnUtc = new DateTime(2024, 1, 2, 8, 0, 0, DateTimeKind.Utc),
+                Type = EntryType.Publication,
+                Year = 2024
+            };
+
+            var beta = new Entry
+            {
+                Id = "beta",
+                Title = "Shared",
+                Source = "Beta Journal",
+                AddedOnUtc = new DateTime(2024, 1, 3, 8, 0, 0, DateTimeKind.Utc),
+                Type = EntryType.Publication,
+                Year = 2024
+            };
+
+            await store.SaveAsync(beta);
+            await store.SaveAsync(lateAlpha);
+            await store.SaveAsync(earlyAlpha);
+
+            var results = await store.SearchAsync(new EntryFilter());
+
+            Assert.Equal(new[] { "alpha-early", "alpha-late", "beta" }, results.Select(r => r.Id).ToArray());
+        }
+
+        private static async Task<JsonEntryStore> CreateStoreAsync(string workspacePath)
+        {
+            var ws = new WorkspaceService();
+            await ws.EnsureWorkspaceAsync(workspacePath);
+            var store = new JsonEntryStore(ws);
+            await store.InitializeAsync();
+            return store;
+        }
+
+        private sealed class TempWorkspace : IDisposable
+        {
+            public string Path { get; }
+
+            public TempWorkspace()
+            {
+                Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "lm_jsonstore_" + Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(Path);
+            }
+
+            public void Dispose()
+            {
+                try { Directory.Delete(Path, recursive: true); } catch { /* ignore */ }
+            }
+        }
+    }
+}

--- a/src/LM.Infrastructure/Entries/JsonEntryStore.cs
+++ b/src/LM.Infrastructure/Entries/JsonEntryStore.cs
@@ -184,6 +184,11 @@ namespace LM.Infrastructure.Entries
                 var needle = f.AuthorContains.Trim();
                 q = q.Where(e => (e.Authors?.Any(a => a.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0) ?? false));
             }
+            if (!string.IsNullOrWhiteSpace(f.SourceContains))
+            {
+                var needle = f.SourceContains.Trim();
+                q = q.Where(e => e.Source?.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
             if (f.TypesAny is { Length: > 0 })
             {
                 var set = new HashSet<EntryType>(f.TypesAny);
@@ -203,7 +208,51 @@ namespace LM.Infrastructure.Entries
                 q = q.Where(e => e.Tags?.Any(t => tags.Contains(t)) ?? false);
             }
 
-            var list = q.OrderByDescending(e => e.Year.HasValue).ThenBy(e => e.Title).Take(1000).ToList();
+            if (!string.IsNullOrWhiteSpace(f.InternalIdContains))
+            {
+                var needle = f.InternalIdContains.Trim();
+                q = q.Where(e => e.InternalId?.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+            if (!string.IsNullOrWhiteSpace(f.DoiContains))
+            {
+                var needle = f.DoiContains.Trim();
+                q = q.Where(e => e.Doi?.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+            if (!string.IsNullOrWhiteSpace(f.PmidContains))
+            {
+                var needle = f.PmidContains.Trim();
+                q = q.Where(e => e.Pmid?.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+            if (!string.IsNullOrWhiteSpace(f.NctContains))
+            {
+                var needle = f.NctContains.Trim();
+                q = q.Where(e => e.Nct?.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+            if (!string.IsNullOrWhiteSpace(f.AddedByContains))
+            {
+                var needle = f.AddedByContains.Trim();
+                q = q.Where(e => e.AddedBy?.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+            if (f.AddedOnFromUtc.HasValue)
+            {
+                var from = f.AddedOnFromUtc.Value;
+                q = q.Where(e => e.AddedOnUtc >= from);
+            }
+            if (f.AddedOnToUtc.HasValue)
+            {
+                var to = f.AddedOnToUtc.Value;
+                q = q.Where(e => e.AddedOnUtc <= to);
+            }
+
+            var list = q
+                .OrderByDescending(e => e.Year.HasValue)
+                .ThenByDescending(e => e.Year ?? int.MinValue)
+                .ThenBy(e => e.Title ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(e => e.Source ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(e => e.AddedOnUtc)
+                .ThenBy(e => e.Id, StringComparer.OrdinalIgnoreCase)
+                .Take(1000)
+                .ToList();
             return Task.FromResult<IReadOnlyList<Entry>>(list);
         }
 


### PR DESCRIPTION
## Summary
- extend EntryFilter with source, identifier, and added-on metadata fields
- apply the expanded filters and deterministic ordering inside JsonEntryStore
- surface the new search inputs and result columns in LibraryView and cover them with tests

## Testing
- `dotnet test` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd41f539c4832b9f74f8e3355a4830