### PR TITLE
Fix watched folder column width

### DIFF
--- a/src/LM.App.Wpf/App.xaml.cs
+++ b/src/LM.App.Wpf/App.xaml.cs
@@ -25,6 +25,8 @@ namespace LM.App.Wpf
 {
     public partial class App : System.Windows.Application
     {
+        private AddViewModel? _addViewModel;
+
         protected override async void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
@@ -72,7 +74,9 @@ namespace LM.App.Wpf
             var presetStore = new LibraryFilterPresetStore(ws);
             var presetPrompt = new LibraryPresetPrompt();
             var libraryVm = new LibraryViewModel(services.Store, ws, presetStore, presetPrompt);
-            var addVm = new AddViewModel(services.Pipeline);
+            var addVm = new AddViewModel(services.Pipeline, ws, services.Scanner);
+            await addVm.InitializeAsync();
+            _addViewModel = addVm;
             var searchPrompt = new SearchSavePrompt();
             var searchVm = new SearchViewModel(services.Store, services.Storage, ws, searchPrompt);
 
@@ -87,6 +91,12 @@ namespace LM.App.Wpf
             if (shell.FindName("SearchViewControl") is SearchView searchView)
                 searchView.DataContext = searchVm;
 
+        }
+
+        protected override void OnExit(ExitEventArgs e)
+        {
+            _addViewModel?.Dispose();
+            base.OnExit(e);
         }
     }
 }

--- a/src/LM.App.Wpf/Composition/ServiceConfig.cs
+++ b/src/LM.App.Wpf/Composition/ServiceConfig.cs
@@ -34,6 +34,7 @@ namespace LM.App.Wpf.Composition
             public required HookOrchestrator Hooks { get; init; }
             public required ISimilarityLog SimLog { get; init; }
             public required IAddPipeline Pipeline { get; init; }
+            public required WatchedFolderScanner Scanner { get; init; }
         }
 
         /// <summary>
@@ -78,6 +79,8 @@ namespace LM.App.Wpf.Composition
                 pmidNorm,          // <-- insert here
                 simlog);
 
+            var scanner = new WatchedFolderScanner(pipeline);
+
             return new AppServices
             {
                 Workspaces = ws,
@@ -92,7 +95,8 @@ namespace LM.App.Wpf.Composition
                 Store = store,
                 Hooks = orchestrator,
                 SimLog = simlog,
-                Pipeline = pipeline
+                Pipeline = pipeline,
+                Scanner = scanner
             };
         }
     }

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -151,22 +151,53 @@ LM.App.Wpf.ViewModels.AddPipeline.CommitAsync(System.Collections.Generic.IEnumer
 LM.App.Wpf.ViewModels.AddPipeline.StagePathsAsync(System.Collections.Generic.IEnumerable<string!>! paths, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!>!
 LM.App.Wpf.ViewModels.AddViewModel
 LM.App.Wpf.ViewModels.AddViewModel.AddFilesCommand.get -> System.Windows.Input.ICommand!
-LM.App.Wpf.ViewModels.AddViewModel.AddViewModel(LM.App.Wpf.ViewModels.IAddPipeline! pipeline) -> void
+LM.App.Wpf.ViewModels.AddViewModel.AddViewModel(LM.App.Wpf.ViewModels.IAddPipeline! pipeline, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.App.Wpf.ViewModels.WatchedFolderScanner? scanner = null) -> void
 LM.App.Wpf.ViewModels.AddViewModel.AddViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.ISimilarityService! similarity, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IMetadataExtractor! metadata, IPublicationLookup! publicationLookup, LM.Core.Abstractions.IDoiNormalizer! doiNormalizer, LM.HubSpoke.Abstractions.ISimilarityLog? simLog = null) -> void
 LM.App.Wpf.ViewModels.AddViewModel.AddViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.ISimilarityService! similarity, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IMetadataExtractor! metadata, IPublicationLookup! publicationLookup, LM.Core.Abstractions.IDoiNormalizer! doiNormalizer, LM.Infrastructure.Hooks.HookOrchestrator! orchestrator, LM.Core.Abstractions.IPmidNormalizer! pmidNormalizer, LM.HubSpoke.Abstractions.ISimilarityLog? simLog = null) -> void
