### PR TITLE
Fix library detail template resource usage

### DIFF
--- a/src/LM.App.Wpf/App.xaml.cs
+++ b/src/LM.App.Wpf/App.xaml.cs
@@ -73,7 +73,8 @@ namespace LM.App.Wpf
             // ViewModels
             var presetStore = new LibraryFilterPresetStore(ws);
             var presetPrompt = new LibraryPresetPrompt();
-            var libraryVm = new LibraryViewModel(services.Store, services.FullTextSearch, ws, presetStore, presetPrompt);
+            var entryEditor = new WorkspaceEntryEditor(ws);
+            var libraryVm = new LibraryViewModel(services.Store, services.FullTextSearch, ws, presetStore, presetPrompt, entryEditor);
             var addVm = new AddViewModel(services.Pipeline, ws, services.Scanner);
             await addVm.InitializeAsync();
             _addViewModel = addVm;

--- a/src/LM.App.Wpf/Library/ILibraryEntryEditor.cs
+++ b/src/LM.App.Wpf/Library/ILibraryEntryEditor.cs
@@ -1,0 +1,9 @@
+using LM.Core.Models;
+
+namespace LM.App.Wpf.Library
+{
+    public interface ILibraryEntryEditor
+    {
+        void EditEntry(Entry entry);
+    }
+}

