### PR TITLE
Document visual extractor feature architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ Run:
 ```powershell
 dotnet run --project src\LM.App.Wpf\LM.App.Wpf.csproj -c Debug
 ```
+
+## Feature documentation
+
+- Visual/Data Extraction feature specifications live under [`docs/visual-extractor/`](docs/visual-extractor/). Start with the [overview](docs/visual-extractor/README.md) for architecture, service contracts, UI flows, storage, and add-in integration guidance.

--- a/docs/visual-extractor/README.md
+++ b/docs/visual-extractor/README.md
@@ -1,0 +1,28 @@
+# Visual Extraction Feature Overview
+
+The Visual/Data Extraction feature lets researchers capture high-signal slices from rich documents and wire them into KnowledgeWorks' local-first knowledge graph.
+It provides an ergonomic front-end for selecting regions, annotating context, exporting cropped imagery plus searchable text, and propagating the captured slice into indexes, workspace storage, and Office surfaces.
+
+## Purpose
+- Give WPF operators a dedicated surface (`ExtractWindow`) to triage slides, PDFs, and screenshots alongside their original entries.
+- Preserve the provenance of each extracted region so downstream spokes (e.g., lit search, review surfaces) can cite the original file and coordinates.
+- Enable multi-step workflows that stay offline-first by leaning on existing local services (`WorkspaceLayout`, SQLite FTS, background job runners).
+
+## Core Capabilities
+- **Region capture pipeline** – selection UX drives an `IRegionExporter` implementation that outputs raster crops, OCR text, and semantic tags.
+- **Index propagation** – exported slices are normalized into hub `EntryHub` hooks, queued for `HubSpokeStore` ingestion, and re-indexed via `SpokeIndexContribution` contracts.
+- **Contextual annotations** – optional notes and linkage to `Review` modules are persisted with the region metadata record.
+- **Office add-in bridge** – ships a trimmed set of commands for the Office add-in slice so users can pull extractions into slide decks without leaving their document.
+
+## Offline Constraints
+- All extraction, OCR, and packaging services MUST run locally; any ML/OCR dependencies must be redistributed as part of the desktop installer.
+- The pipeline never transmits content off-device. Logging omits document payloads and only stores hashed identifiers plus user actions.
+- Background jobs rely on the existing scheduler primitives; introduce no new always-on services or cloud callbacks.
+
+## Navigation
+- [System architecture](architecture.md)
+- [Service contracts](service-contracts.md)
+- [UI workflow](ui-workflow.md)
+- [Data storage model](data-storage.md)
+- [Office add-in slice](office-addin.md)
+- [MVP checklist](checklist.md)

--- a/docs/visual-extractor/architecture.md
+++ b/docs/visual-extractor/architecture.md
@@ -1,0 +1,25 @@
+# Architecture
+
+_Back to [overview](README.md)_ • [Contracts](service-contracts.md) • [UI](ui-workflow.md) • [Storage](data-storage.md) • [Office add-in](office-addin.md)
+
+## High-level layout
+- **Presentation tier**: `ExtractWindow` (WPF) hosts the region canvas, metadata sidebar, and exporter progress rail. It binds to `ExtractWindowViewModel`, which orchestrates selection state, preview rendering, and command routing.
+- **Application services**: `VisualExtractionCoordinator` mediates between UI interactions and backend services, injecting `IRegionExporter`, `IImageCache`, `IHubQueue`, and the `IClock` for repeatable timestamps.
+- **Infrastructure**: Exporters serialize payloads to `WorkspaceLayout.ExtractionRoot(...)`, trigger SQLite index updates through `HubSpokeStore`, and push metadata into `EntryHub.DataExtraction` hooks for downstream spokes.
+
+## Data flow
+1. User selects a region in the viewport, generating a `RegionSelection` model with bounding boxes, zoom level, and annotations.
+2. `VisualExtractionCoordinator` issues an `ExportRegionCommand` to the configured `IRegionExporter` implementation (e.g., `PptRegionExporter`, `PdfRegionExporter`).
+3. Exporter writes:
+   - Cropped bitmap (PNG/JPEG) with deterministic filename keyed by SHA-256 of the source file + coordinates.
+   - OCR text + metadata JSON capturing provenance, tags, and `EntryHubId`.
+   - Optional rich data (vector markup, color palette) for Office add-in experiences.
+4. Completion is reported to the coordinator, which updates the UI state, enqueues a `SpokeIndexContribution` for re-indexing, and raises telemetry events (local only).
+
+## Background jobs
+- Batch extraction jobs can be queued through the existing `IBackgroundJobDispatcher`; each job references a persisted `RegionExtractionRequest` row.
+- Failed exports rehydrate into the UI by reading `extraction/*.json` descriptors and highlighting incomplete steps.
+
+## Extensibility
+- Additional exporters implement `IRegionExporter` and register via DI; the coordinator resolves them based on the `EntryHub.Primary` MIME type.
+- Hooks for plugins: `IExtractionPostProcessor` contracts can decorate exported assets (e.g., run ML tagging) provided they respect offline execution constraints.