+LM.App.Wpf.ViewModels.AddViewModel.AddWatchedFolderCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.AddViewModel.BulkAddFolderCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.AddViewModel.ClearCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.AddViewModel.CommitSelectedCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.AddViewModel.Current.get -> LM.App.Wpf.ViewModels.StagingItem?
 LM.App.Wpf.ViewModels.AddViewModel.Current.set -> void
+LM.App.Wpf.ViewModels.AddViewModel.Dispose() -> void
 LM.App.Wpf.ViewModels.AddViewModel.EntryTypes.get -> System.Array!
 LM.App.Wpf.ViewModels.AddViewModel.IndexLabel.get -> string!
+LM.App.Wpf.ViewModels.AddViewModel.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.App.Wpf.ViewModels.AddViewModel.IsBusy.get -> bool
 LM.App.Wpf.ViewModels.AddViewModel.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.App.Wpf.ViewModels.AddViewModel.RemoveWatchedFolderCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.ScanWatchedFolderCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.AddViewModel.SelectByOffset(int delta) -> void
 LM.App.Wpf.ViewModels.AddViewModel.SelectedType.get -> LM.Core.Models.EntryType
 LM.App.Wpf.ViewModels.AddViewModel.SelectedType.set -> void
 LM.App.Wpf.ViewModels.AddViewModel.Staging.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.StagingItem!>!
