### PR TITLE
Add scan-all command for watched folders and speed up staging search

### DIFF
--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -168,6 +168,7 @@ LM.App.Wpf.ViewModels.AddViewModel.IsBusy.get -> bool
 LM.App.Wpf.ViewModels.AddViewModel.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
 LM.App.Wpf.ViewModels.AddViewModel.RemoveWatchedFolderCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.AddViewModel.ScanWatchedFolderCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.ScanAllWatchedFoldersCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.AddViewModel.SelectByOffset(int delta) -> void
 LM.App.Wpf.ViewModels.AddViewModel.SelectedType.get -> LM.Core.Models.EntryType
 LM.App.Wpf.ViewModels.AddViewModel.SelectedType.set -> void

--- a/src/LM.App.Wpf/Views/AddView.xaml
+++ b/src/LM.App.Wpf/Views/AddView.xaml
@@ -20,10 +20,13 @@
       <StackPanel>
         <DockPanel>
           <TextBlock Text="Watched folders" FontWeight="Bold" FontSize="14" VerticalAlignment="Center"/>
-          <Button Content="Add watched folder..."
-                  Command="{Binding AddWatchedFolderCommand}"
-                  DockPanel.Dock="Right"
-                  HorizontalAlignment="Right"/>
+          <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+            <Button Content="Scan all"
+                    Command="{Binding ScanAllWatchedFoldersCommand}"
+                    Margin="0,0,8,0"/>
+            <Button Content="Add watched folder..."
+                    Command="{Binding AddWatchedFolderCommand}"/>
+          </StackPanel>
         </DockPanel>
 
         <ListView ItemsSource="{Binding WatchedFolders}" Margin="0,8,0,0" BorderThickness="0">


### PR DESCRIPTION
## Summary
- add a Scan all command and button to the Add view to scan every enabled watched folder
- stop forcing manual scans and update command availability as folders change
- reduce staging similarity searches by seeding comparisons from metadata-based candidates before falling back to a full scan

## Testing
- `dotnet test KnowledgeWorks_20250820_082416.sln` *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd70b75f3c832ba4f4c397e68829bf