### PR TITLE
Add library filter preset management

### DIFF
--- a/src/LM.App.Wpf.Tests/LibraryFilterPresetStoreTests.cs
+++ b/src/LM.App.Wpf.Tests/LibraryFilterPresetStoreTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Threading.Tasks;
+using LM.App.Wpf.Library;
+using LM.Infrastructure.FileSystem;
+using Xunit;
+
+public class LibraryFilterPresetStoreTests
+{
+    [Fact]
+    public async Task SaveLoadAndDelete_RoundTripsState()
+    {
+        using var temp = new TempDir();
+        var workspace = new WorkspaceService();
+        await workspace.EnsureWorkspaceAsync(temp.Path);
+
+        var store = new LibraryFilterPresetStore(workspace);
+        var preset = new LibraryFilterPreset
+        {
+            Name = "My Preset",
+            State = new LibraryFilterState
+            {
+                TitleContains = "title",
+                AuthorContains = "author",
+                TagsCsv = "tag1,tag2",
+                IsInternal = true,
+                YearFrom = 2010,
+                YearTo = 2020,
+                SourceContains = "source",
+                InternalIdContains = "internal",
+                DoiContains = "doi",
+                PmidContains = "pmid",
+                NctContains = "nct",
+                AddedByContains = "adder",
+                AddedOnFrom = new DateTime(2024, 1, 1),
+                AddedOnTo = new DateTime(2024, 12, 31),
+                TypePublication = false,
+                TypePresentation = true,
+                TypeWhitePaper = false,
+                TypeSlideDeck = true,
+                TypeReport = false,
+                TypeOther = true
+            }
+        };
+
+        await store.SavePresetAsync(preset);
+
+        var presets = await store.ListPresetsAsync();
+        var loaded = Assert.Single(presets);
+        Assert.Equal("My Preset", loaded.Name);
+        Assert.True((DateTime.UtcNow - loaded.SavedUtc) < TimeSpan.FromMinutes(1));
+
+        Assert.Equal(preset.State.TitleContains, loaded.State.TitleContains);
+        Assert.Equal(preset.State.AuthorContains, loaded.State.AuthorContains);
+        Assert.Equal(preset.State.TagsCsv, loaded.State.TagsCsv);
+        Assert.Equal(preset.State.IsInternal, loaded.State.IsInternal);
+        Assert.Equal(preset.State.YearFrom, loaded.State.YearFrom);
+        Assert.Equal(preset.State.YearTo, loaded.State.YearTo);
+        Assert.Equal(preset.State.SourceContains, loaded.State.SourceContains);
+        Assert.Equal(preset.State.InternalIdContains, loaded.State.InternalIdContains);
+        Assert.Equal(preset.State.DoiContains, loaded.State.DoiContains);
+        Assert.Equal(preset.State.PmidContains, loaded.State.PmidContains);
+        Assert.Equal(preset.State.NctContains, loaded.State.NctContains);
+        Assert.Equal(preset.State.AddedByContains, loaded.State.AddedByContains);
+        Assert.Equal(preset.State.AddedOnFrom, loaded.State.AddedOnFrom);
+        Assert.Equal(preset.State.AddedOnTo, loaded.State.AddedOnTo);
+        Assert.Equal(preset.State.TypePublication, loaded.State.TypePublication);
+        Assert.Equal(preset.State.TypePresentation, loaded.State.TypePresentation);
+        Assert.Equal(preset.State.TypeWhitePaper, loaded.State.TypeWhitePaper);
+        Assert.Equal(preset.State.TypeSlideDeck, loaded.State.TypeSlideDeck);
+        Assert.Equal(preset.State.TypeReport, loaded.State.TypeReport);
+        Assert.Equal(preset.State.TypeOther, loaded.State.TypeOther);
+
+        var fetched = await store.TryGetPresetAsync("my preset");
+        Assert.NotNull(fetched);
+        Assert.Equal("My Preset", fetched!.Name);
+
+        await store.DeletePresetAsync("My Preset");
+        var afterDelete = await store.ListPresetsAsync();
+        Assert.Empty(afterDelete);
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; }
+        public TempDir()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "lm_preset_" + Guid.NewGuid().ToString("N"));
+            System.IO.Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                System.IO.Directory.Delete(Path, recursive: true);
+            }
+            catch
+            {
+                // ignore cleanup failures
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/App.xaml.cs
+++ b/src/LM.App.Wpf/App.xaml.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading.Tasks;
 using System.Windows;
+using LM.App.Wpf.Library;
 using LM.App.Wpf.ViewModels;
 using LM.App.Wpf.Views;
 using LM.Core.Abstractions;
@@ -68,7 +69,9 @@ namespace LM.App.Wpf
             await services.Store.InitializeAsync();
 
             // ViewModels
-            var libraryVm = new LibraryViewModel(services.Store, ws);
+            var presetStore = new LibraryFilterPresetStore(ws);
+            var presetPrompt = new LibraryPresetPrompt();
+            var libraryVm = new LibraryViewModel(services.Store, ws, presetStore, presetPrompt);
             var addVm = new AddViewModel(services.Pipeline);
             var searchPrompt = new SearchSavePrompt();
             var searchVm = new SearchViewModel(services.Store, services.Storage, ws, searchPrompt);

--- a/src/LM.App.Wpf/Common/ILibraryPresetPrompt.cs
+++ b/src/LM.App.Wpf/Common/ILibraryPresetPrompt.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LM.App.Wpf.Common
+{
+    public interface ILibraryPresetPrompt
+    {
+        Task<LibraryPresetSaveResult?> RequestSaveAsync(LibraryPresetSaveContext context);
+        Task<LibraryPresetSelectionResult?> RequestSelectionAsync(LibraryPresetSelectionContext context);
+    }
+
+    public sealed record LibraryPresetSaveContext(string DefaultName, IReadOnlyCollection<string> ExistingNames);
+
+    public sealed record LibraryPresetSaveResult(string Name);
+
+    public sealed record LibraryPresetSelectionContext(
+        IReadOnlyList<LibraryPresetSummary> Presets,
+        bool AllowLoad,
+        string Title);
+
+    public sealed record LibraryPresetSelectionResult(string? SelectedPresetName, IReadOnlyList<string> DeletedPresetNames);
+
+    public sealed record LibraryPresetSummary(string Name, DateTime SavedUtc);
+}

--- a/src/LM.App.Wpf/Library/LibraryFilterPresetStore.cs
+++ b/src/LM.App.Wpf/Library/LibraryFilterPresetStore.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Abstractions;
+
+namespace LM.App.Wpf.Library
+{
+    /// <summary>
+    /// Persists named Library filter presets under the active workspace.
+    /// </summary>
+    public sealed class LibraryFilterPresetStore
+    {
+        private readonly IWorkSpaceService _workspace;
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            AllowTrailingCommas = true
+        };
+
+        public LibraryFilterPresetStore(IWorkSpaceService workspace)
+        {
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+        }
+
+        public async Task SavePresetAsync(LibraryFilterPreset preset, CancellationToken ct = default)
+        {
+            if (preset is null)
+                throw new ArgumentNullException(nameof(preset));
+
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+
+            var existingIndex = file.Presets.FindIndex(p => string.Equals(p.Name, preset.Name, StringComparison.OrdinalIgnoreCase));
+            preset.SavedUtc = DateTime.UtcNow;
+
+            if (existingIndex >= 0)
+            {
+                file.Presets[existingIndex] = preset;
+            }
+            else
+            {
+                file.Presets.Add(preset);
+            }
+
+            file.Presets.Sort(static (a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+            await SaveAsync(file, ct).ConfigureAwait(false);
+        }
+
+        public async Task<IReadOnlyList<LibraryFilterPreset>> ListPresetsAsync(CancellationToken ct = default)
+        {
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            return file.Presets
+                .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(p => p.Clone())
+                .ToArray();
+        }
+
+        public async Task<LibraryFilterPreset?> TryGetPresetAsync(string name, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return null;
+
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            var preset = file.Presets.FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+            return preset?.Clone();
+        }
+
+        public async Task DeletePresetAsync(string name, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return;
+
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            file.Presets.RemoveAll(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+            await SaveAsync(file, ct).ConfigureAwait(false);
+        }
+
+        private async Task<LibraryPresetFile> LoadAsync(CancellationToken ct)
+        {
+            var path = GetFilePath();
+            if (!File.Exists(path))
+                return new LibraryPresetFile();
+
+            await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+            var file = await JsonSerializer.DeserializeAsync<LibraryPresetFile>(stream, JsonOptions, ct).ConfigureAwait(false);
+            return file ?? new LibraryPresetFile();
+        }
+
+        private async Task SaveAsync(LibraryPresetFile file, CancellationToken ct)
+        {
+            var path = GetFilePath();
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var json = JsonSerializer.Serialize(file, JsonOptions);
+            await File.WriteAllTextAsync(path, json, ct).ConfigureAwait(false);
+        }
+
+        private string GetFilePath()
+        {
+            var root = _workspace.GetWorkspaceRoot();
+            return Path.Combine(root, "library", "filter-presets.json");
+        }
+
+        private sealed class LibraryPresetFile
+        {
+            public List<LibraryFilterPreset> Presets { get; set; } = new();
+        }
+    }
+
+    public sealed class LibraryFilterPreset
+    {
+        public string Name { get; set; } = string.Empty;
+        public DateTime SavedUtc { get; set; } = DateTime.UtcNow;
+        public LibraryFilterState State { get; set; } = new();
+
+        internal LibraryFilterPreset Clone()
+            => new()
+            {
+                Name = Name,
+                SavedUtc = SavedUtc,
+                State = State.Clone()
+            };
+    }
+
+    public sealed class LibraryFilterState
+    {
+        public string? TitleContains { get; set; }
+        public string? AuthorContains { get; set; }
+        public string? TagsCsv { get; set; }
+        public bool? IsInternal { get; set; }
+        public int? YearFrom { get; set; }
+        public int? YearTo { get; set; }
+        public string? SourceContains { get; set; }
+        public string? InternalIdContains { get; set; }
+        public string? DoiContains { get; set; }
+        public string? PmidContains { get; set; }
+        public string? NctContains { get; set; }
+        public string? AddedByContains { get; set; }
+        public DateTime? AddedOnFrom { get; set; }
+        public DateTime? AddedOnTo { get; set; }
+        public bool TypePublication { get; set; } = true;
+        public bool TypePresentation { get; set; } = true;
+        public bool TypeWhitePaper { get; set; } = true;
+        public bool TypeSlideDeck { get; set; } = true;
+        public bool TypeReport { get; set; } = true;
+        public bool TypeOther { get; set; } = true;
+
+        internal LibraryFilterState Clone()
+            => (LibraryFilterState)MemberwiseClone();
+    }
+}

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -19,6 +19,9 @@ LM.App.Wpf.Common.BooleanToOpacityConverter.FalseOpacity.get -> double
 LM.App.Wpf.Common.BooleanToOpacityConverter.FalseOpacity.set -> void
 LM.App.Wpf.Common.BooleanToOpacityConverter.TrueOpacity.get -> double
 LM.App.Wpf.Common.BooleanToOpacityConverter.TrueOpacity.set -> void
+LM.App.Wpf.Common.ILibraryPresetPrompt
+LM.App.Wpf.Common.ILibraryPresetPrompt.RequestSaveAsync(LM.App.Wpf.Common.LibraryPresetSaveContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.LibraryPresetSaveResult?>!
+LM.App.Wpf.Common.ILibraryPresetPrompt.RequestSelectionAsync(LM.App.Wpf.Common.LibraryPresetSelectionContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.LibraryPresetSelectionResult?>!
 LM.App.Wpf.Common.ISearchSavePrompt
 LM.App.Wpf.Common.ISearchSavePrompt.RequestAsync(LM.App.Wpf.Common.SearchSavePromptContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.SearchSavePromptResult?>!
 LM.App.Wpf.Common.SearchSavePromptContext
@@ -45,6 +48,36 @@ LM.App.Wpf.Common.SearchSavePromptResult.SearchSavePromptResult(string! Name, st
 LM.App.Wpf.Common.SearchSavePromptResult.Name.get -> string!
 LM.App.Wpf.Common.SearchSavePromptResult.Notes.get -> string!
 LM.App.Wpf.Common.SearchSavePromptResult.Tags.get -> string!
+LM.App.Wpf.Common.LibraryPresetSaveContext
+LM.App.Wpf.Common.LibraryPresetSaveContext.DefaultName.get -> string!
+LM.App.Wpf.Common.LibraryPresetSaveContext.DefaultName.init -> void
+LM.App.Wpf.Common.LibraryPresetSaveContext.ExistingNames.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+LM.App.Wpf.Common.LibraryPresetSaveContext.ExistingNames.init -> void
+LM.App.Wpf.Common.LibraryPresetSaveContext.LibraryPresetSaveContext(string! DefaultName, System.Collections.Generic.IReadOnlyCollection<string!>! ExistingNames) -> void
+LM.App.Wpf.Common.LibraryPresetSaveResult
+LM.App.Wpf.Common.LibraryPresetSaveResult.LibraryPresetSaveResult(string! Name) -> void
+LM.App.Wpf.Common.LibraryPresetSaveResult.Name.get -> string!
+LM.App.Wpf.Common.LibraryPresetSaveResult.Name.init -> void
+LM.App.Wpf.Common.LibraryPresetSelectionContext
+LM.App.Wpf.Common.LibraryPresetSelectionContext.AllowLoad.get -> bool
+LM.App.Wpf.Common.LibraryPresetSelectionContext.AllowLoad.init -> void
+LM.App.Wpf.Common.LibraryPresetSelectionContext.LibraryPresetSelectionContext(System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Common.LibraryPresetSummary!>! Presets, bool AllowLoad, string! Title) -> void
+LM.App.Wpf.Common.LibraryPresetSelectionContext.Presets.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Common.LibraryPresetSummary!>!
+LM.App.Wpf.Common.LibraryPresetSelectionContext.Presets.init -> void
+LM.App.Wpf.Common.LibraryPresetSelectionContext.Title.get -> string!
+LM.App.Wpf.Common.LibraryPresetSelectionContext.Title.init -> void
+LM.App.Wpf.Common.LibraryPresetSelectionResult
+LM.App.Wpf.Common.LibraryPresetSelectionResult.DeletedPresetNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.Common.LibraryPresetSelectionResult.DeletedPresetNames.init -> void
+LM.App.Wpf.Common.LibraryPresetSelectionResult.LibraryPresetSelectionResult(string? SelectedPresetName, System.Collections.Generic.IReadOnlyList<string!>! DeletedPresetNames) -> void
+LM.App.Wpf.Common.LibraryPresetSelectionResult.SelectedPresetName.get -> string?
+LM.App.Wpf.Common.LibraryPresetSelectionResult.SelectedPresetName.init -> void
+LM.App.Wpf.Common.LibraryPresetSummary
+LM.App.Wpf.Common.LibraryPresetSummary.LibraryPresetSummary(string! Name, System.DateTime SavedUtc) -> void
+LM.App.Wpf.Common.LibraryPresetSummary.Name.get -> string!
+LM.App.Wpf.Common.LibraryPresetSummary.Name.init -> void
+LM.App.Wpf.Common.LibraryPresetSummary.SavedUtc.get -> System.DateTime
+LM.App.Wpf.Common.LibraryPresetSummary.SavedUtc.init -> void
 LM.App.Wpf.Common.RelayCommand
 LM.App.Wpf.Common.RelayCommand.CanExecute(object? parameter) -> bool
 LM.App.Wpf.Common.RelayCommand.CanExecuteChanged -> System.EventHandler?
@@ -55,6 +88,62 @@ LM.App.Wpf.Common.ViewModelBase
 LM.App.Wpf.Common.ViewModelBase.OnPropertyChanged(string? name = null) -> void
 LM.App.Wpf.Common.ViewModelBase.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
 LM.App.Wpf.Common.ViewModelBase.ViewModelBase() -> void
+LM.App.Wpf.Library.LibraryFilterPreset
+LM.App.Wpf.Library.LibraryFilterPreset.LibraryFilterPreset() -> void
+LM.App.Wpf.Library.LibraryFilterPreset.Name.get -> string!
+LM.App.Wpf.Library.LibraryFilterPreset.Name.set -> void
+LM.App.Wpf.Library.LibraryFilterPreset.SavedUtc.get -> System.DateTime
+LM.App.Wpf.Library.LibraryFilterPreset.SavedUtc.set -> void
+LM.App.Wpf.Library.LibraryFilterPreset.State.get -> LM.App.Wpf.Library.LibraryFilterState!
+LM.App.Wpf.Library.LibraryFilterPreset.State.set -> void
+LM.App.Wpf.Library.LibraryFilterPresetStore
+LM.App.Wpf.Library.LibraryFilterPresetStore.DeletePresetAsync(string? name, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.LibraryFilterPresetStore.LibraryFilterPresetStore(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.App.Wpf.Library.LibraryFilterPresetStore.ListPresetsAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Library.LibraryFilterPreset!>!>!
+LM.App.Wpf.Library.LibraryFilterPresetStore.SavePresetAsync(LM.App.Wpf.Library.LibraryFilterPreset! preset, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.LibraryFilterPresetStore.TryGetPresetAsync(string? name, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.LibraryFilterPreset?>!
+LM.App.Wpf.Library.LibraryFilterState
+LM.App.Wpf.Library.LibraryFilterState.AddedByContains.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.AddedByContains.set -> void
+LM.App.Wpf.Library.LibraryFilterState.AddedOnFrom.get -> System.DateTime?
+LM.App.Wpf.Library.LibraryFilterState.AddedOnFrom.set -> void
+LM.App.Wpf.Library.LibraryFilterState.AddedOnTo.get -> System.DateTime?
+LM.App.Wpf.Library.LibraryFilterState.AddedOnTo.set -> void
+LM.App.Wpf.Library.LibraryFilterState.AuthorContains.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.AuthorContains.set -> void
+LM.App.Wpf.Library.LibraryFilterState.DoiContains.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.DoiContains.set -> void
+LM.App.Wpf.Library.LibraryFilterState.InternalIdContains.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.InternalIdContains.set -> void
+LM.App.Wpf.Library.LibraryFilterState.IsInternal.get -> bool?
+LM.App.Wpf.Library.LibraryFilterState.IsInternal.set -> void
+LM.App.Wpf.Library.LibraryFilterState.LibraryFilterState() -> void
+LM.App.Wpf.Library.LibraryFilterState.NctContains.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.NctContains.set -> void
+LM.App.Wpf.Library.LibraryFilterState.PmidContains.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.PmidContains.set -> void
+LM.App.Wpf.Library.LibraryFilterState.SourceContains.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.SourceContains.set -> void
+LM.App.Wpf.Library.LibraryFilterState.TagsCsv.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.TagsCsv.set -> void
+LM.App.Wpf.Library.LibraryFilterState.TitleContains.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.TitleContains.set -> void
+LM.App.Wpf.Library.LibraryFilterState.TypeOther.get -> bool
+LM.App.Wpf.Library.LibraryFilterState.TypeOther.set -> void
+LM.App.Wpf.Library.LibraryFilterState.TypePresentation.get -> bool
+LM.App.Wpf.Library.LibraryFilterState.TypePresentation.set -> void
+LM.App.Wpf.Library.LibraryFilterState.TypePublication.get -> bool
+LM.App.Wpf.Library.LibraryFilterState.TypePublication.set -> void
+LM.App.Wpf.Library.LibraryFilterState.TypeReport.get -> bool
+LM.App.Wpf.Library.LibraryFilterState.TypeReport.set -> void
+LM.App.Wpf.Library.LibraryFilterState.TypeSlideDeck.get -> bool
+LM.App.Wpf.Library.LibraryFilterState.TypeSlideDeck.set -> void
+LM.App.Wpf.Library.LibraryFilterState.TypeWhitePaper.get -> bool
+LM.App.Wpf.Library.LibraryFilterState.TypeWhitePaper.set -> void
+LM.App.Wpf.Library.LibraryFilterState.YearFrom.get -> int?
+LM.App.Wpf.Library.LibraryFilterState.YearFrom.set -> void
+LM.App.Wpf.Library.LibraryFilterState.YearTo.get -> int?
+LM.App.Wpf.Library.LibraryFilterState.YearTo.set -> void
 LM.App.Wpf.ViewModels.AddPipeline
 LM.App.Wpf.ViewModels.AddPipeline.AddPipeline(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.ISimilarityService! similarity, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IMetadataExtractor! metadata, IPublicationLookup! publicationLookup, LM.Core.Abstractions.IDoiNormalizer! doiNormalizer, LM.Infrastructure.Hooks.HookOrchestrator! orchestrator, LM.Core.Abstractions.IPmidNormalizer! pmidNormalizer, LM.HubSpoke.Abstractions.ISimilarityLog? simLog = null) -> void
 LM.App.Wpf.ViewModels.AddPipeline.AddPipeline(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.ISimilarityService! similarity, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IMetadataExtractor! metadata, LM.HubSpoke.Abstractions.ISimilarityLog? simLog = null) -> void
@@ -97,7 +186,9 @@ LM.App.Wpf.ViewModels.LibraryViewModel.InternalIdContains.get -> string?
 LM.App.Wpf.ViewModels.LibraryViewModel.InternalIdContains.set -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.IsInternal.get -> bool?
 LM.App.Wpf.ViewModels.LibraryViewModel.IsInternal.set -> void
-LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IWorkSpaceService! ws) -> void
+LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IWorkSpaceService! ws, LM.App.Wpf.Library.LibraryFilterPresetStore! presetStore, LM.App.Wpf.Common.ILibraryPresetPrompt! presetPrompt) -> void
+LM.App.Wpf.ViewModels.LibraryViewModel.LoadPresetCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.LibraryViewModel.ManagePresetsCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.LibraryViewModel.NctContains.get -> string?
 LM.App.Wpf.ViewModels.LibraryViewModel.NctContains.set -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.OpenCommand.get -> System.Windows.Input.ICommand!
@@ -109,6 +200,7 @@ LM.App.Wpf.ViewModels.LibraryViewModel.Selected.get -> LM.Core.Models.Entry?
 LM.App.Wpf.ViewModels.LibraryViewModel.Selected.set -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.SourceContains.get -> string?
 LM.App.Wpf.ViewModels.LibraryViewModel.SourceContains.set -> void
+LM.App.Wpf.ViewModels.LibraryViewModel.SavePresetCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.LibraryViewModel.TagsCsv.get -> string?
 LM.App.Wpf.ViewModels.LibraryViewModel.TagsCsv.set -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.TitleContains.get -> string?
@@ -235,6 +327,10 @@ LM.App.Wpf.Views.AddView.InitializeComponent() -> void
 LM.App.Wpf.Views.LibraryView
 LM.App.Wpf.Views.LibraryView.InitializeComponent() -> void
 LM.App.Wpf.Views.LibraryView.LibraryView() -> void
+LM.App.Wpf.Views.LibraryPresetPrompt
+LM.App.Wpf.Views.LibraryPresetPrompt.LibraryPresetPrompt() -> void
+LM.App.Wpf.Views.LibraryPresetPrompt.RequestSaveAsync(LM.App.Wpf.Common.LibraryPresetSaveContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.LibraryPresetSaveResult?>!
+LM.App.Wpf.Views.LibraryPresetPrompt.RequestSelectionAsync(LM.App.Wpf.Common.LibraryPresetSelectionContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.LibraryPresetSelectionResult?>!
 LM.App.Wpf.Views.SearchSavePrompt
 LM.App.Wpf.Views.SearchSavePrompt.RequestAsync(LM.App.Wpf.Common.SearchSavePromptContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.SearchSavePromptResult?>!
 LM.App.Wpf.Views.SearchSavePrompt.SearchSavePrompt() -> void

--- a/src/LM.App.Wpf/Views/LibraryPresetPickerDialog.xaml
+++ b/src/LM.App.Wpf/Views/LibraryPresetPickerDialog.xaml
@@ -1,0 +1,61 @@
+<Window x:Class="LM.App.Wpf.Views.LibraryPresetPickerDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:common="clr-namespace:LM.App.Wpf.Common"
+        Title="Library Presets"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner"
+        MinWidth="420"
+        MinHeight="320">
+  <Grid Margin="16">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="8" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="12" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+
+    <TextBlock x:Name="HeaderText"
+               Grid.Row="0"
+               FontWeight="SemiBold" />
+
+    <Border Grid.Row="2"
+            BorderBrush="#33000000"
+            BorderThickness="1"
+            CornerRadius="4">
+      <ListBox x:Name="PresetList"
+               MinWidth="360"
+               HorizontalContentAlignment="Stretch"
+               DisplayMemberPath="Name">
+        <ListBox.ItemTemplate>
+          <DataTemplate DataType="{x:Type common:LibraryPresetSummary}">
+            <StackPanel Orientation="Vertical" Margin="4">
+              <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
+              <TextBlock Text="{Binding SavedUtc, StringFormat='Saved {0:yyyy-MM-dd HH:mm}'}" FontSize="12" Opacity="0.7" />
+            </StackPanel>
+          </DataTemplate>
+        </ListBox.ItemTemplate>
+      </ListBox>
+    </Border>
+
+    <StackPanel Grid.Row="4"
+                Orientation="Horizontal"
+                HorizontalAlignment="Right">
+      <Button x:Name="DeleteButton"
+              Content="Delete"
+              Width="80"
+              Margin="0,0,8,0"
+              Click="OnDelete" />
+      <Button x:Name="LoadButton"
+              Content="Load"
+              Width="80"
+              Margin="0,0,8,0"
+              Click="OnLoad" />
+      <Button Content="Close"
+              Width="80"
+              IsCancel="True"
+              Click="OnClose" />
+    </StackPanel>
+  </Grid>
+</Window>

--- a/src/LM.App.Wpf/Views/LibraryPresetPickerDialog.xaml.cs
+++ b/src/LM.App.Wpf/Views/LibraryPresetPickerDialog.xaml.cs
@@ -1,0 +1,95 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using LM.App.Wpf.Common;
+
+namespace LM.App.Wpf.Views
+{
+    internal partial class LibraryPresetPickerDialog : Window
+    {
+        private readonly ObservableCollection<LibraryPresetSummary> _presets;
+        private readonly bool _allowLoad;
+        private readonly List<string> _deleted = new();
+
+        public string? SelectedPresetName { get; private set; }
+        public IReadOnlyList<string> DeletedPresetNames => _deleted;
+
+        public LibraryPresetPickerDialog(LibraryPresetSelectionContext context)
+        {
+            InitializeComponent();
+
+            Title = context.Title;
+            HeaderText.Text = context.Title;
+            _allowLoad = context.AllowLoad;
+            LoadButton.Visibility = _allowLoad ? Visibility.Visible : Visibility.Collapsed;
+            LoadButton.IsEnabled = _allowLoad;
+
+            _presets = new ObservableCollection<LibraryPresetSummary>(context.Presets.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase));
+            PresetList.ItemsSource = _presets;
+            DeleteButton.IsEnabled = _presets.Count > 0;
+            if (!_allowLoad)
+            {
+                LoadButton.IsEnabled = false;
+            }
+            else
+            {
+                LoadButton.IsEnabled = _presets.Count > 0;
+            }
+
+            Loaded += (_, _) =>
+            {
+                if (_presets.Count > 0)
+                {
+                    PresetList.SelectedIndex = 0;
+                    PresetList.Focus();
+                }
+            };
+        }
+
+        private void OnLoad(object? sender, RoutedEventArgs e)
+        {
+            if (!_allowLoad)
+                return;
+
+            if (PresetList.SelectedItem is not LibraryPresetSummary summary)
+            {
+                MessageBox.Show(this, "Select a preset to load.", Title, MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            SelectedPresetName = summary.Name;
+            DialogResult = true;
+        }
+
+        private void OnDelete(object? sender, RoutedEventArgs e)
+        {
+            if (PresetList.SelectedItem is not LibraryPresetSummary summary)
+            {
+                MessageBox.Show(this, "Select a preset to delete.", Title, MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var confirm = MessageBox.Show(this, $"Delete preset \"{summary.Name}\"?", Title, MessageBoxButton.YesNo, MessageBoxImage.Question);
+            if (confirm != MessageBoxResult.Yes)
+                return;
+
+            _deleted.Add(summary.Name);
+            _presets.Remove(summary);
+
+            if (_presets.Count == 0)
+            {
+                DeleteButton.IsEnabled = false;
+                if (_allowLoad)
+                    LoadButton.IsEnabled = false;
+            }
+        }
+
+        private void OnClose(object? sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/LibraryPresetPrompt.cs
+++ b/src/LM.App.Wpf/Views/LibraryPresetPrompt.cs
@@ -1,0 +1,70 @@
+using System.Threading.Tasks;
+using System.Windows;
+using LM.App.Wpf.Common;
+
+namespace LM.App.Wpf.Views
+{
+    public sealed class LibraryPresetPrompt : ILibraryPresetPrompt
+    {
+        public Task<LibraryPresetSaveResult?> RequestSaveAsync(LibraryPresetSaveContext context)
+        {
+            var app = Application.Current;
+            if (app is null)
+                return Task.FromResult<LibraryPresetSaveResult?>(null);
+
+            if (app.Dispatcher.CheckAccess())
+            {
+                return Task.FromResult(ShowSaveDialog(context));
+            }
+
+            return app.Dispatcher.InvokeAsync(() => ShowSaveDialog(context)).Task;
+        }
+
+        public Task<LibraryPresetSelectionResult?> RequestSelectionAsync(LibraryPresetSelectionContext context)
+        {
+            var app = Application.Current;
+            if (app is null)
+                return Task.FromResult<LibraryPresetSelectionResult?>(null);
+
+            if (app.Dispatcher.CheckAccess())
+            {
+                return Task.FromResult(ShowSelectionDialog(context));
+            }
+
+            return app.Dispatcher.InvokeAsync(() => ShowSelectionDialog(context)).Task;
+        }
+
+        private static LibraryPresetSaveResult? ShowSaveDialog(LibraryPresetSaveContext context)
+        {
+            var dialog = new LibraryPresetSaveDialog(context);
+            if (Application.Current?.MainWindow is Window owner && owner.IsVisible)
+            {
+                dialog.Owner = owner;
+            }
+
+            var ok = dialog.ShowDialog();
+            return ok == true ? new LibraryPresetSaveResult(dialog.ResultName) : null;
+        }
+
+        private static LibraryPresetSelectionResult? ShowSelectionDialog(LibraryPresetSelectionContext context)
+        {
+            if (context.Presets.Count == 0)
+                return null;
+
+            var dialog = new LibraryPresetPickerDialog(context);
+            if (Application.Current?.MainWindow is Window owner && owner.IsVisible)
+            {
+                dialog.Owner = owner;
+            }
+
+            dialog.ShowDialog();
+            var deleted = dialog.DeletedPresetNames;
+            var selected = dialog.SelectedPresetName;
+
+            if (deleted.Count == 0 && string.IsNullOrEmpty(selected))
+                return null;
+
+            return new LibraryPresetSelectionResult(selected, deleted);
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/LibraryPresetSaveDialog.xaml
+++ b/src/LM.App.Wpf/Views/LibraryPresetSaveDialog.xaml
@@ -1,0 +1,51 @@
+<Window x:Class="LM.App.Wpf.Views.LibraryPresetSaveDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Save Library Preset"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        MinWidth="360">
+  <Grid Margin="16">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="8" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="8" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="Auto" />
+      <ColumnDefinition Width="*" />
+    </Grid.ColumnDefinitions>
+
+    <TextBlock Grid.Row="0"
+               Grid.ColumnSpan="2"
+               Text="Name this filter preset." />
+
+    <TextBlock Grid.Row="2"
+               Grid.Column="0"
+               Margin="0,0,8,0"
+               VerticalAlignment="Center"
+               Text="Name:" />
+    <TextBox x:Name="NameBox"
+             Grid.Row="2"
+             Grid.Column="1"
+             MinWidth="220" />
+
+    <StackPanel Grid.Row="4"
+                Grid.ColumnSpan="2"
+                Orientation="Horizontal"
+                HorizontalAlignment="Right">
+      <Button Content="Cancel"
+              Width="80"
+              Margin="0,0,8,0"
+              IsCancel="True"
+              Click="OnCancel" />
+      <Button Content="Save"
+              Width="80"
+              IsDefault="True"
+              Click="OnSave" />
+    </StackPanel>
+  </Grid>
+</Window>

--- a/src/LM.App.Wpf/Views/LibraryPresetSaveDialog.xaml.cs
+++ b/src/LM.App.Wpf/Views/LibraryPresetSaveDialog.xaml.cs
@@ -1,0 +1,42 @@
+#nullable enable
+using System.Windows;
+using LM.App.Wpf.Common;
+
+namespace LM.App.Wpf.Views
+{
+    internal partial class LibraryPresetSaveDialog : Window
+    {
+        public string ResultName { get; private set; } = string.Empty;
+
+        public LibraryPresetSaveDialog(LibraryPresetSaveContext context)
+        {
+            InitializeComponent();
+
+            NameBox.Text = context.DefaultName;
+            Loaded += (_, _) =>
+            {
+                NameBox.Focus();
+                NameBox.SelectAll();
+            };
+        }
+
+        private void OnSave(object sender, RoutedEventArgs e)
+        {
+            var name = NameBox.Text?.Trim();
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                MessageBox.Show(this, "Please provide a name for the preset.", "Save Library Preset", MessageBoxButton.OK, MessageBoxImage.Information);
+                NameBox.Focus();
+                return;
+            }
+
+            ResultName = name;
+            DialogResult = true;
+        }
+
+        private void OnCancel(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -74,8 +74,20 @@
         </ComboBox>
 
         <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
-          <Button Content="Search" Command="{Binding SearchCommand}"/>
-          <Button Content="Clear" Command="{Binding ClearCommand}"/>
+          <Button Content="Search"
+                  Margin="0,0,8,0"
+                  Command="{Binding SearchCommand}"/>
+          <Button Content="Clear"
+                  Margin="0,0,8,0"
+                  Command="{Binding ClearCommand}"/>
+          <Button Content="Save preset"
+                  Margin="0,0,8,0"
+                  Command="{Binding SavePresetCommand}"/>
+          <Button Content="Load preset"
+                  Margin="0,0,8,0"
+                  Command="{Binding LoadPresetCommand}"/>
+          <Button Content="Manage presets"
+                  Command="{Binding ManagePresetsCommand}"/>
         </StackPanel>
       </StackPanel>
     </ScrollViewer>


### PR DESCRIPTION
## Summary
- add a JSON-backed library filter preset store and supporting prompt abstractions
- extend LibraryViewModel and the LibraryView UI with save/load/manage preset commands and dialogs
- cover preset serialization and deserialization with a new unit test

## Testing
- dotnet test KnowledgeWorks_20250820_082416.sln *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd518f10ec832b98172e247c30233f