--- a/docs/visual-extractor/checklist.md
+++ b/docs/visual-extractor/checklist.md
@@ -1,0 +1,33 @@
+# MVP Checklist
+
+_Back to [overview](README.md)_ • [Architecture](architecture.md) • [Contracts](service-contracts.md) • [UI](ui-workflow.md) • [Storage](data-storage.md)
+
+## ✅ UI wiring (`ExtractWindow`)
+- [ ] `ExtractWindow` launched from library context menu and shortcut; passes `EntryHubId` into `ExtractWindowViewModel`.
+- [ ] Region selection tools (rectangle + lasso) implemented in `RegionCanvasControl`; keyboard shortcuts documented in in-app help.
+- [ ] Export rail binds to observable collection of `RegionExportItemViewModel` with progress + retry support.
+- Acceptance: manual smoke test can select a region, enter metadata, and trigger a no-op exporter without crashing.
+
+## ✅ Exporter implementation (`IRegionExporter`)
+- [ ] Default `CompositeRegionExporter` wires PDF + PPTX support by delegating to `PdfRegionExporter` and `PptRegionExporter`.
+- [ ] Exports emit PNG + OCR text into `WorkspaceLayout.ExtractionRoot(...)` using deterministic region hash filenames.
+- [ ] Errors bubble through `RegionExportFailed` with sanitized message and diagnostic correlation ID.
+- Acceptance: running exporter against sample PDF generates descriptor JSON and assets; rerunning with same region is idempotent.
+
+## ✅ Index creation (`HubSpokeStore`, SQLite)
+- [ ] `region_descriptor` schema created via workspace migration; includes FTS table as in [data storage](data-storage.md).
+- [ ] `HubSpokeStore` ingests new descriptors and publishes `SpokeIndexContribution` with OCR text + tags.
+- [ ] Search UI surfaces extracted regions when querying by OCR text.
+- Acceptance: integration test seeds descriptors and verifies FTS query returns expected `EntryHubId` references.
+
+## ✅ Office add-in slice
+- [ ] `ExtractorAddInShim` registers ribbon buttons (insert, browse, refresh) and communicates over named pipes.
+- [ ] "Insert latest extraction" command pulls most recent `RegionDescriptor` and pastes slide-friendly layout into PowerPoint.
+- [ ] Add-in handles offline state gracefully (status badge + retry) without blocking host UI.
+- Acceptance: manual test inserts extraction into offline PowerPoint session with KnowledgeWorks running.
+
+## ✅ Testing & QA
+- [ ] Unit tests cover `VisualExtractionCoordinator`, `CompositeRegionExporter`, and `IExtractionRepository` migration logic.
+- [ ] UI automation scenario verifies selection + export happy path using `ExtractWindow` test harness.
+- [ ] Add-in integration test stubs Office host and validates named pipe payload contract.
+- Acceptance: CI job `dotnet test` passes with new suites; offline smoke script exercises exporter + add-in handshake.

