### PR TITLE
Track watched folder state and expose status

### DIFF
--- a/CombinedPublicAPI.txt
+++ b/CombinedPublicAPI.txt
@@ -2788,14 +2788,28 @@ LM.App.Wpf.ViewModels.WatchedFolder.IsEnabled.get -> bool
 LM.App.Wpf.ViewModels.WatchedFolder.IsEnabled.set -> void
 LM.App.Wpf.ViewModels.WatchedFolder.LastScanDisplay.get -> string!
 LM.App.Wpf.ViewModels.WatchedFolder.LastScanUtc.get -> System.DateTimeOffset?
-LM.App.Wpf.ViewModels.WatchedFolder.MarkScanned(System.DateTimeOffset whenUtc) -> void
+LM.App.Wpf.ViewModels.WatchedFolder.LastScanWasUnchanged.get -> bool?
 LM.App.Wpf.ViewModels.WatchedFolder.Path.get -> string!
 LM.App.Wpf.ViewModels.WatchedFolder.Path.set -> void
 LM.App.Wpf.ViewModels.WatchedFolder.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.App.Wpf.ViewModels.WatchedFolder.ResetScanState() -> void
+LM.App.Wpf.ViewModels.WatchedFolder.ScanStatusLabel.get -> string!
+LM.App.Wpf.ViewModels.WatchedFolder.ScanStatusToolTip.get -> string!
 LM.App.Wpf.ViewModels.WatchedFolder.WatchedFolder() -> void
+LM.App.Wpf.ViewModels.WatchedFolderState
+LM.App.Wpf.ViewModels.WatchedFolderState.AggregatedHash.get -> string?
+LM.App.Wpf.ViewModels.WatchedFolderState.LastScanUtc.get -> System.DateTimeOffset?
+LM.App.Wpf.ViewModels.WatchedFolderState.LastScanWasUnchanged.get -> bool
+LM.App.Wpf.ViewModels.WatchedFolderState.Path.get -> string!
+LM.App.Wpf.ViewModels.WatchedFolderState.WatchedFolderState(string path, System.DateTimeOffset? lastScanUtc, string? aggregatedHash, bool lastScanWasUnchanged) -> void
 LM.App.Wpf.ViewModels.WatchedFolderConfig
+LM.App.Wpf.ViewModels.WatchedFolderConfig.ApplyState(LM.App.Wpf.ViewModels.WatchedFolder folder) -> void
+LM.App.Wpf.ViewModels.WatchedFolderConfig.ClearState(LM.App.Wpf.ViewModels.WatchedFolder folder) -> void
 LM.App.Wpf.ViewModels.WatchedFolderConfig.Folders.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.WatchedFolder!>!
