### PR TITLE
Add drag-and-drop attachment support to Library view

### DIFF
--- a/docs/library-drag-drop-qa.md
+++ b/docs/library-drag-drop-qa.md
@@ -1,0 +1,26 @@
+# Library drag-and-drop QA
+
+## Prerequisites
+- Launch the WPF shell and choose a workspace with at least one entry.
+- Ensure the entry detail panel shows the target entry (click the row in the results grid).
+
+## Add attachments via drag & drop
+1. Open File Explorer and select one or more supported files (`.pdf`, `.doc`, `.docx`, `.ppt`, `.pptx`, `.txt`, `.md`).
+2. Drag the files onto the detail panel in the Library view.
+3. Expected: the drop cursor shows a **Copy** icon, the UI accepts the drop, and the attachments list refreshes with the new files.
+4. Confirm the workspace now contains hashed copies under `library/` and the entry JSON lists the new attachment paths.
+
+## Unsupported files
+1. Drag a file with an unsupported extension (e.g., `.exe`) onto the same detail panel.
+2. Expected: the drop cursor is disabled and the UI displays an informational message stating the file was skipped.
+3. Verify that no new attachment is added and the workspace is unchanged.
+
+## Duplicate handling
+1. Drag a file that has already been attached (or drop the same file twice).
+2. Expected: the UI skips the duplicate, reports that it was already attached, and the entry is not resaved (no timestamp change).
+
+## Error resilience
+- Temporarily make the workspace read-only (e.g., remove write permissions) and attempt another drop.
+- Expected: the app reports that the save failed and the attachment list remains unchanged after the failure.
+
+Document any deviations, including screenshots of message boxes, before marking the QA run complete.

--- a/src/LM.App.Wpf.Tests/LibraryViewModelFullTextTests.cs
+++ b/src/LM.App.Wpf.Tests/LibraryViewModelFullTextTests.cs
@@ -111,6 +111,92 @@ namespace LM.App.Wpf.Tests
             Assert.Same(entry, editor.LastEdited);
         }
 
