### PR TITLE
Handle invalid lit search timestamps when formatting entry notes

### DIFF
--- a/src/LM.HubSpoke.Tests/EntryNotesHookTests.cs
+++ b/src/LM.HubSpoke.Tests/EntryNotesHookTests.cs
@@ -1,0 +1,39 @@
+using System;
+using LM.HubSpoke.Models;
+using Xunit;
+
+public class EntryNotesHookTests
+{
+    [Fact]
+    public void ToDisplayString_HandlesMissingAndInvalidValues()
+    {
+        var summary = new LitSearchNoteSummary
+        {
+            Title = "  Example  ",
+            Query = "   ",
+            Provider = string.Empty,
+            CreatedBy = "   ",
+            CreatedUtc = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Local),
+            RunCount = -5,
+            DerivedFromEntryId = "  ENTRY-42  ",
+            LatestRun = new LitSearchNoteRunSummary
+            {
+                ExecutedBy = null,
+                RunUtc = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Local),
+                TotalHits = -10,
+                From = null,
+                To = null
+            }
+        };
+
+        var text = summary.ToDisplayString();
+
+        Assert.Contains("Title: Example", text);
+        Assert.Contains("Query: unknown", text);
+        Assert.Contains("Provider: unknown", text);
+        Assert.Contains("Created by unknown on unknown.", text);
+        Assert.Contains("Run count: 0", text);
+        Assert.Contains("Latest run executed by unknown on unknown (hits: 0).", text);
+        Assert.Contains("Derived from entry ENTRY-42.", text);
+    }
+}


### PR DESCRIPTION
## Summary
- guard the lit search entry notes summary against missing or malformed field values so it never throws while rendering
- clamp negative counts, trim derived IDs, and reuse a shared formatter for UTC timestamps
- add a regression test that exercises the fallback formatting logic for incomplete lit search data

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cd47a459e8832ba7f287b36e8b142a