+LM.App.Wpf.ViewModels.AddViewModel.WatchedFolders.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.WatchedFolder!>!
+LM.App.Wpf.ViewModels.WatchedFolder
+LM.App.Wpf.ViewModels.WatchedFolder.IsEnabled.get -> bool
+LM.App.Wpf.ViewModels.WatchedFolder.IsEnabled.set -> void
+LM.App.Wpf.ViewModels.WatchedFolder.LastScanDisplay.get -> string!
+LM.App.Wpf.ViewModels.WatchedFolder.LastScanUtc.get -> System.DateTimeOffset?
+LM.App.Wpf.ViewModels.WatchedFolder.MarkScanned(System.DateTimeOffset whenUtc) -> void
+LM.App.Wpf.ViewModels.WatchedFolder.Path.get -> string!
+LM.App.Wpf.ViewModels.WatchedFolder.Path.set -> void
+LM.App.Wpf.ViewModels.WatchedFolder.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.App.Wpf.ViewModels.WatchedFolder.WatchedFolder() -> void
+LM.App.Wpf.ViewModels.WatchedFolderConfig
+LM.App.Wpf.ViewModels.WatchedFolderConfig.Folders.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.WatchedFolder!>!
+LM.App.Wpf.ViewModels.WatchedFolderConfig.LoadAsync(string! path, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<LM.App.Wpf.ViewModels.WatchedFolderConfig!>!
+LM.App.Wpf.ViewModels.WatchedFolderConfig.SaveAsync(string! path, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.WatchedFolderConfig.WatchedFolderConfig() -> void
+LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs
+LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs.Folder.get -> LM.App.Wpf.ViewModels.WatchedFolder!
+LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs.Items.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!
+LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs.WatchedFolderScanEventArgs(LM.App.Wpf.ViewModels.WatchedFolder! folder, System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>! items) -> void
+LM.App.Wpf.ViewModels.WatchedFolderScanner
+LM.App.Wpf.ViewModels.WatchedFolderScanner.Attach(LM.App.Wpf.ViewModels.WatchedFolderConfig! config) -> void
+LM.App.Wpf.ViewModels.WatchedFolderScanner.Dispose() -> void
+LM.App.Wpf.ViewModels.WatchedFolderScanner.ItemsStaged -> System.EventHandler<LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs!>?
+LM.App.Wpf.ViewModels.WatchedFolderScanner.ScanAsync(LM.App.Wpf.ViewModels.WatchedFolder? folder, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.WatchedFolderScanner.WatchedFolderScanner(LM.App.Wpf.ViewModels.IAddPipeline! pipeline) -> void
 LM.App.Wpf.ViewModels.IAddPipeline
 LM.App.Wpf.ViewModels.IAddPipeline.CommitAsync(System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.StagingItem!>! selectedRows, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!>!
 LM.App.Wpf.ViewModels.IAddPipeline.StagePathsAsync(System.Collections.Generic.IEnumerable<string!>! paths, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!>!

--- a/src/LM.App.Wpf/ViewModels/Add/WatchedFolder.cs
+++ b/src/LM.App.Wpf/ViewModels/Add/WatchedFolder.cs
@@ -1,0 +1,155 @@
+#nullable enable
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LM.App.Wpf.ViewModels
+{
+    /// <summary>Represents a single watched folder entry.</summary>
+    public sealed class WatchedFolder : INotifyPropertyChanged
+    {
+        private string _path = string.Empty;
+        private bool _isEnabled = true;
+        private DateTimeOffset? _lastScanUtc;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public string Path
+        {
+            get => _path;
+            set => SetProperty(ref _path, value ?? string.Empty);
+        }
+
+        public bool IsEnabled
+        {
+            get => _isEnabled;
+            set => SetProperty(ref _isEnabled, value);
+        }
+
+        [JsonIgnore]
+        public DateTimeOffset? LastScanUtc
+        {
+            get => _lastScanUtc;
+            private set
+            {
+                if (SetProperty(ref _lastScanUtc, value))
+                {
+                    OnPropertyChanged(nameof(LastScanDisplay));
+                }
+            }
+        }
+
+        [JsonIgnore]
+        public string LastScanDisplay => _lastScanUtc is null
+            ? "Never"
+            : _lastScanUtc.Value.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+
+        public void MarkScanned(DateTimeOffset whenUtc)
+        {
+            LastScanUtc = whenUtc;
+        }
+
+        internal WatchedFolder Clone() => new()
+        {
+            Path = Path,
+            IsEnabled = IsEnabled
+        };
+
+        private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (Equals(field, value))
+                return false;
+
+            field = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+    }
+
+    /// <summary>Collection wrapper that can persist watched folders to disk.</summary>
+    public sealed class WatchedFolderConfig
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            WriteIndented = true,
+            AllowTrailingCommas = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public ObservableCollection<WatchedFolder> Folders { get; } = new();
+
+        public static async Task<WatchedFolderConfig> LoadAsync(string path, CancellationToken ct)
+        {
+            var config = new WatchedFolderConfig();
+            if (!File.Exists(path))
+                return config;
+
+            try
+            {
+                await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
+                var snapshot = await JsonSerializer.DeserializeAsync<WatchedFolderConfigSnapshot>(stream, JsonOptions, ct).ConfigureAwait(false);
+                if (snapshot?.Folders is not null)
+                {
+                    foreach (var folder in snapshot.Folders)
+                    {
+                        if (string.IsNullOrWhiteSpace(folder.Path))
+                            continue;
+                        config.Folders.Add(new WatchedFolder
+                        {
+                            Path = folder.Path,
+                            IsEnabled = folder.IsEnabled
+                        });
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // Ignore malformed files – treat as empty config.
+            }
+            return config;
+        }
+
+        public async Task SaveAsync(string path, CancellationToken ct)
+        {
+            var snapshot = new WatchedFolderConfigSnapshot
+            {
+                Folders = Folders.Select(static f => new WatchedFolderSnapshot
+                {
+                    Path = f.Path,
+                    IsEnabled = f.IsEnabled
+                }).ToArray()
+            };
+
+            var directory = System.IO.Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            await using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read, 4096, useAsync: true);
+            await JsonSerializer.SerializeAsync(stream, snapshot, JsonOptions, ct).ConfigureAwait(false);
+        }
+
+        private sealed class WatchedFolderConfigSnapshot
+        {
+            public WatchedFolderSnapshot[]? Folders { get; set; }
+        }
+
+        private sealed class WatchedFolderSnapshot
+        {
+            public string Path { get; set; } = string.Empty;
+            public bool IsEnabled { get; set; } = true;
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Add/WatchedFolderScanner.cs
+++ b/src/LM.App.Wpf/ViewModels/Add/WatchedFolderScanner.cs
@@ -1,0 +1,302 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LM.App.Wpf.ViewModels
+{
+    /// <summary>Watches configured folders and stages updated files through the add pipeline.</summary>
+    public sealed class WatchedFolderScanner : IDisposable
+    {
+        private readonly IAddPipeline _pipeline;
+        private readonly TimeSpan _debounce = TimeSpan.FromSeconds(1.5);
+        private readonly Dictionary<WatchedFolder, FolderSubscription> _subscriptions = new();
+        private readonly object _gate = new();
+        private bool _disposed;
+        private WatchedFolderConfig? _config;
+
+        public WatchedFolderScanner(IAddPipeline pipeline)
+        {
+            _pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        public event EventHandler<WatchedFolderScanEventArgs>? ItemsStaged;
+
+        public void Attach(WatchedFolderConfig config)
+        {
+            if (config is null) throw new ArgumentNullException(nameof(config));
+            lock (_gate)
+            {
+                if (_config is not null)
+                    throw new InvalidOperationException("Scanner already attached.");
+                _config = config;
+            }
+
+            config.Folders.CollectionChanged += OnFoldersChanged;
+            foreach (var folder in config.Folders)
+            {
+                StartTracking(folder);
+            }
+        }
+
+        public async Task ScanAsync(WatchedFolder? folder, CancellationToken ct)
+        {
+            if (folder is null) return;
+            if (string.IsNullOrWhiteSpace(folder.Path)) return;
+            if (!Directory.Exists(folder.Path)) return;
+
+            try
+            {
+                var files = Directory.EnumerateFiles(folder.Path, "*.*", SearchOption.AllDirectories);
+                var staged = await _pipeline.StagePathsAsync(files, ct).ConfigureAwait(false);
+                folder.MarkScanned(DateTimeOffset.UtcNow);
+                if (staged.Count > 0)
+                {
+                    OnItemsStaged(folder, staged);
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[WatchedFolderScanner] Failed to scan '{folder.Path}': {ex}");
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            if (_config is not null)
+            {
+                _config.Folders.CollectionChanged -= OnFoldersChanged;
+                foreach (var folder in _config.Folders)
+                {
+                    folder.PropertyChanged -= OnFolderPropertyChanged;
+                }
+            }
+
+            foreach (var entry in _subscriptions.Values)
+            {
+                entry.Dispose();
+            }
+            _subscriptions.Clear();
+        }
+
+        private void OnFoldersChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.NewItems is not null)
+            {
+                foreach (WatchedFolder folder in e.NewItems)
+                {
+                    StartTracking(folder);
+                }
+            }
+
+            if (e.OldItems is not null)
+            {
+                foreach (WatchedFolder folder in e.OldItems)
+                {
+                    StopTracking(folder);
+                }
+            }
+        }
+
+        private void StartTracking(WatchedFolder folder)
+        {
+            folder.PropertyChanged += OnFolderPropertyChanged;
+            if (folder.IsEnabled)
+            {
+                TryEnable(folder);
+            }
+        }
+
+        private void StopTracking(WatchedFolder folder)
+        {
+            folder.PropertyChanged -= OnFolderPropertyChanged;
+            Disable(folder);
+        }
+
+        private void OnFolderPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (sender is not WatchedFolder folder) return;
+            if (e.PropertyName == nameof(WatchedFolder.IsEnabled))
+            {
+                if (folder.IsEnabled)
+                {
+                    TryEnable(folder);
+                }
+                else
+                {
+                    Disable(folder);
+                }
+            }
+            else if (e.PropertyName == nameof(WatchedFolder.Path))
+            {
+                Disable(folder);
+                if (folder.IsEnabled)
+                {
+                    TryEnable(folder);
+                }
+            }
+        }
+
+        private void TryEnable(WatchedFolder folder)
+        {
+            if (_subscriptions.ContainsKey(folder))
+                return;
+            if (string.IsNullOrWhiteSpace(folder.Path))
+                return;
+            if (!Directory.Exists(folder.Path))
+                return;
+
+            try
+            {
+                var subscription = new FolderSubscription(folder, ProcessPathsAsync, _debounce);
+                _subscriptions[folder] = subscription;
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[WatchedFolderScanner] Failed to watch '{folder.Path}': {ex}");
+            }
+        }
+
+        private void Disable(WatchedFolder folder)
+        {
+            if (_subscriptions.Remove(folder, out var subscription))
+            {
+                subscription.Dispose();
+            }
+        }
+
+        private Task ProcessPathsAsync(WatchedFolder folder, IReadOnlyList<string> paths)
+        {
+            if (paths.Count == 0)
+                return Task.CompletedTask;
+
+            return Task.Run(async () =>
+            {
+                try
+                {
+                    var staged = await _pipeline.StagePathsAsync(paths, CancellationToken.None).ConfigureAwait(false);
+                    folder.MarkScanned(DateTimeOffset.UtcNow);
+                    if (staged.Count > 0)
+                    {
+                        OnItemsStaged(folder, staged);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Trace.WriteLine($"[WatchedFolderScanner] Failed to stage changes for '{folder.Path}': {ex}");
+                }
+            });
+        }
+
+        private void OnItemsStaged(WatchedFolder folder, IReadOnlyList<StagingItem> items)
+        {
+            ItemsStaged?.Invoke(this, new WatchedFolderScanEventArgs(folder, items));
+        }
+
+        private sealed class FolderSubscription : IDisposable
+        {
+            private readonly WatchedFolder _folder;
+            private readonly Func<WatchedFolder, IReadOnlyList<string>, Task> _flush;
+            private readonly TimeSpan _debounce;
+            private readonly object _gate = new();
+            private readonly HashSet<string> _pending = new(StringComparer.OrdinalIgnoreCase);
+            private readonly FileSystemWatcher _watcher;
+            private readonly Timer _timer;
+            private bool _disposed;
+
+            public FolderSubscription(WatchedFolder folder, Func<WatchedFolder, IReadOnlyList<string>, Task> flush, TimeSpan debounce)
+            {
+                _folder = folder;
+                _flush = flush;
+                _debounce = debounce;
+
+                _watcher = new FileSystemWatcher(folder.Path)
+                {
+                    IncludeSubdirectories = true,
+                    NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime
+                };
+                _watcher.Created += OnChanged;
+                _watcher.Changed += OnChanged;
+                _watcher.Renamed += OnRenamed;
+                _watcher.EnableRaisingEvents = true;
+
+                _timer = new Timer(OnTimer, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            }
+
+            public void Dispose()
+            {
+                if (_disposed) return;
+                _disposed = true;
+
+                _watcher.EnableRaisingEvents = false;
+                _watcher.Created -= OnChanged;
+                _watcher.Changed -= OnChanged;
+                _watcher.Renamed -= OnRenamed;
+                _watcher.Dispose();
+
+                lock (_gate)
+                {
+                    _pending.Clear();
+                }
+
+                _timer.Dispose();
+            }
+
+            private void OnChanged(object sender, FileSystemEventArgs e)
+                => QueuePath(e.FullPath);
+
+            private void OnRenamed(object sender, RenamedEventArgs e)
+                => QueuePath(e.FullPath);
+
+            private void QueuePath(string? path)
+            {
+                if (string.IsNullOrWhiteSpace(path))
+                    return;
+                if (!File.Exists(path))
+                    return;
+
+                lock (_gate)
+                {
+                    _pending.Add(path);
+                    _timer.Change(_debounce, Timeout.InfiniteTimeSpan);
+                }
+            }
+
+            private void OnTimer(object? state)
+            {
+                string[] paths;
+                lock (_gate)
+                {
+                    if (_pending.Count == 0)
+                        return;
+                    paths = _pending.ToArray();
+                    _pending.Clear();
+                }
+
+                _ = _flush(_folder, paths);
+            }
+        }
+    }
+
+    public sealed class WatchedFolderScanEventArgs : EventArgs
+    {
+        public WatchedFolderScanEventArgs(WatchedFolder folder, IReadOnlyList<StagingItem> items)
+        {
+            Folder = folder ?? throw new ArgumentNullException(nameof(folder));
+            Items = items ?? throw new ArgumentNullException(nameof(items));
+        }
+
+        public WatchedFolder Folder { get; }
+
+        public IReadOnlyList<StagingItem> Items { get; }
+    }
+}

--- a/src/LM.App.Wpf/Views/AddView.xaml
+++ b/src/LM.App.Wpf/Views/AddView.xaml
@@ -15,9 +15,86 @@
       <Button Content="Clear" Command="{Binding ClearCommand}"/>
     </StackPanel>
 
-	  <!-- Staging grid -->
-	  <DataGrid ItemsSource="{Binding Staging}"
-				SelectedItem="{Binding Current, Mode=TwoWay}"
+    <!-- Watched folders management -->
+    <Border DockPanel.Dock="Top" Margin="12,0,12,12" Padding="12" Background="#FFF8F8F8" CornerRadius="4">
+      <StackPanel>
+        <DockPanel>
+          <TextBlock Text="Watched folders" FontWeight="Bold" FontSize="14" VerticalAlignment="Center"/>
+          <Button Content="Add watched folder..."
+                  Command="{Binding AddWatchedFolderCommand}"
+                  DockPanel.Dock="Right"
+                  HorizontalAlignment="Right"/>
+        </DockPanel>
+
+        <ListView ItemsSource="{Binding WatchedFolders}" Margin="0,8,0,0" BorderThickness="0">
+          <ListView.Style>
+            <Style TargetType="ListView">
+              <Setter Property="Visibility" Value="Visible"/>
+              <Style.Triggers>
+                <DataTrigger Binding="{Binding WatchedFolders.Count}" Value="0">
+                  <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+              </Style.Triggers>
+            </Style>
+          </ListView.Style>
+          <ListView.View>
+            <GridView>
+              <GridViewColumn Width="80" Header="Enabled">
+                <GridViewColumn.CellTemplate>
+                  <DataTemplate>
+                    <CheckBox IsChecked="{Binding IsEnabled, Mode=TwoWay}" HorizontalAlignment="Center"/>
+                  </DataTemplate>
+                </GridViewColumn.CellTemplate>
+              </GridViewColumn>
+              <GridViewColumn Width="320" Header="Folder">
+                <GridViewColumn.DisplayMemberBinding>
+                  <Binding Path="Path"/>
+                </GridViewColumn.DisplayMemberBinding>
+              </GridViewColumn>
+              <GridViewColumn Width="160" Header="Last scan">
+                <GridViewColumn.CellTemplate>
+                  <DataTemplate>
+                    <TextBlock Text="{Binding LastScanDisplay}"/>
+                  </DataTemplate>
+                </GridViewColumn.CellTemplate>
+              </GridViewColumn>
+              <GridViewColumn Width="200">
+                <GridViewColumn.CellTemplate>
+                  <DataTemplate>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                      <Button Content="Scan now"
+                              Command="{Binding DataContext.ScanWatchedFolderCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                              CommandParameter="{Binding}"
+                              Margin="0,0,6,0"/>
+                      <Button Content="Remove"
+                              Command="{Binding DataContext.RemoveWatchedFolderCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                              CommandParameter="{Binding}"/>
+                    </StackPanel>
+                  </DataTemplate>
+                </GridViewColumn.CellTemplate>
+              </GridViewColumn>
+            </GridView>
+          </ListView.View>
+        </ListView>
+
+        <TextBlock Text="No watched folders configured." Foreground="Gray" FontStyle="Italic" HorizontalAlignment="Center" Margin="0,8,0,0">
+          <TextBlock.Style>
+            <Style TargetType="TextBlock">
+              <Setter Property="Visibility" Value="Collapsed"/>
+              <Style.Triggers>
+                <DataTrigger Binding="{Binding WatchedFolders.Count}" Value="0">
+                  <Setter Property="Visibility" Value="Visible"/>
+                </DataTrigger>
+              </Style.Triggers>
+            </Style>
+          </TextBlock.Style>
+        </TextBlock>
+      </StackPanel>
+    </Border>
+
+          <!-- Staging grid -->
+          <DataGrid ItemsSource="{Binding Staging}"
+                                SelectedItem="{Binding Current, Mode=TwoWay}"
                 IsSynchronizedWithCurrentItem="True"
                 Margin="12"
 				IsReadOnly="False"


### PR DESCRIPTION
## Summary
- replace the watched-folder list's star column width with a fixed pixel width so the XAML parser no longer throws a FormatException during load

## Testing
- dotnet build *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd591c7a8c832b88bc658a5b3eeaf1