+        [Fact]
+        public async Task HandleFileDropAsync_AddsAttachmentsAndSavesEntry()
+        {
+            using var temp = new TempWorkspace();
+            var store = new FakeEntryStore();
+            var entry = new Entry { Id = "drop-1", Title = "Doc" };
+            store.EntriesById[entry.Id] = entry;
+
+            var storage = new RecordingFileStorageRepository();
+            var vm = CreateViewModel(store, new FakeFullTextSearchService(), temp, storage: storage);
+            var result = new LibrarySearchResult(entry, null, null);
+            vm.Results.Add(result);
+            vm.Selected = result;
+
+            var filePath = Path.Combine(temp.RootPath, "notes.pdf");
+            File.WriteAllText(filePath, "demo");
+
+            await vm.HandleFileDropAsync(new[] { filePath });
+
+            Assert.Equal(1, store.SaveCallCount);
+            var savedEntry = store.EntriesById[entry.Id];
+            Assert.Single(savedEntry.Attachments);
+            var attachment = savedEntry.Attachments[0];
+            Assert.Equal(storage.SavedRelativePaths[0], attachment.RelativePath);
+            Assert.Equal(Path.Combine("attachments", entry.Id), storage.TargetDirs[0]);
+            Assert.Same(vm.Selected, vm.Results[0]);
+            Assert.NotSame(result, vm.Selected);
+            Assert.Contains(vm.Selected.Entry.Attachments, a => a.RelativePath == attachment.RelativePath);
+        }
+
+        [Fact]
+        public async Task HandleFileDropAsync_SkipsDuplicatesWhenRelativePathExists()
+        {
+            using var temp = new TempWorkspace();
+            var store = new FakeEntryStore();
+            var existingPath = Path.Combine("attachments", "dup-1", "notes.pdf");
+            var entry = new Entry
+            {
+                Id = "dup-1",
+                Title = "Doc",
+                Attachments = new List<Attachment>
+                {
+                    new Attachment { RelativePath = existingPath }
+                }
+            };
+            store.EntriesById[entry.Id] = entry;
+
+            var storage = new RecordingFileStorageRepository
+            {
+                PathFactory = _ => existingPath
+            };
+
+            var vm = CreateViewModel(store, new FakeFullTextSearchService(), temp, storage: storage);
+            vm.Selected = new LibrarySearchResult(entry, null, null);
+
+            var filePath = Path.Combine(temp.RootPath, "notes.pdf");
+            File.WriteAllText(filePath, "dup");
+
+            await vm.HandleFileDropAsync(new[] { filePath });
+
+            Assert.Equal(0, store.SaveCallCount);
+            Assert.Single(entry.Attachments);
+        }
+
+        [Fact]
+        public void CanAcceptFileDrop_RequiresSelectionAndSupportedFile()
+        {
+            using var temp = new TempWorkspace();
+            var store = new FakeEntryStore();
+            var storage = new RecordingFileStorageRepository();
+            var vm = CreateViewModel(store, new FakeFullTextSearchService(), temp, storage: storage);
+
+            var pdf = Path.Combine(temp.RootPath, "drop.pdf");
+            File.WriteAllText(pdf, "pdf");
+            var exe = Path.Combine(temp.RootPath, "run.exe");
+            File.WriteAllText(exe, "exe");
+
+            Assert.False(vm.CanAcceptFileDrop(new[] { pdf }));
+
+            var entry = new Entry { Id = "sel-1", Title = "Doc" };
+            vm.Selected = new LibrarySearchResult(entry, null, null);
+
+            Assert.True(vm.CanAcceptFileDrop(new[] { pdf }));
+            Assert.False(vm.CanAcceptFileDrop(new[] { exe }));
+        }
+
         private static async Task InvokeSearchAsync(LibraryViewModel vm)
         {
             var method = typeof(LibraryViewModel).GetMethod("SearchAsync", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -121,13 +207,15 @@ namespace LM.App.Wpf.Tests
         private static LibraryViewModel CreateViewModel(IEntryStore store,
                                                        IFullTextSearchService search,
                                                        TempWorkspace workspace,
-                                                       ILibraryEntryEditor? editor = null)
+                                                       ILibraryEntryEditor? editor = null,
+                                                       IFileStorageRepository? storage = null)
         {
             var ws = new TestWorkspaceService(workspace.RootPath);
             var presetStore = new LibraryFilterPresetStore(ws);
             var prompt = new StubPresetPrompt();
             editor ??= new NoopEntryEditor();
-            return new LibraryViewModel(store, search, ws, presetStore, prompt, editor);
+            storage ??= new RecordingFileStorageRepository();
+            return new LibraryViewModel(store, search, ws, storage, presetStore, prompt, editor);
         }
 
         private sealed class NoopEntryEditor : ILibraryEntryEditor
@@ -148,9 +236,18 @@ namespace LM.App.Wpf.Tests
 
             public Dictionary<string, Entry> EntriesById { get; } = new(StringComparer.OrdinalIgnoreCase);
 
+            public int SaveCallCount { get; private set; }
+
             public Task InitializeAsync(CancellationToken ct = default) => Task.CompletedTask;
 
-            public Task SaveAsync(Entry entry, CancellationToken ct = default) => throw new NotImplementedException();
+            public Task SaveAsync(Entry entry, CancellationToken ct = default)
+            {
+                SaveCallCount++;
+                if (string.IsNullOrWhiteSpace(entry.Id))
+                    throw new InvalidOperationException("Entry must have an identifier.");
+                EntriesById[entry.Id] = entry;
+                return Task.CompletedTask;
+            }
 
             public Task<Entry?> GetByIdAsync(string id, CancellationToken ct = default)
                 => Task.FromResult(EntriesById.TryGetValue(id, out var entry) ? entry : null);
@@ -174,6 +271,23 @@ namespace LM.App.Wpf.Tests
 
             public Task<Entry?> FindByIdsAsync(string? doi, string? pmid, CancellationToken ct = default)
                 => throw new NotImplementedException();
+        }
+
+        private sealed class RecordingFileStorageRepository : IFileStorageRepository
+        {
+            public List<string> TargetDirs { get; } = new();
+            public List<string> SavedRelativePaths { get; } = new();
+            public Func<string, string>? PathFactory { get; set; }
+
+            public Task<string> SaveNewAsync(string sourcePath, string relativeTargetDir, string? preferredFileName = null, CancellationToken ct = default)
+            {
+                TargetDirs.Add(relativeTargetDir);
+                var fileName = Path.GetFileName(sourcePath) ?? string.Empty;
+                var relative = PathFactory?.Invoke(sourcePath)
+                    ?? (string.IsNullOrEmpty(relativeTargetDir) ? fileName : Path.Combine(relativeTargetDir, fileName));
+                SavedRelativePaths.Add(relative);
+                return Task.FromResult(relative);
+            }
         }
 
         private sealed class FakeFullTextSearchService : IFullTextSearchService