+LM.App.Wpf.ViewModels.WatchedFolderConfig.GetState(string path) -> LM.App.Wpf.ViewModels.WatchedFolderState?
+LM.App.Wpf.ViewModels.WatchedFolderConfig.GetState(LM.App.Wpf.ViewModels.WatchedFolder folder) -> LM.App.Wpf.ViewModels.WatchedFolderState?
 LM.App.Wpf.ViewModels.WatchedFolderConfig.SaveAsync(string! path, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.WatchedFolderConfig.StoreState(LM.App.Wpf.ViewModels.WatchedFolder folder, LM.App.Wpf.ViewModels.WatchedFolderState state) -> void
 LM.App.Wpf.ViewModels.WatchedFolderConfig.WatchedFolderConfig() -> void
 LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs
 LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs.Folder.get -> LM.App.Wpf.ViewModels.WatchedFolder!
@@ -2805,7 +2819,7 @@ LM.App.Wpf.ViewModels.WatchedFolderScanner
 LM.App.Wpf.ViewModels.WatchedFolderScanner.Attach(LM.App.Wpf.ViewModels.WatchedFolderConfig! config) -> void
 LM.App.Wpf.ViewModels.WatchedFolderScanner.Dispose() -> void
 LM.App.Wpf.ViewModels.WatchedFolderScanner.ItemsStaged -> System.EventHandler<LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs!>?
-LM.App.Wpf.ViewModels.WatchedFolderScanner.ScanAsync(LM.App.Wpf.ViewModels.WatchedFolder? folder, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.WatchedFolderScanner.ScanAsync(LM.App.Wpf.ViewModels.WatchedFolder? folder, System.Threading.CancellationToken ct, bool force = false) -> System.Threading.Tasks.Task!
 LM.App.Wpf.ViewModels.WatchedFolderScanner.WatchedFolderScanner(LM.App.Wpf.ViewModels.IAddPipeline! pipeline) -> void
 LM.App.Wpf.ViewModels.IAddPipeline
 LM.App.Wpf.ViewModels.IAddPipeline.CommitAsync(System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.StagingItem!>! selectedRows, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!>!

--- a/src/LM.App.Wpf.Tests/WatchedFolderConfigTests.cs
+++ b/src/LM.App.Wpf.Tests/WatchedFolderConfigTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.App.Wpf.ViewModels;
+using Xunit;
+
+public class WatchedFolderConfigTests
+{
+    [Fact]
+    public async Task SaveAndLoad_PreservesFolderState()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "lm_watched_" + Guid.NewGuid().ToString("N"));
+        var configPath = tempDirectory + ".json";
+
+        Directory.CreateDirectory(tempDirectory);
+        var folderPath = Path.Combine(tempDirectory, "watched");
+        Directory.CreateDirectory(folderPath);
+
+        try
+        {
+            var original = new WatchedFolderConfig();
+            var folder = new WatchedFolder { Path = folderPath, IsEnabled = true };
+            original.Folders.Add(folder);
+
+            var scanTime = DateTimeOffset.UtcNow;
+            var state = new WatchedFolderState(folderPath, scanTime, "HASH", true);
+            original.StoreState(folder, state);
+
+            await original.SaveAsync(configPath, CancellationToken.None);
+
+            var reloaded = await WatchedFolderConfig.LoadAsync(configPath, CancellationToken.None);
+            Assert.Single(reloaded.Folders);
+
+            var reloadedFolder = reloaded.Folders[0];
+            Assert.Equal(folderPath, reloadedFolder.Path);
+            Assert.Equal(scanTime, reloadedFolder.LastScanUtc);
+            Assert.True(reloadedFolder.LastScanWasUnchanged);
+
+            var reloadedState = reloaded.GetState(folderPath);
+            Assert.NotNull(reloadedState);
+            Assert.Equal("HASH", reloadedState!.AggregatedHash);
+            Assert.Equal(scanTime, reloadedState.LastScanUtc);
+            Assert.True(reloadedState.LastScanWasUnchanged);
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(configPath))
+                {
+                    File.Delete(configPath);
+                }
+
+                if (Directory.Exists(tempDirectory))
+                {
+                    Directory.Delete(tempDirectory, recursive: true);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup errors in tests.
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -178,14 +178,28 @@ LM.App.Wpf.ViewModels.WatchedFolder.IsEnabled.get -> bool
 LM.App.Wpf.ViewModels.WatchedFolder.IsEnabled.set -> void
 LM.App.Wpf.ViewModels.WatchedFolder.LastScanDisplay.get -> string!
 LM.App.Wpf.ViewModels.WatchedFolder.LastScanUtc.get -> System.DateTimeOffset?
-LM.App.Wpf.ViewModels.WatchedFolder.MarkScanned(System.DateTimeOffset whenUtc) -> void
+LM.App.Wpf.ViewModels.WatchedFolder.LastScanWasUnchanged.get -> bool?
 LM.App.Wpf.ViewModels.WatchedFolder.Path.get -> string!
 LM.App.Wpf.ViewModels.WatchedFolder.Path.set -> void
 LM.App.Wpf.ViewModels.WatchedFolder.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.App.Wpf.ViewModels.WatchedFolder.ResetScanState() -> void
+LM.App.Wpf.ViewModels.WatchedFolder.ScanStatusLabel.get -> string!
+LM.App.Wpf.ViewModels.WatchedFolder.ScanStatusToolTip.get -> string!
 LM.App.Wpf.ViewModels.WatchedFolder.WatchedFolder() -> void
+LM.App.Wpf.ViewModels.WatchedFolderState
+LM.App.Wpf.ViewModels.WatchedFolderState.AggregatedHash.get -> string?
+LM.App.Wpf.ViewModels.WatchedFolderState.LastScanUtc.get -> System.DateTimeOffset?
+LM.App.Wpf.ViewModels.WatchedFolderState.LastScanWasUnchanged.get -> bool
+LM.App.Wpf.ViewModels.WatchedFolderState.Path.get -> string!
+LM.App.Wpf.ViewModels.WatchedFolderState.WatchedFolderState(string path, System.DateTimeOffset? lastScanUtc, string? aggregatedHash, bool lastScanWasUnchanged) -> void
 LM.App.Wpf.ViewModels.WatchedFolderConfig
+LM.App.Wpf.ViewModels.WatchedFolderConfig.ApplyState(LM.App.Wpf.ViewModels.WatchedFolder folder) -> void
+LM.App.Wpf.ViewModels.WatchedFolderConfig.ClearState(LM.App.Wpf.ViewModels.WatchedFolder folder) -> void
 LM.App.Wpf.ViewModels.WatchedFolderConfig.Folders.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.WatchedFolder!>!
+LM.App.Wpf.ViewModels.WatchedFolderConfig.GetState(string path) -> LM.App.Wpf.ViewModels.WatchedFolderState?
+LM.App.Wpf.ViewModels.WatchedFolderConfig.GetState(LM.App.Wpf.ViewModels.WatchedFolder folder) -> LM.App.Wpf.ViewModels.WatchedFolderState?
 LM.App.Wpf.ViewModels.WatchedFolderConfig.SaveAsync(string! path, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.WatchedFolderConfig.StoreState(LM.App.Wpf.ViewModels.WatchedFolder folder, LM.App.Wpf.ViewModels.WatchedFolderState state) -> void
 LM.App.Wpf.ViewModels.WatchedFolderConfig.WatchedFolderConfig() -> void
 LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs
 LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs.Folder.get -> LM.App.Wpf.ViewModels.WatchedFolder!
@@ -195,7 +209,7 @@ LM.App.Wpf.ViewModels.WatchedFolderScanner
 LM.App.Wpf.ViewModels.WatchedFolderScanner.Attach(LM.App.Wpf.ViewModels.WatchedFolderConfig! config) -> void
 LM.App.Wpf.ViewModels.WatchedFolderScanner.Dispose() -> void
 LM.App.Wpf.ViewModels.WatchedFolderScanner.ItemsStaged -> System.EventHandler<LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs!>?
-LM.App.Wpf.ViewModels.WatchedFolderScanner.ScanAsync(LM.App.Wpf.ViewModels.WatchedFolder? folder, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.WatchedFolderScanner.ScanAsync(LM.App.Wpf.ViewModels.WatchedFolder? folder, System.Threading.CancellationToken ct, bool force = false) -> System.Threading.Tasks.Task!
 LM.App.Wpf.ViewModels.WatchedFolderScanner.WatchedFolderScanner(LM.App.Wpf.ViewModels.IAddPipeline! pipeline) -> void
 LM.App.Wpf.ViewModels.IAddPipeline
 LM.App.Wpf.ViewModels.IAddPipeline.CommitAsync(System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.StagingItem!>! selectedRows, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!>!

--- a/src/LM.App.Wpf/ViewModels/Add/WatchedFolder.cs
+++ b/src/LM.App.Wpf/ViewModels/Add/WatchedFolder.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
@@ -19,13 +20,21 @@ namespace LM.App.Wpf.ViewModels
         private string _path = string.Empty;
         private bool _isEnabled = true;
         private DateTimeOffset? _lastScanUtc;
+        private bool? _lastScanWasUnchanged;
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
         public string Path
         {
             get => _path;
-            set => SetProperty(ref _path, value ?? string.Empty);
+            set
+            {
+                var normalized = value ?? string.Empty;
+                if (SetProperty(ref _path, normalized))
+                {
+                    ResetScanState();
+                }
+            }
         }
 
         public bool IsEnabled
@@ -52,16 +61,69 @@ namespace LM.App.Wpf.ViewModels
             ? "Never"
             : _lastScanUtc.Value.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
 
-        public void MarkScanned(DateTimeOffset whenUtc)
+        [JsonIgnore]
+        public bool? LastScanWasUnchanged
         {
-            LastScanUtc = whenUtc;
+            get => _lastScanWasUnchanged;
+            private set
+            {
+                if (SetProperty(ref _lastScanWasUnchanged, value))
+                {
+                    OnPropertyChanged(nameof(ScanStatusLabel));
+                    OnPropertyChanged(nameof(ScanStatusToolTip));
+                }
+            }
         }
 
-        internal WatchedFolder Clone() => new()
+        [JsonIgnore]
+        public string ScanStatusLabel => _lastScanWasUnchanged switch
         {
-            Path = Path,
-            IsEnabled = IsEnabled
+            true => "Unchanged",
+            false => "Changed",
+            _ => "Not scanned"
         };
+
+        [JsonIgnore]
+        public string ScanStatusToolTip => _lastScanWasUnchanged switch
+        {
+            true => "The last scan found no new or modified files.",
+            false => "The last scan detected new or modified files.",
+            _ => "This folder has not been scanned yet."
+        };
+
+        internal void ApplyState(WatchedFolderState? state)
+        {
+            if (state is null)
+            {
+                ResetScanState();
+                return;
+            }
+
+            LastScanUtc = state.LastScanUtc;
+            LastScanWasUnchanged = state.LastScanWasUnchanged;
+        }
+
+        public void ResetScanState()
+        {
+            LastScanUtc = null;
+            LastScanWasUnchanged = null;
+        }
+
+        internal WatchedFolder Clone()
+        {
+            var clone = new WatchedFolder
+            {
+                Path = Path,
+                IsEnabled = IsEnabled
+            };
+
+            if (LastScanUtc is not null)
+            {
+                clone.ApplyState(new WatchedFolderState(Path, LastScanUtc, null, LastScanWasUnchanged ?? false));
+            }
+
+            return clone;
+        }
 
         private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -89,6 +151,10 @@ namespace LM.App.Wpf.ViewModels
 
         public ObservableCollection<WatchedFolder> Folders { get; } = new();
 
+        private readonly Dictionary<string, WatchedFolderState> _states = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<WatchedFolder, string> _stateKeys = new();
+        private readonly object _stateGate = new();
+
         public static async Task<WatchedFolderConfig> LoadAsync(string path, CancellationToken ct)
         {
             var config = new WatchedFolderConfig();
@@ -99,17 +165,35 @@ namespace LM.App.Wpf.ViewModels
             {
                 await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
                 var snapshot = await JsonSerializer.DeserializeAsync<WatchedFolderConfigSnapshot>(stream, JsonOptions, ct).ConfigureAwait(false);
+                if (snapshot?.States is not null)
+                {
+                    foreach (var state in snapshot.States)
+                    {
+                        if (string.IsNullOrWhiteSpace(state.Path))
+                            continue;
+
+                        config.StoreStateInternal(new WatchedFolderState(state.Path,
+                                                                         state.LastScanUtc,
+                                                                         state.AggregatedHash,
+                                                                         state.LastScanWasUnchanged));
+                    }
+                }
+
                 if (snapshot?.Folders is not null)
                 {
                     foreach (var folder in snapshot.Folders)
                     {
                         if (string.IsNullOrWhiteSpace(folder.Path))
                             continue;
-                        config.Folders.Add(new WatchedFolder
+
+                        var watched = new WatchedFolder
                         {
                             Path = folder.Path,
                             IsEnabled = folder.IsEnabled
-                        });
+                        };
+
+                        config.Folders.Add(watched);
+                        config.ApplyState(watched);
                     }
                 }
             }
@@ -122,13 +206,42 @@ namespace LM.App.Wpf.ViewModels
 
         public async Task SaveAsync(string path, CancellationToken ct)
         {
-            var snapshot = new WatchedFolderConfigSnapshot
+            WatchedFolderSnapshot[] folders;
+            WatchedFolderStateSnapshot[]? states;
+
+            lock (_stateGate)
             {
-                Folders = Folders.Select(static f => new WatchedFolderSnapshot
+                folders = Folders.Select(static f => new WatchedFolderSnapshot
                 {
                     Path = f.Path,
                     IsEnabled = f.IsEnabled
-                }).ToArray()
+                }).ToArray();
+
+                var stateList = new List<WatchedFolderStateSnapshot>();
+                foreach (var folder in Folders)
+                {
+                    if (!_stateKeys.TryGetValue(folder, out var key))
+                        key = NormalizePath(folder.Path);
+
+                    if (_states.TryGetValue(key, out var state))
+                    {
+                        stateList.Add(new WatchedFolderStateSnapshot
+                        {
+                            Path = folder.Path,
+                            LastScanUtc = state.LastScanUtc,
+                            AggregatedHash = state.AggregatedHash,
+                            LastScanWasUnchanged = state.LastScanWasUnchanged
+                        });
+                    }
+                }
+
+                states = stateList.Count == 0 ? null : stateList.ToArray();
+            }
+
+            var snapshot = new WatchedFolderConfigSnapshot
+            {
+                Folders = folders,
+                States = states
             };
 
             var directory = System.IO.Path.GetDirectoryName(path);
@@ -141,15 +254,132 @@ namespace LM.App.Wpf.ViewModels
             await JsonSerializer.SerializeAsync(stream, snapshot, JsonOptions, ct).ConfigureAwait(false);
         }
 
+        public WatchedFolderState? GetState(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return null;
+
+            var key = NormalizePath(path);
+            lock (_stateGate)
+            {
+                return _states.TryGetValue(key, out var state) ? state : null;
+            }
+        }
+
+        public WatchedFolderState? GetState(WatchedFolder folder)
+        {
+            if (folder is null) throw new ArgumentNullException(nameof(folder));
+
+            lock (_stateGate)
+            {
+                if (_stateKeys.TryGetValue(folder, out var key) && _states.TryGetValue(key, out var state))
+                    return state;
+
+                var fallback = NormalizePath(folder.Path);
+                return _states.TryGetValue(fallback, out var fallbackState) ? fallbackState : null;
+            }
+        }
+
+        public void StoreState(WatchedFolder folder, WatchedFolderState state)
+        {
+            if (folder is null) throw new ArgumentNullException(nameof(folder));
+
+            var normalized = NormalizePath(folder.Path);
+            lock (_stateGate)
+            {
+                _states[normalized] = state with { Path = folder.Path };
+                _stateKeys[folder] = normalized;
+            }
+
+            folder.ApplyState(state with { Path = folder.Path });
+        }
+
+        public void ApplyState(WatchedFolder folder)
+        {
+            if (folder is null) throw new ArgumentNullException(nameof(folder));
+
+            WatchedFolderState? state = null;
+            var key = NormalizePath(folder.Path);
+            lock (_stateGate)
+            {
+                if (_states.TryGetValue(key, out var stored))
+                {
+                    state = stored;
+                    _stateKeys[folder] = key;
+                }
+                else
+                {
+                    _stateKeys.Remove(folder);
+                }
+            }
+
+            folder.ApplyState(state);
+        }
+
+        public void ClearState(WatchedFolder folder)
+        {
+            if (folder is null) throw new ArgumentNullException(nameof(folder));
+
+            lock (_stateGate)
+            {
+                if (_stateKeys.TryGetValue(folder, out var key))
+                {
+                    _stateKeys.Remove(folder);
+                    _states.Remove(key);
+                }
+                else
+                {
+                    var normalized = NormalizePath(folder.Path);
+                    _states.Remove(normalized);
+                }
+            }
+
+            folder.ResetScanState();
+        }
+
+        private void StoreStateInternal(WatchedFolderState state)
+        {
+            var key = NormalizePath(state.Path);
+            lock (_stateGate)
+            {
+                _states[key] = state;
+            }
+        }
+
+        private static string NormalizePath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return string.Empty;
+
+            try
+            {
+                var full = System.IO.Path.GetFullPath(path);
+                return full.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar);
+            }
+            catch
+            {
+                return path.Trim();
+            }
+        }
+
         private sealed class WatchedFolderConfigSnapshot
         {
             public WatchedFolderSnapshot[]? Folders { get; set; }
+            public WatchedFolderStateSnapshot[]? States { get; set; }
         }
 
         private sealed class WatchedFolderSnapshot
         {
             public string Path { get; set; } = string.Empty;
             public bool IsEnabled { get; set; } = true;
+        }
+
+        private sealed class WatchedFolderStateSnapshot
+        {
+            public string Path { get; set; } = string.Empty;
+            public DateTimeOffset? LastScanUtc { get; set; }
+            public string? AggregatedHash { get; set; }
+            public bool LastScanWasUnchanged { get; set; }
         }
     }
 }

--- a/src/LM.App.Wpf/ViewModels/Add/WatchedFolderState.cs
+++ b/src/LM.App.Wpf/ViewModels/Add/WatchedFolderState.cs
@@ -1,0 +1,11 @@
+#nullable enable
+using System;
+
+namespace LM.App.Wpf.ViewModels
+{
+    /// <summary>Represents persisted state for a watched folder scan.</summary>
+    public sealed record class WatchedFolderState(string Path,
+                                                  DateTimeOffset? LastScanUtc,
+                                                  string? AggregatedHash,
+                                                  bool LastScanWasUnchanged);
+}

--- a/src/LM.App.Wpf/Views/AddView.xaml
+++ b/src/LM.App.Wpf/Views/AddView.xaml
@@ -60,6 +60,39 @@
                   </DataTemplate>
                 </GridViewColumn.CellTemplate>
               </GridViewColumn>
+              <GridViewColumn Width="140" Header="Status">
+                <GridViewColumn.CellTemplate>
+                  <DataTemplate>
+                    <Border Padding="4,2"
+                            CornerRadius="4"
+                            BorderThickness="1"
+                            ToolTip="{Binding ScanStatusToolTip}">
+                      <Border.Style>
+                        <Style TargetType="Border">
+                          <Setter Property="Background" Value="#FFEDEDED"/>
+                          <Setter Property="BorderBrush" Value="#FFBDBDBD"/>
+                          <Setter Property="HorizontalAlignment" Value="Center"/>
+                          <Style.Triggers>
+                            <DataTrigger Binding="{Binding LastScanWasUnchanged}" Value="True">
+                              <Setter Property="Background" Value="#FFE6F4EA"/>
+                              <Setter Property="BorderBrush" Value="#FF4CAF50"/>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding LastScanWasUnchanged}" Value="False">
+                              <Setter Property="Background" Value="#FFFDECEA"/>
+                              <Setter Property="BorderBrush" Value="#FFF44336"/>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding LastScanWasUnchanged}" Value="{x:Null}">
+                              <Setter Property="Background" Value="#FFEDEDED"/>
+                              <Setter Property="BorderBrush" Value="#FFBDBDBD"/>
+                            </DataTrigger>
+                          </Style.Triggers>
+                        </Style>
+                      </Border.Style>
+                      <TextBlock Text="{Binding ScanStatusLabel}" HorizontalAlignment="Center" Margin="4,0"/>
+                    </Border>
+                  </DataTemplate>
+                </GridViewColumn.CellTemplate>
+              </GridViewColumn>
               <GridViewColumn Width="200">
                 <GridViewColumn.CellTemplate>
                   <DataTemplate>


### PR DESCRIPTION
## Summary
- persist watched folder scan metadata and aggregated hashes alongside the watched folder configuration
- update the watched folder scanner to compare directory hashes, skip unchanged scans by default, and refresh the stored state after runs (including forced scans)
- surface scan status in the Add view/view model with UI badges and add coverage for config state persistence

## Testing
- dotnet test src/LM.App.Wpf.Tests/LM.App.Wpf.Tests.csproj *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6a2dddf8832bba92c8ac6d9575c9