### PR TITLE
Add extraction domain contracts to LM.Core

### DIFF
--- a/src/LM.Core/Abstractions/IExtractionPostProcessor.cs
+++ b/src/LM.Core/Abstractions/IExtractionPostProcessor.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Models;
+
+namespace LM.Core.Abstractions
+{
+    /// <summary>
+    /// Optional hook executed after a region export completes, enabling enrichment steps such as ML tagging.
+    /// </summary>
+    public interface IExtractionPostProcessor
+    {
+        /// <summary>
+        /// Gets the display name for diagnostics and logging.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Determines whether the post-processor should run for the provided export result.
+        /// </summary>
+        bool CanHandle(RegionExportResult result);
+
+        /// <summary>
+        /// Performs the post-processing work. Implementations should honour the two-second guideline noted in the docs.
+        /// </summary>
+        Task PostProcessAsync(RegionExportResult result, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/LM.Core/Abstractions/IExtractionRepository.cs
+++ b/src/LM.Core/Abstractions/IExtractionRepository.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Models;
+
+namespace LM.Core.Abstractions
+{
+    /// <summary>
+    /// Persists and queries <see cref="RegionDescriptor"/> records backed by the extractor SQLite store.
+    /// Implementations provide history lookups for the UI and Office add-in integration.
+    /// </summary>
+    public interface IExtractionRepository
+    {
+        /// <summary>
+        /// Inserts or updates a descriptor along with its FTS index entries.
+        /// </summary>
+        Task UpsertAsync(RegionDescriptor descriptor, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Fetches a descriptor by its region hash.
+        /// </summary>
+        Task<RegionDescriptor?> GetAsync(string regionHash, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Enumerates descriptors for a specific entry hub ordered by newest first.
+        /// </summary>
+        IAsyncEnumerable<RegionDescriptor> ListByEntryAsync(string entryHubId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves the most recent descriptors across the workspace (limited by <paramref name="take"/>).
+        /// </summary>
+        Task<IReadOnlyList<RegionDescriptor>> GetRecentAsync(int take, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Searches descriptors via the OCR full-text index.
+        /// </summary>
+        Task<IReadOnlyList<RegionDescriptor>> SearchAsync(string query, int take, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates the last known export status for a region.
+        /// </summary>
+        Task UpdateStatusAsync(string regionHash, RegionExportStatus status, string? errorMessage = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a descriptor and its assets from the repository.
+        /// </summary>
+        Task DeleteAsync(string regionHash, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/LM.Core/Abstractions/IRegionExporter.cs
+++ b/src/LM.Core/Abstractions/IRegionExporter.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Models;
+
+namespace LM.Core.Abstractions
+{
+    /// <summary>
+    /// Performs region exports by writing cropped assets, OCR text, and metadata described in the visual extractor docs.
+    /// Implementations must be cancellable and avoid blocking the UI thread.
+    /// </summary>
+    public interface IRegionExporter
+    {
+        /// <summary>
+        /// Gets the unique identifier for the exporter (e.g., <c>image/png</c>, <c>office/ppmx</c>).
+        /// </summary>
+        string ExporterId { get; }
+
+        /// <summary>
+        /// Determines whether the exporter can handle the supplied request.
+        /// </summary>
+        bool CanHandle(RegionExportRequest request);
+
+        /// <summary>
+        /// Executes the export and returns the generated assets and descriptor updates.
+        /// </summary>
+        Task<RegionExportResult> ExportAsync(RegionExportRequest request, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/LM.Core/Abstractions/IRegionPreviewService.cs
+++ b/src/LM.Core/Abstractions/IRegionPreviewService.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Models;
+
+namespace LM.Core.Abstractions
+{
+    /// <summary>
+    /// Produces lightweight previews for selections so the UI can render thumbnails and hover cards quickly.
+    /// Implementations may cache previews on disk but must honour cancellation and offline quotas.
+    /// </summary>
+    public interface IRegionPreviewService
+    {
+        /// <summary>
+        /// Generates or retrieves a preview for the given export request.
+        /// </summary>
+        Task<RegionPreview> RenderAsync(RegionExportRequest request, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Invalidates cached previews associated with the supplied cache key or region hash.
+        /// </summary>
+        Task InvalidateAsync(string cacheKey, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/LM.Core/Abstractions/IVisualExtractionCoordinator.cs
+++ b/src/LM.Core/Abstractions/IVisualExtractionCoordinator.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Models;
+
+namespace LM.Core.Abstractions
+{
+    /// <summary>
+    /// Coordinates region export requests, dispatching work to exporters and surfacing completion/failure events to the UI layer.
+    /// </summary>
+    public interface IVisualExtractionCoordinator
+    {
+        /// <summary>
+        /// Raised when an export completes successfully.
+        /// </summary>
+        event EventHandler<RegionExportCompleted>? ExportCompleted;
+
+        /// <summary>
+        /// Raised when an export fails.
+        /// </summary>
+        event EventHandler<RegionExportFailed>? ExportFailed;
+
+        /// <summary>
+        /// Queues a region export and returns the result once finished.
+        /// Implementations may offload work to background jobs but should still honour cancellation.
+        /// </summary>
+        Task<RegionExportResult> QueueExportAsync(RegionExportRequest request, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Attempts to cancel a queued or running export identified by region hash.
+        /// </summary>
+        Task CancelAsync(string regionHash, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Fetches a descriptor for a previously exported region.
+        /// </summary>
+        Task<RegionDescriptor?> GetDescriptorAsync(string regionHash, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Enumerates recent exports for display in history panes.
+        /// </summary>
+        IAsyncEnumerable<RegionDescriptor> EnumerateRecentAsync(int take, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/LM.Core/Models/RegionBounds.cs
+++ b/src/LM.Core/Models/RegionBounds.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace LM.Core.Models
+{
+    /// <summary>
+    /// Describes the rectangular coordinates of an extracted region in pixel space.
+    /// Coordinates follow the JSON schema documented in
+    /// <c>docs/visual-extractor/data-storage.md</c> (x, y, width, height).
+    /// </summary>
+    public sealed partial class RegionBounds
+    {
+        /// <summary>
+        /// Gets or sets the X coordinate (in pixels) relative to the source page or slide.
+        /// </summary>
+        public double X { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Y coordinate (in pixels) relative to the source page or slide.
+        /// </summary>
+        public double Y { get; set; }
+
+        /// <summary>
+        /// Gets or sets the width of the region in pixels.
+        /// </summary>
+        public double Width { get; set; }
+
+        /// <summary>
+        /// Gets or sets the height of the region in pixels.
+        /// </summary>
+        public double Height { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the region is empty (width or height less than or equal to zero).
+        /// </summary>
+        public bool IsEmpty => Width <= 0 || Height <= 0;
+
+        /// <summary>
+        /// Creates a shallow copy of the current bounds instance.
+        /// </summary>
+        public RegionBounds Clone() => (RegionBounds)MemberwiseClone();
+    }
+}

--- a/src/LM.Core/Models/RegionDescriptor.cs
+++ b/src/LM.Core/Models/RegionDescriptor.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+
+namespace LM.Core.Models
+{
+    /// <summary>
+    /// Represents a persisted region descriptor stored under <c>%WORKSPACE%/extraction</c> and indexed in SQLite.
+    /// Aligns with the schema documented in <c>docs/visual-extractor/data-storage.md</c>.
+    /// </summary>
+    public sealed partial class RegionDescriptor
+    {
+        /// <summary>
+        /// Gets or sets the deterministic SHA-256 hash that uniquely identifies the exported region.
+        /// </summary>
+        public string RegionHash { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the identifier of the entry hub that owns the source file.
+        /// </summary>
+        public string EntryHubId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the relative path of the source file inside the workspace.
+        /// </summary>
+        public string SourceRelativePath { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the SHA-256 hash of the source file that produced the region (optional).
+        /// </summary>
+        public string? SourceSha256 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the page or slide number (1-based) for the source document, if applicable.
+        /// </summary>
+        public int? PageNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the rectangular bounds captured at export time.
+        /// </summary>
+        public RegionBounds Bounds { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the OCR text extracted from the region.
+        /// </summary>
+        public string? OcrText { get; set; }
+
+        /// <summary>
+        /// Gets the list of tags applied to the region descriptor.
+        /// </summary>
+        public List<string> Tags { get; } = new();
+
+        /// <summary>
+        /// Gets or sets user-authored notes persisted alongside the descriptor.
+        /// </summary>
+        public string? Notes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the short annotation text displayed in UI previews.
+        /// </summary>
+        public string? Annotation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UTC timestamp when the descriptor was created.
+        /// </summary>
+        public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// Gets or sets the UTC timestamp for the last update to the descriptor, if any.
+        /// </summary>
+        public DateTime? UpdatedUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the most recent export status for the descriptor.
+        /// </summary>
+        public RegionExportStatus LastExportStatus { get; set; } = RegionExportStatus.Pending;
+
+        /// <summary>
+        /// Gets or sets the path to an Office-ready package (PPMX) generated for this region.
+        /// </summary>
+        public string? OfficePackagePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the exported raster image (PNG/JPEG).
+        /// </summary>
+        public string? ImagePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the exported OCR text file.
+        /// </summary>
+        public string? OcrTextPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the exporter identifier that produced the latest descriptor update.
+        /// </summary>
+        public string? ExporterId { get; set; }
+
+        /// <summary>
+        /// Gets metadata specific to exporters or post-processors, serialized into JSON when persisted.
+        /// </summary>
+        public Dictionary<string, string> ExtraMetadata { get; } = new();
+    }
+}

--- a/src/LM.Core/Models/RegionExportCompleted.cs
+++ b/src/LM.Core/Models/RegionExportCompleted.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace LM.Core.Models
+{
+    /// <summary>
+    /// Event payload raised when a region export completes successfully.
+    /// Surfaces to the UI and hub ingestion pipeline per the extractor design documentation.
+    /// </summary>
+    public sealed partial class RegionExportCompleted
+    {
+        /// <summary>
+        /// Gets or sets the request that initiated the export.
+        /// </summary>
+        public RegionExportRequest Request { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the resulting export payload.
+        /// </summary>
+        public RegionExportResult Result { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the completion timestamp in UTC.
+        /// </summary>
+        public DateTime CompletedUtc { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/src/LM.Core/Models/RegionExportFailed.cs
+++ b/src/LM.Core/Models/RegionExportFailed.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace LM.Core.Models
+{
+    /// <summary>
+    /// Event payload raised when a region export fails.
+    /// Contains sanitized error information surfaced to UI and diagnostics logs.
+    /// </summary>
+    public sealed partial class RegionExportFailed
+    {
+        /// <summary>
+        /// Gets or sets the original export request.
+        /// </summary>
+        public RegionExportRequest Request { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the identifier of the exporter that reported the failure.
+        /// </summary>
+        public string ExporterId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the failure timestamp in UTC.
+        /// </summary>
+        public DateTime FailedUtc { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// Gets or sets the sanitized error message suitable for user display.
+        /// </summary>
+        public string ErrorMessage { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets an optional machine-readable error code for diagnostics.
+        /// </summary>
+        public string? ErrorCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the export can be retried automatically.
+        /// </summary>
+        public bool IsRetryable { get; set; }
+    }
+}

--- a/src/LM.Core/Models/RegionExportRequest.cs
+++ b/src/LM.Core/Models/RegionExportRequest.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+
+namespace LM.Core.Models
+{
+    /// <summary>
+    /// Represents an export command issued by the visual extraction workflow.
+    /// Contains the selection, source provenance, and exporter preferences described in
+    /// <c>docs/visual-extractor/service-contracts.md</c>.
+    /// </summary>
+    public sealed partial class RegionExportRequest
+    {
+        /// <summary>
+        /// Gets or sets the entry hub identifier that owns the source document.
+        /// </summary>
+        public string EntryHubId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the relative path to the source file inside the workspace.
+        /// </summary>
+        public string SourceRelativePath { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the SHA-256 hash of the source file used to derive region hashes.
+        /// </summary>
+        public string? SourceSha256 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MIME type of the source file (used to dispatch to exporters).
+        /// </summary>
+        public string? SourceMimeType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the selection captured by the UI.
+        /// </summary>
+        public RegionSelection Selection { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the identifier of the exporter that should handle this request.
+        /// </summary>
+        public string ExporterId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether cached outputs can satisfy the request.
+        /// </summary>
+        public bool AllowCachedResult { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets when the export was queued (UTC).
+        /// </summary>
+        public DateTime RequestedUtc { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// Gets or sets the user identifier that initiated the export, if tracked.
+        /// </summary>
+        public string? RequestedBy { get; set; }
+
+        /// <summary>
+        /// Gets exporter-specific options (e.g., DPI overrides, color profiles).
+        /// </summary>
+        public Dictionary<string, string> ExportOptions { get; } = new();
+
+        /// <summary>
+        /// Gets or sets the Office destination hint (e.g., slide id) when routing to the add-in bridge.
+        /// </summary>
+        public string? OfficeDestination { get; set; }
+    }
+}

--- a/src/LM.Core/Models/RegionExportResult.cs
+++ b/src/LM.Core/Models/RegionExportResult.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+namespace LM.Core.Models
+{
+    /// <summary>
+    /// Represents the outcome of a region export operation, including generated assets and metadata updates.
+    /// Mirrors the data returned by <see cref="Abstractions.IRegionExporter"/> implementations.
+    /// </summary>
+    public sealed partial class RegionExportResult
+    {
+        /// <summary>
+        /// Gets or sets the exporter identifier that produced this result.
+        /// </summary>
+        public string ExporterId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the descriptor persisted for the exported region.
+        /// </summary>
+        public RegionDescriptor Descriptor { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the path to the exported raster image asset.
+        /// </summary>
+        public string ImagePath { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the path to the exported OCR text asset, if produced.
+        /// </summary>
+        public string? OcrTextPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the Office-ready package (PPMX) if generated.
+        /// </summary>
+        public string? OfficePackagePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the result was served from cached assets.
+        /// </summary>
+        public bool WasCached { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration of the export operation.
+        /// </summary>
+        public TimeSpan Duration { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
+        /// Gets or sets the completion timestamp in UTC.
+        /// </summary>
+        public DateTime CompletedUtc { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// Gets auxiliary exporter outputs (e.g., color palette JSON, vector snapshots).
+        /// </summary>
+        public Dictionary<string, string> AdditionalOutputs { get; } = new();
+    }
+}

--- a/src/LM.Core/Models/RegionExportStatus.cs
+++ b/src/LM.Core/Models/RegionExportStatus.cs
@@ -1,0 +1,34 @@
+namespace LM.Core.Models
+{
+    /// <summary>
+    /// Represents the most recent export status for a region descriptor persisted in SQLite storage.
+    /// Values map to the <c>last_export_status</c> column described in data-storage documentation.
+    /// </summary>
+    public enum RegionExportStatus
+    {
+        /// <summary>
+        /// Default value when the status has not been set.
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// Export has been enqueued but not yet completed.
+        /// </summary>
+        Pending,
+
+        /// <summary>
+        /// Export completed successfully and assets are available on disk.
+        /// </summary>
+        Completed,
+
+        /// <summary>
+        /// Export failed; details are recorded in the descriptor metadata.
+        /// </summary>
+        Failed,
+
+        /// <summary>
+        /// Export was canceled by the user or system.
+        /// </summary>
+        Canceled
+    }
+}

--- a/src/LM.Core/Models/RegionPreview.cs
+++ b/src/LM.Core/Models/RegionPreview.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace LM.Core.Models
+{
+    /// <summary>
+    /// Represents a lightweight bitmap preview for quick redraws in the extraction UI.
+    /// Aligns with <c>IRegionPreviewService</c> responsibilities documented in the extractor specs.
+    /// </summary>
+    public sealed partial class RegionPreview
+    {
+        /// <summary>
+        /// Gets or sets the stable cache key used by preview caches.
+        /// </summary>
+        public string CacheKey { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the on-disk path to the preview bitmap.
+        /// </summary>
+        public string PreviewPath { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the pixel width of the preview image.
+        /// </summary>
+        public int PixelWidth { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pixel height of the preview image.
+        /// </summary>
+        public int PixelHeight { get; set; }
+
+        /// <summary>
+        /// Gets or sets the horizontal DPI metadata associated with the preview image.
+        /// </summary>
+        public double DpiX { get; set; } = 96d;
+
+        /// <summary>
+        /// Gets or sets the vertical DPI metadata associated with the preview image.
+        /// </summary>
+        public double DpiY { get; set; } = 96d;
+
+        /// <summary>
+        /// Gets or sets the timestamp when the preview was generated.
+        /// </summary>
+        public DateTime GeneratedUtc { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the preview originated from cache.
+        /// </summary>
+        public bool FromCache { get; set; }
+    }
+}

--- a/src/LM.Core/Models/RegionSelection.cs
+++ b/src/LM.Core/Models/RegionSelection.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+namespace LM.Core.Models
+{
+    /// <summary>
+    /// Captures a user's visual selection, including geometry, annotations, and tagging metadata.
+    /// This model originates from the WPF extraction canvas as described in
+    /// <c>docs/visual-extractor/architecture.md</c>.
+    /// </summary>
+    public sealed partial class RegionSelection
+    {
+        /// <summary>
+        /// Gets or sets the bounding box for the selection in pixel coordinates.
+        /// </summary>
+        public RegionBounds Bounds { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the page or slide number (1-based) associated with the selection.
+        /// </summary>
+        public int? PageNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the zoom factor used when the region was captured (1.0 represents 100%).
+        /// </summary>
+        public double ZoomLevel { get; set; } = 1d;
+
+        /// <summary>
+        /// Gets or sets the rotation applied to the source page or slide, expressed in degrees.
+        /// </summary>
+        public double RotationDegrees { get; set; }
+
+        /// <summary>
+        /// Gets or sets the free-form annotation entered at capture time (displayed in the metadata sidebar).
+        /// </summary>
+        public string? Annotation { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional operator notes stored with the selection.
+        /// </summary>
+        public string? Notes { get; set; }
+
+        /// <summary>
+        /// Gets the list of tags applied to the selection.
+        /// </summary>
+        public List<string> Tags { get; } = new();
+    }
+}

--- a/src/LM.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Core/PublicAPI.Unshipped.txt
@@ -317,3 +317,180 @@ static LM.Core.Utils.IdGen.NewId() -> string!
 static LM.Core.Utils.JsonEx.Deserialize<T>(string! s) -> T?
 static LM.Core.Utils.JsonEx.Serialize<T>(T v) -> string!
 static readonly LM.Core.Utils.JsonEx.Options -> System.Text.Json.JsonSerializerOptions!
+LM.Core.Abstractions.IExtractionPostProcessor
+LM.Core.Abstractions.IExtractionPostProcessor.CanHandle(LM.Core.Models.RegionExportResult! result) -> bool
+LM.Core.Abstractions.IExtractionPostProcessor.Name.get -> string!
+LM.Core.Abstractions.IExtractionPostProcessor.PostProcessAsync(LM.Core.Models.RegionExportResult! result, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IExtractionRepository
+LM.Core.Abstractions.IExtractionRepository.DeleteAsync(string! regionHash, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IExtractionRepository.GetAsync(string! regionHash, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.RegionDescriptor?>!
+LM.Core.Abstractions.IExtractionRepository.GetRecentAsync(int take, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.RegionDescriptor!>!>!
+LM.Core.Abstractions.IExtractionRepository.ListByEntryAsync(string! entryHubId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<LM.Core.Models.RegionDescriptor!>!
+LM.Core.Abstractions.IExtractionRepository.SearchAsync(string! query, int take, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.RegionDescriptor!>!>!
+LM.Core.Abstractions.IExtractionRepository.UpdateStatusAsync(string! regionHash, LM.Core.Models.RegionExportStatus status, string? errorMessage = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IExtractionRepository.UpsertAsync(LM.Core.Models.RegionDescriptor! descriptor, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IRegionExporter
+LM.Core.Abstractions.IRegionExporter.CanHandle(LM.Core.Models.RegionExportRequest! request) -> bool
+LM.Core.Abstractions.IRegionExporter.ExporterId.get -> string!
+LM.Core.Abstractions.IRegionExporter.ExportAsync(LM.Core.Models.RegionExportRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.RegionExportResult!>!
+LM.Core.Abstractions.IRegionPreviewService
+LM.Core.Abstractions.IRegionPreviewService.InvalidateAsync(string! cacheKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IRegionPreviewService.RenderAsync(LM.Core.Models.RegionExportRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.RegionPreview!>!
+LM.Core.Abstractions.IVisualExtractionCoordinator
+LM.Core.Abstractions.IVisualExtractionCoordinator.CancelAsync(string! regionHash, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IVisualExtractionCoordinator.EnumerateRecentAsync(int take, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<LM.Core.Models.RegionDescriptor!>!
+LM.Core.Abstractions.IVisualExtractionCoordinator.ExportCompleted -> System.EventHandler<LM.Core.Models.RegionExportCompleted!>?
+LM.Core.Abstractions.IVisualExtractionCoordinator.ExportFailed -> System.EventHandler<LM.Core.Models.RegionExportFailed!>?
+LM.Core.Abstractions.IVisualExtractionCoordinator.GetDescriptorAsync(string! regionHash, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.RegionDescriptor?>!
+LM.Core.Abstractions.IVisualExtractionCoordinator.QueueExportAsync(LM.Core.Models.RegionExportRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.RegionExportResult!>!
+LM.Core.Models.RegionBounds
+LM.Core.Models.RegionBounds.Clone() -> LM.Core.Models.RegionBounds!
+LM.Core.Models.RegionBounds.Height.get -> double
+LM.Core.Models.RegionBounds.Height.set -> void
+LM.Core.Models.RegionBounds.IsEmpty.get -> bool
+LM.Core.Models.RegionBounds.RegionBounds() -> void
+LM.Core.Models.RegionBounds.Width.get -> double
+LM.Core.Models.RegionBounds.Width.set -> void
+LM.Core.Models.RegionBounds.X.get -> double
+LM.Core.Models.RegionBounds.X.set -> void
+LM.Core.Models.RegionBounds.Y.get -> double
+LM.Core.Models.RegionBounds.Y.set -> void
+LM.Core.Models.RegionDescriptor
+LM.Core.Models.RegionDescriptor.Annotation.get -> string?
+LM.Core.Models.RegionDescriptor.Annotation.set -> void
+LM.Core.Models.RegionDescriptor.Bounds.get -> LM.Core.Models.RegionBounds!
+LM.Core.Models.RegionDescriptor.Bounds.set -> void
+LM.Core.Models.RegionDescriptor.CreatedUtc.get -> System.DateTime
+LM.Core.Models.RegionDescriptor.CreatedUtc.set -> void
+LM.Core.Models.RegionDescriptor.EntryHubId.get -> string!
+LM.Core.Models.RegionDescriptor.EntryHubId.set -> void
+LM.Core.Models.RegionDescriptor.ExporterId.get -> string?
+LM.Core.Models.RegionDescriptor.ExporterId.set -> void
+LM.Core.Models.RegionDescriptor.ExtraMetadata.get -> System.Collections.Generic.Dictionary<string!, string!>!
+LM.Core.Models.RegionDescriptor.ImagePath.get -> string?
+LM.Core.Models.RegionDescriptor.ImagePath.set -> void
+LM.Core.Models.RegionDescriptor.LastExportStatus.get -> LM.Core.Models.RegionExportStatus
+LM.Core.Models.RegionDescriptor.LastExportStatus.set -> void
+LM.Core.Models.RegionDescriptor.Notes.get -> string?
+LM.Core.Models.RegionDescriptor.Notes.set -> void
+LM.Core.Models.RegionDescriptor.OcrText.get -> string?
+LM.Core.Models.RegionDescriptor.OcrText.set -> void
+LM.Core.Models.RegionDescriptor.OcrTextPath.get -> string?
+LM.Core.Models.RegionDescriptor.OcrTextPath.set -> void
+LM.Core.Models.RegionDescriptor.OfficePackagePath.get -> string?
+LM.Core.Models.RegionDescriptor.OfficePackagePath.set -> void
+LM.Core.Models.RegionDescriptor.PageNumber.get -> int?
+LM.Core.Models.RegionDescriptor.PageNumber.set -> void
+LM.Core.Models.RegionDescriptor.RegionDescriptor() -> void
+LM.Core.Models.RegionDescriptor.RegionHash.get -> string!
+LM.Core.Models.RegionDescriptor.RegionHash.set -> void
+LM.Core.Models.RegionDescriptor.SourceRelativePath.get -> string!
+LM.Core.Models.RegionDescriptor.SourceRelativePath.set -> void
+LM.Core.Models.RegionDescriptor.SourceSha256.get -> string?
+LM.Core.Models.RegionDescriptor.SourceSha256.set -> void
+LM.Core.Models.RegionDescriptor.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.RegionDescriptor.UpdatedUtc.get -> System.DateTime?
+LM.Core.Models.RegionDescriptor.UpdatedUtc.set -> void
+LM.Core.Models.RegionExportCompleted
+LM.Core.Models.RegionExportCompleted.CompletedUtc.get -> System.DateTime
+LM.Core.Models.RegionExportCompleted.CompletedUtc.set -> void
+LM.Core.Models.RegionExportCompleted.RegionExportCompleted() -> void
+LM.Core.Models.RegionExportCompleted.Request.get -> LM.Core.Models.RegionExportRequest!
+LM.Core.Models.RegionExportCompleted.Request.set -> void
+LM.Core.Models.RegionExportCompleted.Result.get -> LM.Core.Models.RegionExportResult!
+LM.Core.Models.RegionExportCompleted.Result.set -> void
+LM.Core.Models.RegionExportFailed
+LM.Core.Models.RegionExportFailed.ErrorCode.get -> string?
+LM.Core.Models.RegionExportFailed.ErrorCode.set -> void
+LM.Core.Models.RegionExportFailed.ErrorMessage.get -> string!
+LM.Core.Models.RegionExportFailed.ErrorMessage.set -> void
+LM.Core.Models.RegionExportFailed.ExporterId.get -> string!
+LM.Core.Models.RegionExportFailed.ExporterId.set -> void
+LM.Core.Models.RegionExportFailed.FailedUtc.get -> System.DateTime
+LM.Core.Models.RegionExportFailed.FailedUtc.set -> void
+LM.Core.Models.RegionExportFailed.IsRetryable.get -> bool
+LM.Core.Models.RegionExportFailed.IsRetryable.set -> void
+LM.Core.Models.RegionExportFailed.RegionExportFailed() -> void
+LM.Core.Models.RegionExportFailed.Request.get -> LM.Core.Models.RegionExportRequest!
+LM.Core.Models.RegionExportFailed.Request.set -> void
+LM.Core.Models.RegionExportRequest
+LM.Core.Models.RegionExportRequest.AllowCachedResult.get -> bool
+LM.Core.Models.RegionExportRequest.AllowCachedResult.set -> void
+LM.Core.Models.RegionExportRequest.EntryHubId.get -> string!
+LM.Core.Models.RegionExportRequest.EntryHubId.set -> void
+LM.Core.Models.RegionExportRequest.ExportOptions.get -> System.Collections.Generic.Dictionary<string!, string!>!
+LM.Core.Models.RegionExportRequest.ExporterId.get -> string!
+LM.Core.Models.RegionExportRequest.ExporterId.set -> void
+LM.Core.Models.RegionExportRequest.OfficeDestination.get -> string?
+LM.Core.Models.RegionExportRequest.OfficeDestination.set -> void
+LM.Core.Models.RegionExportRequest.RequestedBy.get -> string?
+LM.Core.Models.RegionExportRequest.RequestedBy.set -> void
+LM.Core.Models.RegionExportRequest.RequestedUtc.get -> System.DateTime
+LM.Core.Models.RegionExportRequest.RequestedUtc.set -> void
+LM.Core.Models.RegionExportRequest.RegionExportRequest() -> void
+LM.Core.Models.RegionExportRequest.Selection.get -> LM.Core.Models.RegionSelection!
+LM.Core.Models.RegionExportRequest.Selection.set -> void
+LM.Core.Models.RegionExportRequest.SourceMimeType.get -> string?
+LM.Core.Models.RegionExportRequest.SourceMimeType.set -> void
+LM.Core.Models.RegionExportRequest.SourceRelativePath.get -> string!
+LM.Core.Models.RegionExportRequest.SourceRelativePath.set -> void
+LM.Core.Models.RegionExportRequest.SourceSha256.get -> string?
+LM.Core.Models.RegionExportRequest.SourceSha256.set -> void
+LM.Core.Models.RegionExportResult
+LM.Core.Models.RegionExportResult.AdditionalOutputs.get -> System.Collections.Generic.Dictionary<string!, string!>!
+LM.Core.Models.RegionExportResult.CompletedUtc.get -> System.DateTime
+LM.Core.Models.RegionExportResult.CompletedUtc.set -> void
+LM.Core.Models.RegionExportResult.Descriptor.get -> LM.Core.Models.RegionDescriptor!
+LM.Core.Models.RegionExportResult.Descriptor.set -> void
+LM.Core.Models.RegionExportResult.Duration.get -> System.TimeSpan
+LM.Core.Models.RegionExportResult.Duration.set -> void
+LM.Core.Models.RegionExportResult.ExporterId.get -> string!
+LM.Core.Models.RegionExportResult.ExporterId.set -> void
+LM.Core.Models.RegionExportResult.ImagePath.get -> string!
+LM.Core.Models.RegionExportResult.ImagePath.set -> void
+LM.Core.Models.RegionExportResult.OfficePackagePath.get -> string?
+LM.Core.Models.RegionExportResult.OfficePackagePath.set -> void
+LM.Core.Models.RegionExportResult.OcrTextPath.get -> string?
+LM.Core.Models.RegionExportResult.OcrTextPath.set -> void
+LM.Core.Models.RegionExportResult.RegionExportResult() -> void
+LM.Core.Models.RegionExportResult.WasCached.get -> bool
+LM.Core.Models.RegionExportResult.WasCached.set -> void
+LM.Core.Models.RegionExportStatus
+LM.Core.Models.RegionExportStatus.Canceled = 4 -> LM.Core.Models.RegionExportStatus
+LM.Core.Models.RegionExportStatus.Completed = 2 -> LM.Core.Models.RegionExportStatus
+LM.Core.Models.RegionExportStatus.Failed = 3 -> LM.Core.Models.RegionExportStatus
+LM.Core.Models.RegionExportStatus.Pending = 1 -> LM.Core.Models.RegionExportStatus
+LM.Core.Models.RegionExportStatus.Unknown = 0 -> LM.Core.Models.RegionExportStatus
+LM.Core.Models.RegionPreview
+LM.Core.Models.RegionPreview.CacheKey.get -> string!
+LM.Core.Models.RegionPreview.CacheKey.set -> void
+LM.Core.Models.RegionPreview.DpiX.get -> double
+LM.Core.Models.RegionPreview.DpiX.set -> void
+LM.Core.Models.RegionPreview.DpiY.get -> double
+LM.Core.Models.RegionPreview.DpiY.set -> void
+LM.Core.Models.RegionPreview.FromCache.get -> bool
+LM.Core.Models.RegionPreview.FromCache.set -> void
+LM.Core.Models.RegionPreview.GeneratedUtc.get -> System.DateTime
+LM.Core.Models.RegionPreview.GeneratedUtc.set -> void
+LM.Core.Models.RegionPreview.PixelHeight.get -> int
+LM.Core.Models.RegionPreview.PixelHeight.set -> void
+LM.Core.Models.RegionPreview.PixelWidth.get -> int
+LM.Core.Models.RegionPreview.PixelWidth.set -> void
+LM.Core.Models.RegionPreview.PreviewPath.get -> string!
+LM.Core.Models.RegionPreview.PreviewPath.set -> void
+LM.Core.Models.RegionPreview.RegionPreview() -> void
+LM.Core.Models.RegionSelection
+LM.Core.Models.RegionSelection.Annotation.get -> string?
+LM.Core.Models.RegionSelection.Annotation.set -> void
+LM.Core.Models.RegionSelection.Bounds.get -> LM.Core.Models.RegionBounds!
+LM.Core.Models.RegionSelection.Bounds.set -> void
+LM.Core.Models.RegionSelection.Notes.get -> string?
+LM.Core.Models.RegionSelection.Notes.set -> void
+LM.Core.Models.RegionSelection.PageNumber.get -> int?
+LM.Core.Models.RegionSelection.PageNumber.set -> void
+LM.Core.Models.RegionSelection.RegionSelection() -> void
+LM.Core.Models.RegionSelection.RotationDegrees.get -> double
+LM.Core.Models.RegionSelection.RotationDegrees.set -> void
+LM.Core.Models.RegionSelection.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.RegionSelection.ZoomLevel.get -> double
+LM.Core.Models.RegionSelection.ZoomLevel.set -> void


### PR DESCRIPTION
## Summary
- introduce region-focused models (selection, descriptor, export request/result, preview, events, bounds, status) aligned with the visual extractor docs
- add core abstractions for exporters, previews, repository access, post-processing, and coordination
- record the new surface area in `PublicAPI.Unshipped.txt`

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d127f408c0832ba5a4e93afbbb92c0