--- a/src/LM.App.Wpf/App.xaml.cs
+++ b/src/LM.App.Wpf/App.xaml.cs
@@ -74,7 +74,7 @@ namespace LM.App.Wpf
             var presetStore = new LibraryFilterPresetStore(ws);
             var presetPrompt = new LibraryPresetPrompt();
             var entryEditor = new WorkspaceEntryEditor(ws);
-            var libraryVm = new LibraryViewModel(services.Store, services.FullTextSearch, ws, presetStore, presetPrompt, entryEditor);
+            var libraryVm = new LibraryViewModel(services.Store, services.FullTextSearch, ws, services.Storage, presetStore, presetPrompt, entryEditor);
             var addVm = new AddViewModel(services.Pipeline, ws, services.Scanner);
             await addVm.InitializeAsync();
             _addViewModel = addVm;

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -253,7 +253,7 @@ LM.App.Wpf.ViewModels.LibraryViewModel.InternalIdContains.set -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.IsInternal.get -> bool?
 LM.App.Wpf.ViewModels.LibraryViewModel.IsInternal.set -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.IsMetadataSearch.get -> bool
-LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.Core.Abstractions.IWorkSpaceService! ws, LM.App.Wpf.Library.LibraryFilterPresetStore! presetStore, LM.App.Wpf.Common.ILibraryPresetPrompt! presetPrompt, LM.App.Wpf.Library.ILibraryEntryEditor! entryEditor) -> void
+LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.Core.Abstractions.IWorkSpaceService! ws, LM.Core.Abstractions.IFileStorageRepository! storage, LM.App.Wpf.Library.LibraryFilterPresetStore! presetStore, LM.App.Wpf.Common.ILibraryPresetPrompt! presetPrompt, LM.App.Wpf.Library.ILibraryEntryEditor! entryEditor) -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.LoadPresetCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.LibraryViewModel.ManagePresetsCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.LibraryViewModel.NctContains.get -> string?

--- a/src/LM.App.Wpf/ViewModels/LibraryViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/LibraryViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -22,6 +23,7 @@ namespace LM.App.Wpf.ViewModels
         private readonly IEntryStore _store;
         private readonly IFullTextSearchService _fullTextSearch;
         private readonly IWorkSpaceService _ws;
+        private readonly IFileStorageRepository _storage;
         private readonly ILibraryEntryEditor _entryEditor;
         private readonly RelayCommand _editCommand;
         private LibrarySearchResult? _selected;
@@ -42,9 +44,15 @@ namespace LM.App.Wpf.ViewModels
         private bool _fullTextInContent = true;
         private bool _resultsAreFullText;
 
+        private static readonly HashSet<string> s_supportedAttachmentExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ".pdf", ".doc", ".docx", ".ppt", ".pptx", ".txt", ".md"
+        };
+
         public LibraryViewModel(IEntryStore store,
                                 IFullTextSearchService fullTextSearch,
                                 IWorkSpaceService ws,
+                                IFileStorageRepository storage,
                                 LibraryFilterPresetStore presetStore,
                                 ILibraryPresetPrompt presetPrompt,
                                 ILibraryEntryEditor entryEditor)
@@ -52,6 +60,7 @@ namespace LM.App.Wpf.ViewModels
             _store = store;
             _fullTextSearch = fullTextSearch ?? throw new ArgumentNullException(nameof(fullTextSearch));
             _ws = ws;
+            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
             _presetStore = presetStore ?? throw new ArgumentNullException(nameof(presetStore));
             _presetPrompt = presetPrompt ?? throw new ArgumentNullException(nameof(presetPrompt));
             _entryEditor = entryEditor ?? throw new ArgumentNullException(nameof(entryEditor));
@@ -504,6 +513,217 @@ $"YearFrom={filter.YearFrom}, YearTo={filter.YearTo}, IsInternal={filter.IsInter
                     System.Windows.MessageBoxImage.Error);
             }
         }