--- a/src/LM.App.Wpf/Library/WorkspaceEntryEditor.cs
+++ b/src/LM.App.Wpf/Library/WorkspaceEntryEditor.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using LM.Core.Abstractions;
+using LM.Core.Models;
+
+namespace LM.App.Wpf.Library
+{
+    public sealed class WorkspaceEntryEditor : ILibraryEntryEditor
+    {
+        private readonly IWorkSpaceService _workspace;
+
+        public WorkspaceEntryEditor(IWorkSpaceService workspace)
+        {
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+        }
+
+        public void EditEntry(Entry entry)
+        {
+            if (entry is null) throw new ArgumentNullException(nameof(entry));
+            if (string.IsNullOrWhiteSpace(entry.Id))
+            {
+                System.Windows.MessageBox.Show(
+                    "Selected entry is missing an identifier.",
+                    "Edit Entry",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Warning);
+                return;
+            }
+
+            var relative = Path.Combine("entries", entry.Id, "entry.json");
+            var metadataPath = _workspace.GetAbsolutePath(relative);
+
+            try
+            {
+                if (!File.Exists(metadataPath))
+                {
+                    System.Windows.MessageBox.Show(
+                        $"Entry metadata was not found at:\n{metadataPath}",
+                        "Edit Entry",
+                        System.Windows.MessageBoxButton.OK,
+                        System.Windows.MessageBoxImage.Error);
+                    return;
+                }
+
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = metadataPath,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                System.Windows.MessageBox.Show(
+                    $"Failed to open entry metadata:\n{ex.Message}",
+                    "Edit Entry",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -106,6 +106,11 @@ LM.App.Wpf.Library.LibraryFilterPresetStore.LibraryFilterPresetStore(LM.Core.Abs
 LM.App.Wpf.Library.LibraryFilterPresetStore.ListPresetsAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Library.LibraryFilterPreset!>!>!
 LM.App.Wpf.Library.LibraryFilterPresetStore.SavePresetAsync(LM.App.Wpf.Library.LibraryFilterPreset! preset, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.App.Wpf.Library.LibraryFilterPresetStore.TryGetPresetAsync(string! name, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.LibraryFilterPreset?>!
+LM.App.Wpf.Library.ILibraryEntryEditor
+LM.App.Wpf.Library.ILibraryEntryEditor.EditEntry(LM.Core.Models.Entry! entry) -> void
+LM.App.Wpf.Library.WorkspaceEntryEditor
+LM.App.Wpf.Library.WorkspaceEntryEditor.WorkspaceEntryEditor(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.App.Wpf.Library.WorkspaceEntryEditor.EditEntry(LM.Core.Models.Entry! entry) -> void
 LM.App.Wpf.Library.LibraryFilterState
 LM.App.Wpf.Library.LibraryFilterState.FullTextInAbstract.get -> bool
 LM.App.Wpf.Library.LibraryFilterState.FullTextInAbstract.set -> void
@@ -248,12 +253,13 @@ LM.App.Wpf.ViewModels.LibraryViewModel.InternalIdContains.set -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.IsInternal.get -> bool?
 LM.App.Wpf.ViewModels.LibraryViewModel.IsInternal.set -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.IsMetadataSearch.get -> bool
-LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.Core.Abstractions.IWorkSpaceService! ws, LM.App.Wpf.Library.LibraryFilterPresetStore! presetStore, LM.App.Wpf.Common.ILibraryPresetPrompt! presetPrompt) -> void
+LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.Core.Abstractions.IWorkSpaceService! ws, LM.App.Wpf.Library.LibraryFilterPresetStore! presetStore, LM.App.Wpf.Common.ILibraryPresetPrompt! presetPrompt, LM.App.Wpf.Library.ILibraryEntryEditor! entryEditor) -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.LoadPresetCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.LibraryViewModel.ManagePresetsCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.LibraryViewModel.NctContains.get -> string?
 LM.App.Wpf.ViewModels.LibraryViewModel.NctContains.set -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.OpenCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.LibraryViewModel.EditCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.LibraryViewModel.PmidContains.get -> string?
 LM.App.Wpf.ViewModels.LibraryViewModel.PmidContains.set -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.FullTextInAbstract.get -> bool
@@ -303,6 +309,17 @@ LM.App.Wpf.ViewModels.LibrarySearchResult.IsFullText.get -> bool
 LM.App.Wpf.ViewModels.LibrarySearchResult.LibrarySearchResult(LM.Core.Models.Entry! entry, double? score, string? highlight) -> void
 LM.App.Wpf.ViewModels.LibrarySearchResult.Score.get -> double?
 LM.App.Wpf.ViewModels.LibrarySearchResult.ScoreDisplay.get -> string?
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasAttachments.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasDoi.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasIdentifiers.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasInternalId.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasLinks.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasNct.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasNotes.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasPmid.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasRelations.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasSource.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasUserNotes.get -> bool
 LM.App.Wpf.ViewModels.SearchItemViewModel
 LM.App.Wpf.ViewModels.SearchItemViewModel.Header.get -> string!
 LM.App.Wpf.ViewModels.SearchItemViewModel.SearchItemViewModel(string! header, LM.App.Wpf.ViewModels.LibraryViewModel! vm) -> void

--- a/src/LM.App.Wpf/ViewModels/Library/LibrarySearchResult.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LibrarySearchResult.cs
@@ -26,5 +26,17 @@ namespace LM.App.Wpf.ViewModels
             : null;
 
         public string? HighlightDisplay => string.IsNullOrWhiteSpace(Highlight) ? null : Highlight;
+
+        public bool HasSource => !string.IsNullOrWhiteSpace(Entry.Source);
+        public bool HasNotes => !string.IsNullOrWhiteSpace(Entry.Notes);
+        public bool HasUserNotes => !string.IsNullOrWhiteSpace(Entry.UserNotes);
+        public bool HasInternalId => !string.IsNullOrWhiteSpace(Entry.InternalId);
+        public bool HasDoi => !string.IsNullOrWhiteSpace(Entry.Doi);
+        public bool HasPmid => !string.IsNullOrWhiteSpace(Entry.Pmid);
+        public bool HasNct => !string.IsNullOrWhiteSpace(Entry.Nct);
+        public bool HasIdentifiers => HasInternalId || HasDoi || HasPmid || HasNct;
+        public bool HasLinks => Entry.Links is { Count: > 0 };
+        public bool HasAttachments => Entry.Attachments is { Count: > 0 };
+        public bool HasRelations => Entry.Relations is { Count: > 0 };
     }
 }

--- a/src/LM.App.Wpf/Views/Library/LibraryEntryDetailTemplate.xaml
+++ b/src/LM.App.Wpf/Views/Library/LibraryEntryDetailTemplate.xaml
@@ -1,0 +1,273 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:common="clr-namespace:LM.App.Wpf.Common"
+                    xmlns:viewModels="clr-namespace:LM.App.Wpf.ViewModels">
+  <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+  <common:StringJoinConverter x:Key="StringJoinConverter" />
+
+  <Style x:Key="SectionHeaderTextStyle" TargetType="TextBlock">
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="Margin" Value="0,16,0,4" />
+  </Style>
+
+  <Style x:Key="SectionTextStyle" TargetType="TextBlock">
+    <Setter Property="TextWrapping" Value="Wrap" />
+  </Style>
+
+  <Style x:Key="OptionalSectionTextStyle"
+         TargetType="TextBlock"
+         BasedOn="{StaticResource SectionTextStyle}">
+    <Setter Property="Visibility" Value="Visible" />
+    <Style.Triggers>
+      <Trigger Property="Text" Value="">
+        <Setter Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <Trigger Property="Text" Value="{x:Null}">
+        <Setter Property="Visibility" Value="Collapsed" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+
+  <Style x:Key="DisplayNameTextStyle"
+         TargetType="TextBlock"
+         BasedOn="{StaticResource OptionalSectionTextStyle}">
+    <Setter Property="FontStyle" Value="Italic" />
+    <Setter Property="Foreground" Value="Gray" />
+    <Setter Property="Margin" Value="0,4,0,0" />
+  </Style>
+
+  <Style x:Key="OptionalInlineTextStyle" TargetType="TextBlock">
+    <Setter Property="Visibility" Value="Visible" />
+    <Style.Triggers>
+      <Trigger Property="Text" Value="">
+        <Setter Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <Trigger Property="Text" Value="{x:Null}">
+        <Setter Property="Visibility" Value="Collapsed" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+
+  <Style x:Key="SectionPlaceholderTextStyle" TargetType="TextBlock">
+    <Setter Property="FontStyle" Value="Italic" />
+    <Setter Property="Foreground" Value="Gray" />
+    <Setter Property="Visibility" Value="Collapsed" />
+  </Style>
+
+  <Style x:Key="AttachmentNotesTextStyle"
+         TargetType="TextBlock"
+         BasedOn="{StaticResource SectionTextStyle}">
+    <Setter Property="Visibility" Value="Visible" />
+    <Style.Triggers>
+      <Trigger Property="Text" Value="">
+        <Setter Property="Visibility" Value="Collapsed" />
+      </Trigger>
+      <Trigger Property="Text" Value="{x:Null}">
+        <Setter Property="Visibility" Value="Collapsed" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+
+  <Style x:Key="AttachmentTagsTextStyle" TargetType="TextBlock">
+    <Setter Property="Visibility" Value="Visible" />
+    <Style.Triggers>
+      <DataTrigger Binding="{Binding Tags}" Value="{x:Null}">
+        <Setter Property="Visibility" Value="Collapsed" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Tags.Count}" Value="0">
+        <Setter Property="Visibility" Value="Collapsed" />
+      </DataTrigger>
+    </Style.Triggers>
+  </Style>
+
+  <DataTemplate DataType="{x:Type viewModels:LibrarySearchResult}">
+    <StackPanel>
+      <Grid Margin="0,0,0,12">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <StackPanel Grid.Column="0">
+          <TextBlock Text="{Binding Entry.Title}"
+                     FontSize="16"
+                     FontWeight="SemiBold"
+                     TextWrapping="Wrap" />
+          <TextBlock Text="{Binding Entry.DisplayName}"
+                     Style="{StaticResource DisplayNameTextStyle}" />
+          <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+            <TextBlock Text="{Binding Entry.Type}" />
+            <TextBlock Text="{Binding Entry.Year}"
+                       Margin="12,0,0,0"
+                       Style="{StaticResource OptionalInlineTextStyle}" />
+            <TextBlock Text="Internal"
+                       Margin="12,0,0,0"
+                       Visibility="{Binding Entry.IsInternal, Converter={StaticResource BoolToVisibilityConverter}}" />
+          </StackPanel>
+        </StackPanel>
+
+        <Button Grid.Column="1"
+                Content="Edit"
+                Command="{Binding DataContext.EditCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                Margin="12,0,0,0"
+                Padding="12,4"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top" />
+      </Grid>
+
+      <TextBlock Text="Source" Style="{StaticResource SectionHeaderTextStyle}" />
+      <TextBlock Text="{Binding Entry.Source}"
+                 Style="{StaticResource SectionTextStyle}"
+                 Visibility="{Binding HasSource, Converter={StaticResource BoolToVisibilityConverter}}" />
+      <TextBlock Text="No source recorded.">
+        <TextBlock.Style>
+          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding HasSource}" Value="False">
+                <Setter Property="Visibility" Value="Visible" />
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </TextBlock.Style>
+      </TextBlock>
+
+      <TextBlock Text="Notes" Style="{StaticResource SectionHeaderTextStyle}" />
+      <TextBlock Text="{Binding Entry.Notes}" Style="{StaticResource OptionalSectionTextStyle}" />
+      <TextBlock Text="No notes recorded.">
+        <TextBlock.Style>
+          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding HasNotes}" Value="False">
+                <Setter Property="Visibility" Value="Visible" />
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </TextBlock.Style>
+      </TextBlock>
+
+      <TextBlock Text="User notes" Style="{StaticResource SectionHeaderTextStyle}" />
+      <TextBlock Text="{Binding Entry.UserNotes}" Style="{StaticResource OptionalSectionTextStyle}" />
+      <TextBlock Text="No user notes provided.">
+        <TextBlock.Style>
+          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding HasUserNotes}" Value="False">
+                <Setter Property="Visibility" Value="Visible" />
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </TextBlock.Style>
+      </TextBlock>
+
+      <TextBlock Text="Identifiers" Style="{StaticResource SectionHeaderTextStyle}" />
+      <StackPanel>
+        <TextBlock Visibility="{Binding HasInternalId, Converter={StaticResource BoolToVisibilityConverter}}">
+          <Run Text="Internal ID: " />
+          <Run Text="{Binding Entry.InternalId}" />
+        </TextBlock>
+        <TextBlock Visibility="{Binding HasDoi, Converter={StaticResource BoolToVisibilityConverter}}">
+          <Run Text="DOI: " />
+          <Run Text="{Binding Entry.Doi}" />
+        </TextBlock>
+        <TextBlock Visibility="{Binding HasPmid, Converter={StaticResource BoolToVisibilityConverter}}">
+          <Run Text="PMID: " />
+          <Run Text="{Binding Entry.Pmid}" />
+        </TextBlock>
+        <TextBlock Visibility="{Binding HasNct, Converter={StaticResource BoolToVisibilityConverter}}">
+          <Run Text="NCT: " />
+          <Run Text="{Binding Entry.Nct}" />
+        </TextBlock>
+      </StackPanel>
+      <TextBlock Text="No identifiers recorded.">
+        <TextBlock.Style>
+          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding HasIdentifiers}" Value="False">
+                <Setter Property="Visibility" Value="Visible" />
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </TextBlock.Style>
+      </TextBlock>
+
+      <TextBlock Text="Links" Style="{StaticResource SectionHeaderTextStyle}" />
+      <ItemsControl ItemsSource="{Binding Entry.Links}"
+                    Visibility="{Binding HasLinks, Converter={StaticResource BoolToVisibilityConverter}}">
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <TextBlock Text="{Binding}" Style="{StaticResource SectionTextStyle}" />
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+      <TextBlock Text="No links added.">
+        <TextBlock.Style>
+          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding HasLinks}" Value="False">
+                <Setter Property="Visibility" Value="Visible" />
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </TextBlock.Style>
+      </TextBlock>
+
+      <TextBlock Text="Attachments" Style="{StaticResource SectionHeaderTextStyle}" />
+      <ItemsControl ItemsSource="{Binding Entry.Attachments}"
+                    Visibility="{Binding HasAttachments, Converter={StaticResource BoolToVisibilityConverter}}">
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <Border BorderBrush="#FFE0E0E0"
+                    BorderThickness="1"
+                    Padding="8"
+                    Margin="0,0,0,8">
+              <StackPanel>
+                <TextBlock Text="{Binding RelativePath}" FontWeight="SemiBold" />
+                <TextBlock Text="{Binding Notes}" Style="{StaticResource AttachmentNotesTextStyle}" />
+                <TextBlock Style="{StaticResource AttachmentTagsTextStyle}">
+                  <Run Text="Tags: " />
+                  <Run Text="{Binding Tags, Converter={StaticResource StringJoinConverter}}" />
+                </TextBlock>
+              </StackPanel>
+            </Border>
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+      <TextBlock Text="No attachments found.">
+        <TextBlock.Style>
+          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding HasAttachments}" Value="False">
+                <Setter Property="Visibility" Value="Visible" />
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </TextBlock.Style>
+      </TextBlock>
+
+      <TextBlock Text="Relations" Style="{StaticResource SectionHeaderTextStyle}" />
+      <ItemsControl ItemsSource="{Binding Entry.Relations}"
+                    Visibility="{Binding HasRelations, Converter={StaticResource BoolToVisibilityConverter}}">
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <TextBlock>
+              <Run Text="{Binding Type}" FontWeight="SemiBold" />
+              <Run Text=" → " />
+              <Run Text="{Binding TargetEntryId}" />
+            </TextBlock>
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+      <TextBlock Text="No relations associated.">
+        <TextBlock.Style>
+          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding HasRelations}" Value="False">
+                <Setter Property="Visibility" Value="Visible" />
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </TextBlock.Style>
+      </TextBlock>
+    </StackPanel>
+  </DataTemplate>
+</ResourceDictionary>

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -3,17 +3,21 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:common="clr-namespace:LM.App.Wpf.Common"
              mc:Ignorable="d"
              d:DesignHeight="600" d:DesignWidth="900">
   <UserControl.Resources>