--- a/docs/visual-extractor/data-storage.md
+++ b/docs/visual-extractor/data-storage.md
@@ -1,0 +1,48 @@
+# Data Storage
+
+_Back to [overview](README.md)_ • [Architecture](architecture.md) • [Contracts](service-contracts.md) • [UI](ui-workflow.md)
+
+## Filesystem layout
+```
+%WORKSPACE%/
+  extraction/
+    aa/bb/<region-hash>.json      # Region descriptor (see schema below)
+    aa/bb/<region-hash>.png       # Cropped image
+    aa/bb/<region-hash>.txt       # OCR text (UTF-8)
+    aa/bb/<region-hash>.ppmx      # Optional Office-friendly package
+```
+- `aa/bb/` path segments are derived from the first four hex characters of the region hash (SHA-256 of source SHA + coordinates).
+- JSON descriptor includes references back to the source entry, original page, selection bounds, tags, and exporter metadata.
+- Assets are stored alongside doc-specific subfolders when per-document grouping is enabled (`UsePerEntryFolders`).
+
+## SQLite schema
+Region descriptors are indexed in the local SQLite database alongside other KnowledgeWorks entities. Add the following tables:
+
+```sql
+CREATE TABLE IF NOT EXISTS region_descriptor (
+    region_hash TEXT PRIMARY KEY,
+    entry_hub_id TEXT NOT NULL,
+    source_rel_path TEXT NOT NULL,
+    page_number INTEGER,
+    bounds TEXT NOT NULL,          -- JSON array [x, y, width, height]
+    ocr_text TEXT,
+    tags TEXT,
+    notes TEXT,
+    created_utc TEXT NOT NULL,
+    last_export_status TEXT NOT NULL,
+    office_package_path TEXT,
+    extra_metadata TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_region_descriptor_entry ON region_descriptor(entry_hub_id);
+CREATE VIRTUAL TABLE IF NOT EXISTS region_descriptor_fts USING fts5(region_hash, ocr_text, content='region_descriptor', content_rowid='rowid');
+```
+
+- `RegionDescriptor` records map to this table. Repository methods ensure `region_descriptor_fts` stays synchronized (trigger-based or manual refresh).
+- `source_rel_path` uses the same relative path semantics as `EntryHub.Primary.RelPath`.
+- Use `HubSpokeStore` migrations to create the schema during workspace initialization.
+
+## Retention & cleanup
+- Default retention: keep all extraction assets until the parent entry is removed. Deleting an entry triggers a cascading cleanup routine.
+- Provide a "Compact extraction storage" command that purges orphaned descriptors and prunes failed exports older than 14 days.
+- Background cleanup jobs run during idle windows only and respect offline disk quotas.