+
+        internal bool CanAcceptFileDrop(IEnumerable<string>? filePaths)
+        {
+            if (Selected?.Entry is null || filePaths is null)
+                return false;
+
+            foreach (var path in filePaths)
+            {
+                if (string.IsNullOrWhiteSpace(path))
+                    continue;
+                if (!File.Exists(path))
+                    continue;
+                if (IsSupportedAttachment(path))
+                    return true;
+            }
+
+            return false;
+        }
+
+        internal async Task HandleFileDropAsync(IEnumerable<string>? filePaths)
+        {
+            var selectedResult = Selected;
+            var entry = selectedResult?.Entry;
+            if (entry is null)
+            {
+                System.Windows.MessageBox.Show(
+                    "Select an entry before adding attachments.",
+                    "Add Attachments",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Information);
+                return;
+            }
+
+            if (filePaths is null)
+                return;
+
+            var normalized = filePaths
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .Select(p => p!.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Where(File.Exists)
+                .ToList();
+
+            if (normalized.Count == 0)
+                return;
+
+            var unsupported = new List<string>();
+            var candidates = new List<string>();
+
+            foreach (var path in normalized)
+            {
+                if (IsSupportedAttachment(path))
+                    candidates.Add(path);
+                else
+                    unsupported.Add(DisplayNameForPath(path));
+            }
+
+            if (candidates.Count == 0)
+            {
+                if (unsupported.Count > 0)
+                {
+                    System.Windows.MessageBox.Show(
+                        "Unsupported file types were skipped:\n" + string.Join(Environment.NewLine, unsupported),
+                        "Add Attachments",
+                        System.Windows.MessageBoxButton.OK,
+                        System.Windows.MessageBoxImage.Information);
+                }
+
+                return;
+            }
+
+            var entryId = entry.Id;
+            if (string.IsNullOrWhiteSpace(entryId))
+            {
+                System.Windows.MessageBox.Show(
+                    "The selected entry is missing an identifier and cannot receive attachments.",
+                    "Add Attachments",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+                return;
+            }
+
+            var attachments = entry.Attachments ??= new List<Attachment>();
+            var existing = new HashSet<string>(attachments.Select(a => a.RelativePath), StringComparer.OrdinalIgnoreCase);
+            var duplicates = new List<string>();
+            var failures = new List<string>();
+            var added = new List<Attachment>();
+            var targetDir = Path.Combine("attachments", entryId);
+
+            foreach (var path in candidates)
+            {
+                try
+                {
+                    var relative = await _storage.SaveNewAsync(path, targetDir);
+                    if (!existing.Add(relative))
+                    {
+                        duplicates.Add(DisplayNameForPath(path));
+                        continue;
+                    }
+
+                    var attachment = new Attachment { RelativePath = relative };
+                    attachments.Add(attachment);
+                    added.Add(attachment);
+                }
+                catch (Exception ex)
+                {
+                    failures.Add($"{DisplayNameForPath(path)} — {ex.Message}");
+                }
+            }
+
+            if (added.Count == 0)
+            {
+                ShowDropWarnings(unsupported, duplicates, failures);
+                return;
+            }
+
+            try
+            {
+                await _store.SaveAsync(entry);
+            }
+            catch (Exception ex)
+            {
+                foreach (var attachment in added)
+                    attachments.Remove(attachment);
+
+                System.Windows.MessageBox.Show(
+                    $"Failed to save entry with new attachments:\n{ex.Message}",
+                    "Add Attachments",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+                return;
+            }
+
+            await RefreshSelectedEntryAsync(selectedResult, entryId);
+
+            ShowDropWarnings(unsupported, duplicates, failures);
+        }
+
+
+        private static bool IsSupportedAttachment(string path)
+        {
+            var ext = Path.GetExtension(path);
+            return !string.IsNullOrWhiteSpace(ext) && s_supportedAttachmentExtensions.Contains(ext);
+        }
+
+        private static string DisplayNameForPath(string path)
+        {
+            var name = Path.GetFileName(path);
+            return string.IsNullOrWhiteSpace(name) ? path : name!;
+        }
+
+        private static void ShowDropWarnings(IReadOnlyCollection<string> unsupported,
+                                             IReadOnlyCollection<string> duplicates,
+                                             IReadOnlyCollection<string> failures)
+        {
+            if (unsupported.Count == 0 && duplicates.Count == 0 && failures.Count == 0)
+                return;
+
+            var sections = new List<string>();
+
+            if (unsupported.Count > 0)
+                sections.Add("Unsupported files:\n" + string.Join(Environment.NewLine, unsupported));
+
+            if (duplicates.Count > 0)
+                sections.Add("Already attached:\n" + string.Join(Environment.NewLine, duplicates));
+
+            if (failures.Count > 0)
+                sections.Add("Failed to add:\n" + string.Join(Environment.NewLine, failures));
+
+            var icon = failures.Count > 0
+                ? System.Windows.MessageBoxImage.Warning
+                : System.Windows.MessageBoxImage.Information;
+
+            System.Windows.MessageBox.Show(
+                string.Join(Environment.NewLine + Environment.NewLine, sections),
+                "Add Attachments",
+                System.Windows.MessageBoxButton.OK,
+                icon);
+        }
+
+        private async Task RefreshSelectedEntryAsync(LibrarySearchResult? previous, string entryId)
+        {
+            try
+            {
+                var updated = await _store.GetByIdAsync(entryId);
+                if (updated is null)
+                    return;
+
+                PrepareEntry(updated);
+
+                LibrarySearchResult newResult;
+                if (previous is not null)
+                {
+                    newResult = new LibrarySearchResult(updated, previous.Score, previous.Highlight);
+                    var index = Results.IndexOf(previous);
+                    if (index >= 0)
+                        Results[index] = newResult;
+                }
+                else
+                {
+                    newResult = new LibrarySearchResult(updated, null, null);
+                }
+
+                Selected = newResult;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[LibraryViewModel] RefreshSelectedEntryAsync failed: {ex}");
+            }
+        }
+
 
         private async Task SavePresetAsync()
         {

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -184,7 +184,10 @@
                   Width="5"/>
 
     <Border Grid.Column="3" BorderBrush="#FFE0E0E0" BorderThickness="1,0,0,0" Background="#FFFDFDFD">
-      <ScrollViewer VerticalScrollBarVisibility="Auto">
+      <ScrollViewer VerticalScrollBarVisibility="Auto"
+                    AllowDrop="True"
+                    DragOver="LibraryDetailDragOver"
+                    Drop="LibraryDetailDrop">
         <Grid>
 
           <ContentPresenter x:Name="EntryDetailPresenter"

--- a/src/LM.App.Wpf/Views/LibraryView.xaml.cs
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml.cs
@@ -1,7 +1,62 @@
+using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+using LM.App.Wpf.ViewModels;
+
 namespace LM.App.Wpf.Views
 {
-    public partial class LibraryView : System.Windows.Controls.UserControl
+    public partial class LibraryView : UserControl
     {
         public LibraryView() { InitializeComponent(); }
+
+        private void LibraryDetailDragOver(object sender, DragEventArgs e)
+        {
+            if (DataContext is not LibraryViewModel vm || !TryGetFilePaths(e, out var paths) || !vm.CanAcceptFileDrop(paths))
+            {
+                e.Effects = DragDropEffects.None;
+            }
+            else
+            {
+                e.Effects = DragDropEffects.Copy;
+            }
+
+            e.Handled = true;
+        }
+
+        private async void LibraryDetailDrop(object sender, DragEventArgs e)
+        {
+            if (DataContext is not LibraryViewModel vm || !TryGetFilePaths(e, out var paths))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            e.Handled = true;
+
+            try
+            {
+                await vm.HandleFileDropAsync(paths);
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[LibraryView] Drop failed: {ex}");
+            }
+        }
+
+        private static bool TryGetFilePaths(DragEventArgs e, out string[] paths)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                if (e.Data.GetData(DataFormats.FileDrop) is string[] files)
+                {
+                    paths = files;
+                    return true;
+                }
+            }
+
+            paths = Array.Empty<string>();
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- inject the file storage service into `LibraryViewModel` and add logic to persist dropped files as attachments
- wire up drag-and-drop events in `LibraryView` so dropped files flow to the view-model and refresh the detail panel
- extend unit coverage for the new drop handler and add manual QA guidance for drag/drop scenarios

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d144779420832bae03a28c64a401f2