-    <common:StringJoinConverter x:Key="StringJoinConverter" />
-    <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="Library/LibraryEntryDetailTemplate.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
   </UserControl.Resources>
   <Grid>
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="310"/>
       <ColumnDefinition Width="*"/>
+      <ColumnDefinition Width="5"/>
+      <ColumnDefinition Width="360"/>
     </Grid.ColumnDefinitions>
 
     <!-- Filters Panel -->
@@ -169,5 +173,50 @@
         <Button Content="Open" Command="{Binding OpenCommand}"/>
       </StackPanel>
     </Grid>
+
+    <GridSplitter Grid.Column="2"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch"
+                  Background="#FFE0E0E0"
+                  ShowsPreview="True"
+                  Width="5"/>
+
+    <Border Grid.Column="3" BorderBrush="#FFE0E0E0" BorderThickness="1,0,0,0" Background="#FFFDFDFD">
+      <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <Grid>
+          <ContentPresenter Content="{Binding Selected}" Margin="12">
+            <ContentPresenter.Style>
+              <Style TargetType="ContentPresenter">
+                <Setter Property="Visibility" Value="Visible"/>
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding Selected}" Value="{x:Null}">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </ContentPresenter.Style>
+          </ContentPresenter>
+
+          <TextBlock Text="Select an entry to view details."
+                     Margin="12"
+                     FontStyle="Italic"
+                     Foreground="Gray"
+                     TextWrapping="Wrap"
+                     VerticalAlignment="Center"
+                     HorizontalAlignment="Center">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock">
+                <Setter Property="Visibility" Value="Collapsed"/>
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding Selected}" Value="{x:Null}">
+                    <Setter Property="Visibility" Value="Visible"/>
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+        </Grid>
+      </ScrollViewer>
+    </Border>
   </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- move the library entry detail DataTemplate into a dedicated resource dictionary with reusable styles that avoid duplicate Style setters
- update LibraryView.xaml to merge the new dictionary while keeping the existing layout intact

## Testing
- `dotnet test` *(fails: `dotnet` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d114ef3d68832b873c0f540020e3b5