--- a/docs/visual-extractor/office-addin.md
+++ b/docs/visual-extractor/office-addin.md
@@ -1,0 +1,26 @@
+# Office Add-in Slice
+
+_Back to [overview](README.md)_ • [Architecture](architecture.md) • [Contracts](service-contracts.md) • [UI](ui-workflow.md)
+
+## Goals
+- Provide a minimal ribbon for PowerPoint/Word that fetches recent region extractions without round-tripping through cloud services.
+- Allow insertion of cropped imagery + citations into the active document, preserving attribution back to the KnowledgeWorks entry.
+- Keep the add-in deployable via the existing offline installer bundle.
+
+## Add-in architecture
+- **Host shim**: `ExtractorAddInShim` is a thin .NET component loaded by Office; it communicates with the WPF app over named pipes (`ExtractorPipeServer`).
+- **Commands**:
+  - "Insert latest extraction" – pulls the most recent `RegionDescriptor` for the active workspace user.
+  - "Browse workspace" – opens a lightweight webview listing extraction history, powered by the same `IExtractionRepository` APIs.
+  - "Refresh connection" – re-establishes the pipe if the desktop app restarted.
+- **Data contract**: `OfficeInsertionPayload` includes image bytes, OCR summary, citation string, and deep link back to KnowledgeWorks.
+
+## Offline considerations
+- The add-in never makes HTTP requests; all communication stays on localhost pipes secured with mutual authentication tokens.
+- Bundled assets (icons, manifests) are embedded so the installer can register the add-in without internet access.
+- Telemetry events queue locally and piggyback on the desktop app's diagnostics flush when the user exports logs manually.
+
+## Deployment
+- Update the installer script to drop the manifest into `%ProgramFiles%\KnowledgeWorks\OfficeAddin\` and register with `reg add` commands executed with admin privileges.
+- Provide MSI transform samples for enterprise deployment referencing the same manifest location.
+- Document manual fallback installation steps in the IT admin guide.

--- a/docs/visual-extractor/service-contracts.md
+++ b/docs/visual-extractor/service-contracts.md
@@ -1,0 +1,22 @@
+# Service Contracts
+
+_Back to [overview](README.md)_ • [Architecture](architecture.md) • [UI](ui-workflow.md) • [Storage](data-storage.md)
+
+## Core interfaces
+| Contract | Responsibilities | Notes |
+| --- | --- | --- |
+| `IRegionExporter` | Accepts `RegionSelection` + source `EntryHub` and emits a `RegionExportResult` (paths, OCR text, checksum). | Implementations must be pure and cancellable; all heavy IO occurs off the UI thread. |
+| `IRegionPreviewService` | Produces lightweight preview bitmaps for quick redraws and thumbnail lists. | Can cache to `%LocalAppData%/KnowledgeWorks/cache/extractor` but must auto-evict when offline disk quotas are hit. |
+| `IExtractionRepository` | Persists region descriptors (`RegionDescriptor` records) and exposes query APIs for UI history + Office add-in lookups. | Backed by SQLite; ensures idempotent upsert keyed by `(EntryHubId, RegionHash)`. |
+| `IHubQueue` | Existing hub ingestion queue used to push `SpokeIndexContribution` jobs. | Visual extractor adds a `Extraction` job type with throttled concurrency. |
+| `IExtractionPostProcessor` (optional) | Chainable hooks invoked after export completes. | Used for ML tagging, color palette detection, etc.; must complete within 2s or run via background job. |
+
+## Commands & events
+- `ExportRegionCommand` (UI → services) contains: region geometry, annotation text, tags, requested exporters, and add-in destinations.
+- `RegionExportCompleted` event surfaces to the UI and to `HubSpokeStore`. Carries references to stored assets plus telemetry metadata (duration, exporter kind).
+- `RegionExportFailed` event includes sanitized exception info; the UI will display actionable hints and log to local diagnostic files.
+
+## Dependency injection
+- Register services in `LM.App.Wpf` composition root using scoped lifetimes per window instance.
+- Exporters may depend on `IContentExtractor`, `IPdfRenderer`, or other infrastructure packages already shipped with KnowledgeWorks.
+- Each contract must have a mock/stub registered in test projects (`LM.App.Wpf.Tests`, `LM.Infrastructure.Tests`) to keep integration tests offline and deterministic.

--- a/docs/visual-extractor/ui-workflow.md
+++ b/docs/visual-extractor/ui-workflow.md
@@ -1,0 +1,32 @@
+# UI Workflow
+
+_Back to [overview](README.md)_ • [Architecture](architecture.md) • [Contracts](service-contracts.md) • [Storage](data-storage.md)
+
+## Entry points
+1. **Command palette** – `ExtractWindow` can be opened from the library grid via `Ctrl+Shift+X`. The command passes the selected `EntryHubId` into the window factory.
+2. **Context menu** – right-clicking a file in `LibraryViewControl` exposes "Extract visual slice"; this persists the last-used export preset.
+3. **Drag/drop** – dropping an image/PDF onto the extractor dock automatically opens `ExtractWindow` with the dropped file as context.
+
+## Window layout
+- **Region canvas** (`RegionCanvasControl`): supports rectangle and freeform lasso tools, multi-selection, zoom, and panning. Keyboard shortcuts mirror PowerPoint (e.g., `Ctrl+=` zoom in).
+- **Metadata sidebar**: binds to `RegionDescriptorViewModel` to capture title, notes, tags, target board, and optional follow-up tasks.
+- **Export rail**: lists configured exporters (image, text, Office) with inline status icons and retry buttons.
+
+## Interaction flow
+1. User chooses a selection tool and marks a region; a floating toolbar shows pixel dimensions and quick actions.
+2. On confirm (`Enter` or "Add to queue"), the selection is captured into a `RegionSelection` model and appended to the pending exports list.
+3. The coordinator kicks off export tasks sequentially (default) or in parallel (if `EnableParallelExports` flag). Progress updates animate in the export rail.
+4. Once an export completes, the UI reveals a toast with shortcuts:
+   - "Copy rich snippet" (puts combined image + markdown summary onto the clipboard).
+   - "Open in workspace" (opens the `extraction/` folder via `WorkspaceLayout`).
+   - "Send to Office" (invokes the add-in bridge when the Office host is connected).
+5. Errors highlight the affected exporter, show sanitized error text, and surface a "Report with diagnostics" option that collects log excerpts without attaching document bits.
+
+## Accessibility
+- All controls have keyboard equivalents; narrations rely on `AutomationProperties.Name` bindings.
+- High-contrast theme uses app-level resource dictionaries and ensures selection handles meet WCAG contrast ratios.
+- Zoom controls support mouse wheel + `Ctrl` and trackpad gestures.
+
+## Persistence of state
+- The last five extraction sessions are serialized via `IExtractionRepository` and can be reloaded through the "Recent extractions" dropdown.
+- UI preferences (tool choice, snap-to-grid) persist via existing settings infrastructure in `LM.App.Wpf`.


### PR DESCRIPTION
## Summary
- add a dedicated docs/visual-extractor documentation set that outlines architecture, contracts, UI, data storage, add-in integration, and checklist guidance
- update the root README to point contributors to the new visual extractor documentation hub

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d1150a6b5c832b98078585fb41d875