### PR TITLE
Annotate watched folder API nullability

### DIFF
--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -191,15 +191,15 @@ LM.App.Wpf.ViewModels.WatchedFolderState.AggregatedHash.get -> string?
 LM.App.Wpf.ViewModels.WatchedFolderState.LastScanUtc.get -> System.DateTimeOffset?
 LM.App.Wpf.ViewModels.WatchedFolderState.LastScanWasUnchanged.get -> bool
 LM.App.Wpf.ViewModels.WatchedFolderState.Path.get -> string!
-LM.App.Wpf.ViewModels.WatchedFolderState.WatchedFolderState(string path, System.DateTimeOffset? lastScanUtc, string? aggregatedHash, bool lastScanWasUnchanged) -> void
+LM.App.Wpf.ViewModels.WatchedFolderState.WatchedFolderState(string! path, System.DateTimeOffset? lastScanUtc, string? aggregatedHash, bool lastScanWasUnchanged) -> void
 LM.App.Wpf.ViewModels.WatchedFolderConfig
-LM.App.Wpf.ViewModels.WatchedFolderConfig.ApplyState(LM.App.Wpf.ViewModels.WatchedFolder folder) -> void
-LM.App.Wpf.ViewModels.WatchedFolderConfig.ClearState(LM.App.Wpf.ViewModels.WatchedFolder folder) -> void
+LM.App.Wpf.ViewModels.WatchedFolderConfig.ApplyState(LM.App.Wpf.ViewModels.WatchedFolder! folder) -> void
+LM.App.Wpf.ViewModels.WatchedFolderConfig.ClearState(LM.App.Wpf.ViewModels.WatchedFolder! folder) -> void
 LM.App.Wpf.ViewModels.WatchedFolderConfig.Folders.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.WatchedFolder!>!
-LM.App.Wpf.ViewModels.WatchedFolderConfig.GetState(string path) -> LM.App.Wpf.ViewModels.WatchedFolderState?
-LM.App.Wpf.ViewModels.WatchedFolderConfig.GetState(LM.App.Wpf.ViewModels.WatchedFolder folder) -> LM.App.Wpf.ViewModels.WatchedFolderState?
+LM.App.Wpf.ViewModels.WatchedFolderConfig.GetState(string? path) -> LM.App.Wpf.ViewModels.WatchedFolderState?
+LM.App.Wpf.ViewModels.WatchedFolderConfig.GetState(LM.App.Wpf.ViewModels.WatchedFolder! folder) -> LM.App.Wpf.ViewModels.WatchedFolderState?
 LM.App.Wpf.ViewModels.WatchedFolderConfig.SaveAsync(string! path, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
-LM.App.Wpf.ViewModels.WatchedFolderConfig.StoreState(LM.App.Wpf.ViewModels.WatchedFolder folder, LM.App.Wpf.ViewModels.WatchedFolderState state) -> void
+LM.App.Wpf.ViewModels.WatchedFolderConfig.StoreState(LM.App.Wpf.ViewModels.WatchedFolder! folder, LM.App.Wpf.ViewModels.WatchedFolderState! state) -> void
 LM.App.Wpf.ViewModels.WatchedFolderConfig.WatchedFolderConfig() -> void
 LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs
 LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs.Folder.get -> LM.App.Wpf.ViewModels.WatchedFolder!

--- a/src/LM.App.Wpf/ViewModels/Add/WatchedFolder.cs
+++ b/src/LM.App.Wpf/ViewModels/Add/WatchedFolder.cs
@@ -254,7 +254,7 @@ namespace LM.App.Wpf.ViewModels
             await JsonSerializer.SerializeAsync(stream, snapshot, JsonOptions, ct).ConfigureAwait(false);
         }
 
-        public WatchedFolderState? GetState(string path)
+        public WatchedFolderState? GetState(string? path)
         {
             if (string.IsNullOrWhiteSpace(path))
                 return null;
@@ -283,6 +283,7 @@ namespace LM.App.Wpf.ViewModels
         public void StoreState(WatchedFolder folder, WatchedFolderState state)
         {
             if (folder is null) throw new ArgumentNullException(nameof(folder));
+            if (state is null) throw new ArgumentNullException(nameof(state));
 
             var normalized = NormalizePath(folder.Path);
             lock (_stateGate)


### PR DESCRIPTION
## Summary
- update watched folder public API entries to include explicit nullability annotations
- allow null folder paths when querying state and guard against null state arguments in the configuration helper

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd74597fd8832b955612a643e0508b