### PR TITLE
Implement SQLite extraction repository and schema bootstrapper

### DIFF
--- a/src/LM.HubAndSpoke/Entries/HubSpokeStore.cs
+++ b/src/LM.HubAndSpoke/Entries/HubSpokeStore.cs
@@ -5,6 +5,7 @@ using LM.Core.Models.Filters;
 using LM.Core.Utils;
 using LM.HubSpoke.Abstractions;
 using LM.HubSpoke.FileSystem;
+using LM.HubSpoke.Extraction;
 using LM.HubSpoke.Hubs;
 using LM.HubSpoke.Indexing;
 using LM.HubSpoke.Storage;
@@ -81,6 +82,7 @@ namespace LM.HubSpoke.Entries
         public async Task InitializeAsync(CancellationToken ct = default)
         {
             WorkspaceLayout.Ensure(_ws);
+            await ExtractionSchemaBootstrapper.EnsureAsync(_ws, ct);
             await _index.InitializeAsync(ct);
         }
 

--- a/src/LM.HubAndSpoke/Extraction/ExtractionSchemaBootstrapper.cs
+++ b/src/LM.HubAndSpoke/Extraction/ExtractionSchemaBootstrapper.cs
@@ -1,0 +1,114 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Abstractions;
+using Microsoft.Data.Sqlite;
+
+namespace LM.HubSpoke.Extraction
+{
+    public static class ExtractionSchemaBootstrapper
+    {
+        private const string DescriptorTableSql = @"
+CREATE TABLE IF NOT EXISTS region_descriptor (
+    region_hash TEXT PRIMARY KEY,
+    entry_hub_id TEXT NOT NULL,
+    source_rel_path TEXT NOT NULL,
+    source_sha256 TEXT,
+    page_number INTEGER,
+    bounds TEXT NOT NULL,
+    ocr_text TEXT,
+    tags TEXT,
+    notes TEXT,
+    annotation TEXT,
+    created_utc TEXT NOT NULL,
+    updated_utc TEXT,
+    last_export_status TEXT NOT NULL,
+    last_error_message TEXT,
+    office_package_path TEXT,
+    image_path TEXT,
+    ocr_text_path TEXT,
+    exporter_id TEXT,
+    extra_metadata TEXT
+);";
+
+        private const string DescriptorIndexesSql = @"
+CREATE INDEX IF NOT EXISTS idx_region_descriptor_entry ON region_descriptor(entry_hub_id);
+CREATE INDEX IF NOT EXISTS idx_region_descriptor_created ON region_descriptor(created_utc);
+CREATE INDEX IF NOT EXISTS idx_region_descriptor_updated ON region_descriptor(updated_utc);
+";
+
+        private const string RecentSessionTableSql = @"
+CREATE TABLE IF NOT EXISTS region_recent_session (
+    session_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    region_hash TEXT NOT NULL,
+    completed_utc TEXT NOT NULL,
+    duration_ms INTEGER,
+    was_cached INTEGER,
+    additional_outputs TEXT,
+    UNIQUE(region_hash, completed_utc)
+);";
+
+        private const string RecentSessionIndexesSql = @"
+CREATE INDEX IF NOT EXISTS idx_region_recent_session_hash ON region_recent_session(region_hash);
+CREATE INDEX IF NOT EXISTS idx_region_recent_session_completed ON region_recent_session(completed_utc);
+";
+
+        public static async Task EnsureAsync(IWorkSpaceService workspace, CancellationToken cancellationToken = default)
+        {
+            if (workspace is null) throw new ArgumentNullException(nameof(workspace));
+
+            var dbPath = workspace.GetLocalDbPath();
+            var directory = Path.GetDirectoryName(dbPath);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            await using var connection = new SqliteConnection($"Data Source={dbPath};Mode=ReadWriteCreate;Cache=Shared;");
+            await connection.OpenAsync(cancellationToken);
+
+            await using (var pragma = connection.CreateCommand())
+            {
+                pragma.CommandText = "PRAGMA journal_mode=WAL;";
+                await pragma.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await ExecuteAsync(connection, DescriptorTableSql, cancellationToken);
+            await ExecuteAsync(connection, DescriptorIndexesSql, cancellationToken);
+            await ExecuteAsync(connection, RecentSessionTableSql, cancellationToken);
+            await ExecuteAsync(connection, RecentSessionIndexesSql, cancellationToken);
+            await EnsureFtsTableAsync(connection, cancellationToken);
+        }
+
+        private static async Task ExecuteAsync(SqliteConnection connection, string sql, CancellationToken cancellationToken)
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        private static async Task EnsureFtsTableAsync(SqliteConnection connection, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await using var command = connection.CreateCommand();
+                command.CommandText = @"
+CREATE VIRTUAL TABLE region_descriptor_fts USING fts5(
+    region_hash UNINDEXED,
+    entry_hub_id UNINDEXED,
+    source_rel_path UNINDEXED,
+    ocr_text,
+    notes,
+    annotation,
+    tags
+);";
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+            catch (SqliteException ex) when (
+                ex.SqliteErrorCode == 1 &&
+                ex.Message.IndexOf("already exists", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                // Table already exists; nothing to do.
+            }
+        }
+    }
+}

--- a/src/LM.HubAndSpoke/Filesystem/WorkspaceLayout.cs
+++ b/src/LM.HubAndSpoke/Filesystem/WorkspaceLayout.cs
@@ -17,6 +17,20 @@ namespace LM.HubSpoke.FileSystem
         public static string StorageRoot(IWorkSpaceService ws) => Path.Combine(ws.GetWorkspaceRoot(), "library");
         public static string ExtractionRoot(IWorkSpaceService ws) => Path.Combine(ws.GetWorkspaceRoot(), "extraction");
 
+        public static string ExtractionDescriptorPath(IWorkSpaceService ws, string regionHash)
+        {
+            var bucket = ExtractionBucket(ws, regionHash);
+            return Path.Combine(bucket, $"{NormalizeHash(regionHash)}.json");
+        }
+
+        public static string ExtractionBucket(IWorkSpaceService ws, string regionHash)
+        {
+            var hash = NormalizeHash(regionHash);
+            var first = Segment(hash, 0);
+            var second = Segment(hash, 2);
+            return Path.Combine(ExtractionRoot(ws), first, second);
+        }
+
         public static string EntryDir(IWorkSpaceService ws, string id) => Path.Combine(EntriesRoot(ws), id);
 
         public static string HubPath(IWorkSpaceService ws, string id) => Path.Combine(EntryDir(ws, id), "hub.json");
@@ -24,5 +38,18 @@ namespace LM.HubSpoke.FileSystem
         public static string DocumentHookPath(IWorkSpaceService ws, string id) => Path.Combine(EntryDir(ws, id), "hooks", "document.json");
         public static string LitSearchHookPath(IWorkSpaceService ws, string id) => Path.Combine(EntryDir(ws, id), "hooks", "litsearch.json");
         public static string NotesHookPath(IWorkSpaceService ws, string id) => Path.Combine(EntryDir(ws, id), "hooks", "notes.json");
+
+        private static string NormalizeHash(string regionHash)
+            => (regionHash ?? string.Empty).Trim().ToLowerInvariant();
+
+        private static string Segment(string hash, int start)
+        {
+            if (hash.Length <= start)
+                return "00";
+
+            var length = System.Math.Min(2, hash.Length - start);
+            var segment = hash.Substring(start, length);
+            return segment.PadRight(2, '0');
+        }
     }
 }

--- a/src/LM.HubAndSpoke/Properties/AssemblyInfo.cs
+++ b/src/LM.HubAndSpoke/Properties/AssemblyInfo.cs
@@ -1,3 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("LM.HubSpoke.Tests")]
+
+[assembly: InternalsVisibleTo("LM.Infrastructure")]

--- a/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
+++ b/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+LM.HubSpoke.Extraction.ExtractionSchemaBootstrapper
+LM.HubSpoke.Extraction.ExtractionSchemaBootstrapper.EnsureAsync(LM.Core.Abstractions.IWorkSpaceService! workspace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.HubSpoke.Abstractions.CasResult
 LM.HubSpoke.Abstractions.CasResult.Bytes.get -> long
 LM.HubSpoke.Abstractions.CasResult.Bytes.init -> void

--- a/src/LM.Infrastructure.Tests/SqliteExtractionRepositoryTests.cs
+++ b/src/LM.Infrastructure.Tests/SqliteExtractionRepositoryTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using LM.Core.Models;
+using LM.Infrastructure.Extraction;
+using LM.Infrastructure.FileSystem;
+using Xunit;
+
+namespace LM.Infrastructure.Tests
+{
+    public sealed class SqliteExtractionRepositoryTests : IDisposable
+    {
+        private readonly string _workspaceRoot;
+        private readonly WorkspaceService _workspace;
+        private readonly SqliteExtractionRepository _repository;
+
+        public SqliteExtractionRepositoryTests()
+        {
+            _workspaceRoot = Path.Combine(Path.GetTempPath(), "kw-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_workspaceRoot);
+
+            _workspace = new WorkspaceService();
+            _workspace.EnsureWorkspaceAsync(_workspaceRoot).GetAwaiter().GetResult();
+            _repository = new SqliteExtractionRepository(_workspace);
+        }
+
+        [Fact]
+        public async Task UpsertAndGetAsync_Roundtrip()
+        {
+            var descriptor = CreateDescriptor();
+
+            await _repository.UpsertAsync(descriptor);
+            var fetched = await _repository.GetAsync(descriptor.RegionHash);
+
+            Assert.NotNull(fetched);
+            Assert.Equal(descriptor.RegionHash, fetched!.RegionHash);
+            Assert.Equal(descriptor.EntryHubId, fetched.EntryHubId);
+            Assert.Equal(descriptor.Bounds.Width, fetched.Bounds.Width);
+            Assert.Contains("tag1", fetched.Tags);
+        }
+
+        [Fact]
+        public async Task SearchAsync_FindsDescriptorByOcr()
+        {
+            var descriptor = CreateDescriptor();
+            descriptor.OcrText = "alpha beta gamma";
+
+            await _repository.UpsertAsync(descriptor);
+
+            var hits = await _repository.SearchAsync("alpha", 5);
+
+            Assert.Single(hits);
+            Assert.Equal(descriptor.RegionHash, hits[0].RegionHash);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_RemovesArtifacts()
+        {
+            var descriptor = CreateDescriptor();
+
+            await _repository.UpsertAsync(descriptor);
+
+            CreateWorkspaceFile(descriptor.ImagePath!);
+            CreateWorkspaceFile(descriptor.OcrTextPath!);
+            CreateWorkspaceFile(descriptor.OfficePackagePath!);
+
+            var descriptorJson = GetDescriptorJsonPath(descriptor.RegionHash);
+            Assert.True(File.Exists(descriptorJson));
+
+            await _repository.DeleteAsync(descriptor.RegionHash);
+
+            Assert.Null(await _repository.GetAsync(descriptor.RegionHash));
+            Assert.False(File.Exists(descriptorJson));
+            Assert.False(File.Exists(_workspace.GetAbsolutePath(descriptor.ImagePath!)));
+            Assert.False(File.Exists(_workspace.GetAbsolutePath(descriptor.OcrTextPath!)));
+            Assert.False(File.Exists(_workspace.GetAbsolutePath(descriptor.OfficePackagePath!)));
+        }
+
+        [Fact]
+        public async Task SaveSessionAsync_PersistsRecentSession()
+        {
+            var descriptor = CreateDescriptor();
+
+            await _repository.UpsertAsync(descriptor);
+
+            var result = new RegionExportResult
+            {
+                Descriptor = descriptor,
+                ExporterId = descriptor.ExporterId ?? "test",
+                ImagePath = descriptor.ImagePath ?? string.Empty,
+                OcrTextPath = descriptor.OcrTextPath,
+                OfficePackagePath = descriptor.OfficePackagePath,
+                WasCached = true,
+                Duration = TimeSpan.FromMilliseconds(150),
+                CompletedUtc = DateTime.UtcNow
+            };
+
+            await _repository.SaveSessionAsync(result);
+
+            var sessions = await _repository.GetRecentSessionsAsync(5);
+            Assert.NotEmpty(sessions);
+            Assert.Equal(descriptor.RegionHash, sessions[0].Descriptor.RegionHash);
+            Assert.True(sessions[0].WasCached);
+            Assert.Equal(TimeSpan.FromMilliseconds(150), sessions[0].Duration);
+
+            var recentDescriptors = await _repository.GetRecentAsync(5);
+            Assert.Contains(recentDescriptors, d => d.RegionHash == descriptor.RegionHash);
+        }
+
+        private RegionDescriptor CreateDescriptor()
+        {
+            var hash = Guid.NewGuid().ToString("N");
+            var bucket = Bucket(hash);
+
+            var descriptor = new RegionDescriptor
+            {
+                RegionHash = hash,
+                EntryHubId = "entry-123",
+                SourceRelativePath = "library/sample.pdf",
+                SourceSha256 = Guid.NewGuid().ToString("N"),
+                PageNumber = 1,
+                Bounds = new RegionBounds { X = 10, Y = 20, Width = 300, Height = 150 },
+                OcrText = "lorem ipsum",
+                Notes = "note",
+                Annotation = "annotation",
+                CreatedUtc = DateTime.UtcNow,
+                UpdatedUtc = DateTime.UtcNow,
+                LastExportStatus = RegionExportStatus.Completed,
+                ImagePath = Path.Combine("extraction", bucket.Item1, bucket.Item2, hash + ".png"),
+                OcrTextPath = Path.Combine("extraction", bucket.Item1, bucket.Item2, hash + ".txt"),
+                OfficePackagePath = Path.Combine("extraction", bucket.Item1, bucket.Item2, hash + ".ppmx"),
+                ExporterId = "exporter-test"
+            };
+            descriptor.Tags.AddRange(new[] { "tag1", "tag2" });
+            descriptor.ExtraMetadata["foo"] = "bar";
+            return descriptor;
+        }
+
+        private void CreateWorkspaceFile(string relativePath)
+        {
+            var absolute = _workspace.GetAbsolutePath(relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(absolute)!);
+            File.WriteAllText(absolute, "test");
+        }
+
+        private string GetDescriptorJsonPath(string regionHash)
+        {
+            var (first, second) = Bucket(regionHash);
+            return Path.Combine(_workspace.GetWorkspaceRoot(), "extraction", first, second, regionHash.ToLowerInvariant() + ".json");
+        }
+
+        private static (string, string) Bucket(string regionHash)
+        {
+            var normalized = (regionHash ?? string.Empty).Trim().ToLowerInvariant();
+            var first = normalized.Length >= 2 ? normalized.Substring(0, 2) : normalized.PadRight(2, '0');
+            var second = normalized.Length >= 4 ? normalized.Substring(2, 2) : normalized.Length > 2 ? normalized.Substring(2).PadRight(2, '0') : "00";
+            return (first, second);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(_workspaceRoot))
+                    Directory.Delete(_workspaceRoot, recursive: true);
+            }
+            catch
+            {
+                // ignore cleanup failures
+            }
+        }
+    }
+
+    internal static class RegionDescriptorExtensions
+    {
+        public static void AddRange(this IList<string> list, IEnumerable<string> values)
+        {
+            foreach (var value in values)
+                list.Add(value);
+        }
+    }
+}

--- a/src/LM.Infrastructure/Extraction/RegionDescriptorMapper.cs
+++ b/src/LM.Infrastructure/Extraction/RegionDescriptorMapper.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LM.Core.Models;
+using Microsoft.Data.Sqlite;
+
+namespace LM.Infrastructure.Extraction
+{
+    internal static class RegionDescriptorMapper
+    {
+        private const string ErrorMetadataKey = "last_error_message";
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = false,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        private static readonly JsonSerializerOptions FileJsonOptions = new(JsonOptions)
+        {
+            WriteIndented = true
+        };
+
+        public static void BindDescriptor(SqliteCommand command, RegionDescriptor descriptor)
+        {
+            if (command is null) throw new ArgumentNullException(nameof(command));
+            if (descriptor is null) throw new ArgumentNullException(nameof(descriptor));
+
+            command.Parameters.AddWithValue("$hash", descriptor.RegionHash);
+            command.Parameters.AddWithValue("$entry", descriptor.EntryHubId);
+            command.Parameters.AddWithValue("$source", descriptor.SourceRelativePath);
+            command.Parameters.AddWithValue("$sourceSha", (object?)descriptor.SourceSha256 ?? DBNull.Value);
+            command.Parameters.AddWithValue("$page", descriptor.PageNumber.HasValue ? descriptor.PageNumber.Value : DBNull.Value);
+            command.Parameters.AddWithValue("$bounds", SerializeBounds(descriptor.Bounds));
+            command.Parameters.AddWithValue("$ocr", (object?)descriptor.OcrText ?? DBNull.Value);
+            command.Parameters.AddWithValue("$tags", (object?)SerializeTags(descriptor.Tags) ?? DBNull.Value);
+            command.Parameters.AddWithValue("$notes", (object?)descriptor.Notes ?? DBNull.Value);
+            command.Parameters.AddWithValue("$annotation", (object?)descriptor.Annotation ?? DBNull.Value);
+            command.Parameters.AddWithValue("$created", FormatDateTime(descriptor.CreatedUtc));
+            command.Parameters.AddWithValue("$updated", descriptor.UpdatedUtc is null ? DBNull.Value : FormatDateTime(descriptor.UpdatedUtc.Value));
+            command.Parameters.AddWithValue("$status", descriptor.LastExportStatus.ToString());
+            command.Parameters.AddWithValue("$error", (object?)GetErrorMessage(descriptor) ?? DBNull.Value);
+            command.Parameters.AddWithValue("$office", (object?)descriptor.OfficePackagePath ?? DBNull.Value);
+            command.Parameters.AddWithValue("$image", (object?)descriptor.ImagePath ?? DBNull.Value);
+            command.Parameters.AddWithValue("$ocrPath", (object?)descriptor.OcrTextPath ?? DBNull.Value);
+            command.Parameters.AddWithValue("$exporter", (object?)descriptor.ExporterId ?? DBNull.Value);
+            command.Parameters.AddWithValue("$metadata", (object?)SerializeMetadata(descriptor.ExtraMetadata) ?? DBNull.Value);
+        }
+
+        public static RegionDescriptor ReadDescriptor(SqliteDataReader reader)
+        {
+            if (reader is null) throw new ArgumentNullException(nameof(reader));
+
+            var descriptor = new RegionDescriptor
+            {
+                RegionHash = reader.GetString(reader.GetOrdinal("region_hash")),
+                EntryHubId = reader.GetString(reader.GetOrdinal("entry_hub_id")),
+                SourceRelativePath = reader.GetString(reader.GetOrdinal("source_rel_path")),
+                SourceSha256 = reader.IsDBNull(reader.GetOrdinal("source_sha256")) ? null : reader.GetString(reader.GetOrdinal("source_sha256")),
+                PageNumber = reader.IsDBNull(reader.GetOrdinal("page_number")) ? null : reader.GetInt32(reader.GetOrdinal("page_number")),
+                Bounds = DeserializeBounds(reader.IsDBNull(reader.GetOrdinal("bounds")) ? null : reader.GetString(reader.GetOrdinal("bounds"))),
+                OcrText = reader.IsDBNull(reader.GetOrdinal("ocr_text")) ? null : reader.GetString(reader.GetOrdinal("ocr_text")),
+                Notes = reader.IsDBNull(reader.GetOrdinal("notes")) ? null : reader.GetString(reader.GetOrdinal("notes")),
+                Annotation = reader.IsDBNull(reader.GetOrdinal("annotation")) ? null : reader.GetString(reader.GetOrdinal("annotation")),
+                CreatedUtc = ParseDateTime(reader.GetString(reader.GetOrdinal("created_utc"))),
+                UpdatedUtc = reader.IsDBNull(reader.GetOrdinal("updated_utc")) ? null : ParseDateTime(reader.GetString(reader.GetOrdinal("updated_utc"))),
+                LastExportStatus = ParseStatus(reader.GetString(reader.GetOrdinal("last_export_status"))),
+                OfficePackagePath = reader.IsDBNull(reader.GetOrdinal("office_package_path")) ? null : reader.GetString(reader.GetOrdinal("office_package_path")),
+                ImagePath = reader.IsDBNull(reader.GetOrdinal("image_path")) ? null : reader.GetString(reader.GetOrdinal("image_path")),
+                OcrTextPath = reader.IsDBNull(reader.GetOrdinal("ocr_text_path")) ? null : reader.GetString(reader.GetOrdinal("ocr_text_path")),
+                ExporterId = reader.IsDBNull(reader.GetOrdinal("exporter_id")) ? null : reader.GetString(reader.GetOrdinal("exporter_id"))
+            };
+
+            foreach (var tag in DeserializeTags(reader.IsDBNull(reader.GetOrdinal("tags")) ? null : reader.GetString(reader.GetOrdinal("tags"))))
+                descriptor.Tags.Add(tag);
+
+            foreach (var kv in DeserializeDictionary(reader.IsDBNull(reader.GetOrdinal("extra_metadata")) ? null : reader.GetString(reader.GetOrdinal("extra_metadata"))))
+                descriptor.ExtraMetadata[kv.Key] = kv.Value;
+
+            var error = reader.IsDBNull(reader.GetOrdinal("last_error_message")) ? null : reader.GetString(reader.GetOrdinal("last_error_message"));
+            if (!string.IsNullOrWhiteSpace(error))
+                descriptor.ExtraMetadata[ErrorMetadataKey] = error;
+
+            return descriptor;
+        }
+
+        public static RegionExportResult ReadExportResult(SqliteDataReader reader)
+        {
+            var descriptor = ReadDescriptor(reader);
+            var result = new RegionExportResult
+            {
+                Descriptor = descriptor,
+                ExporterId = descriptor.ExporterId ?? string.Empty,
+                ImagePath = descriptor.ImagePath ?? string.Empty,
+                OcrTextPath = descriptor.OcrTextPath,
+                OfficePackagePath = descriptor.OfficePackagePath,
+                WasCached = reader.TryGetBoolean("session_was_cached") ?? false,
+                Duration = TimeSpan.FromMilliseconds(reader.TryGetInt64("session_duration_ms") ?? 0),
+                CompletedUtc = reader.TryGetDateTime("session_completed_utc") ?? descriptor.UpdatedUtc ?? descriptor.CreatedUtc
+            };
+
+            foreach (var kv in DeserializeDictionary(reader.TryGetString("session_additional_outputs")))
+                result.AdditionalOutputs[kv.Key] = kv.Value;
+
+            return result;
+        }
+
+        public static string FormatDateTime(DateTime value)
+        {
+            var utc = value.Kind == DateTimeKind.Utc ? value : value.ToUniversalTime();
+            return utc.ToString("yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'", CultureInfo.InvariantCulture);
+        }
+
+        public static string SerializeDescriptor(RegionDescriptor descriptor)
+        {
+            if (descriptor is null) throw new ArgumentNullException(nameof(descriptor));
+            return JsonSerializer.Serialize(descriptor, FileJsonOptions);
+        }
+
+        public static string? SerializeAdditionalOutputs(IReadOnlyDictionary<string, string> outputs)
+        {
+            if (outputs is null || outputs.Count == 0)
+                return null;
+            return JsonSerializer.Serialize(outputs, JsonOptions);
+        }
+
+        public static IEnumerable<string> DeserializeTags(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) yield break;
+            try
+            {
+                var tags = JsonSerializer.Deserialize<string[]>(json, JsonOptions) ?? Array.Empty<string>();
+                foreach (var tag in tags)
+                {
+                    if (string.IsNullOrWhiteSpace(tag)) continue;
+                    yield return tag.Trim();
+                }
+            }
+            catch
+            {
+                yield break;
+            }
+        }
+
+        public static IDictionary<string, string> DeserializeDictionary(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                return JsonSerializer.Deserialize<Dictionary<string, string>>(json, JsonOptions)
+                       ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        public static DateTime ParseDateTime(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return DateTime.UtcNow;
+            if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var dt))
+                return dt;
+            return DateTime.SpecifyKind(DateTime.Parse(value, CultureInfo.InvariantCulture), DateTimeKind.Utc);
+        }
+
+        private static RegionBounds DeserializeBounds(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return new RegionBounds();
+            try
+            {
+                var values = JsonSerializer.Deserialize<double[]>(json, JsonOptions);
+                if (values is { Length: 4 })
+                {
+                    return new RegionBounds
+                    {
+                        X = values[0],
+                        Y = values[1],
+                        Width = values[2],
+                        Height = values[3]
+                    };
+                }
+            }
+            catch
+            {
+                // fall through
+            }
+            return new RegionBounds();
+        }
+
+        private static string SerializeBounds(RegionBounds? bounds)
+        {
+            bounds ??= new RegionBounds();
+            var data = new[] { bounds.X, bounds.Y, bounds.Width, bounds.Height };
+            return JsonSerializer.Serialize(data, JsonOptions);
+        }
+
+        private static string? SerializeTags(IReadOnlyCollection<string> tags)
+        {
+            if (tags is not { Count: > 0 })
+                return null;
+
+            var normalized = tags
+                .Where(t => !string.IsNullOrWhiteSpace(t))
+                .Select(t => t.Trim())
+                .Where(t => t.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (normalized.Length == 0)
+                return null;
+
+            return JsonSerializer.Serialize(normalized, JsonOptions);
+        }
+
+        private static string? SerializeMetadata(IReadOnlyDictionary<string, string> metadata)
+        {
+            if (metadata is null || metadata.Count == 0)
+                return null;
+
+            var filtered = metadata
+                .Where(kv => !string.Equals(kv.Key, ErrorMetadataKey, StringComparison.OrdinalIgnoreCase))
+                .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
+
+            return filtered.Count == 0 ? null : JsonSerializer.Serialize(filtered, JsonOptions);
+        }
+
+        private static RegionExportStatus ParseStatus(string value)
+        {
+            if (Enum.TryParse<RegionExportStatus>(value, ignoreCase: true, out var status))
+                return status;
+            return RegionExportStatus.Unknown;
+        }
+
+        private static string? GetErrorMessage(RegionDescriptor descriptor)
+        {
+            if (descriptor.ExtraMetadata.TryGetValue(ErrorMetadataKey, out var message) && !string.IsNullOrWhiteSpace(message))
+                return message;
+            return null;
+        }
+
+        private static string? TryGetString(this SqliteDataReader reader, string column)
+        {
+            var index = reader.GetOrdinal(column);
+            return reader.IsDBNull(index) ? null : reader.GetString(index);
+        }
+
+        private static long? TryGetInt64(this SqliteDataReader reader, string column)
+        {
+            var index = reader.GetOrdinal(column);
+            return reader.IsDBNull(index) ? null : reader.GetInt64(index);
+        }
+
+        private static bool? TryGetBoolean(this SqliteDataReader reader, string column)
+        {
+            var index = reader.GetOrdinal(column);
+            if (reader.IsDBNull(index)) return null;
+            var value = reader.GetInt64(index);
+            return value != 0;
+        }
+
+        private static DateTime? TryGetDateTime(this SqliteDataReader reader, string column)
+        {
+            var text = reader.TryGetString(column);
+            return string.IsNullOrWhiteSpace(text) ? null : ParseDateTime(text);
+        }
+    }
+}

--- a/src/LM.Infrastructure/Extraction/SqliteExtractionRepository.cs
+++ b/src/LM.Infrastructure/Extraction/SqliteExtractionRepository.cs
@@ -1,0 +1,559 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Abstractions;
+using LM.Core.Models;
+using LM.HubSpoke.Extraction;
+using LM.HubSpoke.FileSystem;
+using Microsoft.Data.Sqlite;
+
+namespace LM.Infrastructure.Extraction
+{
+    public sealed class SqliteExtractionRepository : IExtractionRepository
+    {
+        private const int SessionRetentionLimit = 200;
+
+        private readonly IWorkSpaceService _workspace;
+        private readonly SemaphoreSlim _initLock = new(1, 1);
+
+        private string? _dbPath;
+        private volatile bool _initialized;
+
+        public SqliteExtractionRepository(IWorkSpaceService workspace)
+        {
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+        }
+
+        public async Task UpsertAsync(RegionDescriptor descriptor, CancellationToken cancellationToken = default)
+        {
+            if (descriptor is null) throw new ArgumentNullException(nameof(descriptor));
+            if (string.IsNullOrWhiteSpace(descriptor.RegionHash))
+                throw new ArgumentException("Region hash must not be empty.", nameof(descriptor));
+
+            await EnsureInitializedAsync(cancellationToken);
+
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+            await using (var cmd = connection.CreateCommand())
+            {
+                cmd.Transaction = transaction;
+                cmd.CommandText = @"
+INSERT INTO region_descriptor(
+    region_hash, entry_hub_id, source_rel_path, source_sha256,
+    page_number, bounds, ocr_text, tags, notes, annotation,
+    created_utc, updated_utc, last_export_status, last_error_message,
+    office_package_path, image_path, ocr_text_path, exporter_id, extra_metadata)
+VALUES(
+    $hash, $entry, $source, $sourceSha,
+    $page, $bounds, $ocr, $tags, $notes, $annotation,
+    $created, $updated, $status, $error,
+    $office, $image, $ocrPath, $exporter, $metadata)
+ON CONFLICT(region_hash) DO UPDATE SET
+    entry_hub_id = excluded.entry_hub_id,
+    source_rel_path = excluded.source_rel_path,
+    source_sha256 = excluded.source_sha256,
+    page_number = excluded.page_number,
+    bounds = excluded.bounds,
+    ocr_text = excluded.ocr_text,
+    tags = excluded.tags,
+    notes = excluded.notes,
+    annotation = excluded.annotation,
+    created_utc = excluded.created_utc,
+    updated_utc = excluded.updated_utc,
+    last_export_status = excluded.last_export_status,
+    last_error_message = excluded.last_error_message,
+    office_package_path = excluded.office_package_path,
+    image_path = excluded.image_path,
+    ocr_text_path = excluded.ocr_text_path,
+    exporter_id = excluded.exporter_id,
+    extra_metadata = excluded.extra_metadata;";
+
+                RegionDescriptorMapper.BindDescriptor(cmd, descriptor);
+                await cmd.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await UpsertFtsAsync(connection, transaction, descriptor, cancellationToken);
+            await UpsertRecentSessionAsync(
+                connection,
+                transaction,
+                descriptor.RegionHash,
+                descriptor.UpdatedUtc ?? descriptor.CreatedUtc,
+                durationMs: null,
+                wasCached: null,
+                outputsJson: null,
+                cancellationToken);
+            await TrimRecentSessionsAsync(connection, transaction, cancellationToken);
+
+            await transaction.CommitAsync(cancellationToken);
+            await PersistDescriptorAsync(descriptor, cancellationToken);
+        }
+
+        public async Task<RegionDescriptor?> GetAsync(string regionHash, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(regionHash)) return null;
+            await EnsureInitializedAsync(cancellationToken);
+
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT * FROM region_descriptor WHERE region_hash=$hash LIMIT 1;";
+            command.Parameters.AddWithValue("$hash", regionHash);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (await reader.ReadAsync(cancellationToken))
+                return RegionDescriptorMapper.ReadDescriptor(reader);
+
+            return null;
+        }
+
+        public async IAsyncEnumerable<RegionDescriptor> ListByEntryAsync(
+            string entryHubId,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(entryHubId)) yield break;
+
+            await EnsureInitializedAsync(cancellationToken);
+
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = @"
+SELECT *
+FROM region_descriptor
+WHERE entry_hub_id = $entry
+ORDER BY COALESCE(updated_utc, created_utc) DESC;";
+            command.Parameters.AddWithValue("$entry", entryHubId);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return RegionDescriptorMapper.ReadDescriptor(reader);
+            }
+        }
+
+        public async Task<IReadOnlyList<RegionDescriptor>> GetRecentAsync(int take, CancellationToken cancellationToken = default)
+        {
+            if (take <= 0) return Array.Empty<RegionDescriptor>();
+
+            await EnsureInitializedAsync(cancellationToken);
+
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+
+            var results = new List<RegionDescriptor>();
+
+            await using (var command = connection.CreateCommand())
+            {
+                command.CommandText = @"
+SELECT d.*
+FROM (
+    SELECT region_hash, MAX(completed_utc) AS completed_utc
+    FROM region_recent_session
+    GROUP BY region_hash
+    ORDER BY completed_utc DESC
+    LIMIT $take
+) latest
+JOIN region_descriptor d ON d.region_hash = latest.region_hash
+ORDER BY latest.completed_utc DESC;";
+                command.Parameters.AddWithValue("$take", take);
+
+                await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+                while (await reader.ReadAsync(cancellationToken))
+                    results.Add(RegionDescriptorMapper.ReadDescriptor(reader));
+            }
+
+            if (results.Count == 0)
+            {
+                await using var fallback = connection.CreateCommand();
+                fallback.CommandText = @"
+SELECT *
+FROM region_descriptor
+ORDER BY COALESCE(updated_utc, created_utc) DESC
+LIMIT $take;";
+                fallback.Parameters.AddWithValue("$take", take);
+
+                await using var reader = await fallback.ExecuteReaderAsync(cancellationToken);
+                while (await reader.ReadAsync(cancellationToken))
+                    results.Add(RegionDescriptorMapper.ReadDescriptor(reader));
+            }
+
+            return results;
+        }
+
+        public async Task<IReadOnlyList<RegionDescriptor>> SearchAsync(string query, int take, CancellationToken cancellationToken = default)
+        {
+            if (take <= 0) return Array.Empty<RegionDescriptor>();
+            await EnsureInitializedAsync(cancellationToken);
+
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+
+            var expression = BuildMatchExpression(query);
+            var descriptors = new List<RegionDescriptor>();
+
+            if (!string.IsNullOrEmpty(expression))
+            {
+                await using var command = connection.CreateCommand();
+                command.CommandText = @"
+SELECT d.*
+FROM region_descriptor_fts f
+JOIN region_descriptor d ON d.region_hash = f.region_hash
+WHERE region_descriptor_fts MATCH $expr
+ORDER BY COALESCE(d.updated_utc, d.created_utc) DESC
+LIMIT $take;";
+                command.Parameters.AddWithValue("$expr", expression);
+                command.Parameters.AddWithValue("$take", take);
+
+                await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+                while (await reader.ReadAsync(cancellationToken))
+                    descriptors.Add(RegionDescriptorMapper.ReadDescriptor(reader));
+
+                return descriptors;
+            }
+
+            await using var fallback = connection.CreateCommand();
+            fallback.CommandText = @"
+SELECT *
+FROM region_descriptor
+ORDER BY COALESCE(updated_utc, created_utc) DESC
+LIMIT $take;";
+            fallback.Parameters.AddWithValue("$take", take);
+
+            await using var rdr = await fallback.ExecuteReaderAsync(cancellationToken);
+            while (await rdr.ReadAsync(cancellationToken))
+                descriptors.Add(RegionDescriptorMapper.ReadDescriptor(rdr));
+
+            return descriptors;
+        }
+
+        public async Task UpdateStatusAsync(
+            string regionHash,
+            RegionExportStatus status,
+            string? errorMessage = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(regionHash))
+                throw new ArgumentException("Region hash must not be empty.", nameof(regionHash));
+
+            await EnsureInitializedAsync(cancellationToken);
+
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+            await using (var command = connection.CreateCommand())
+            {
+                command.Transaction = transaction;
+                command.CommandText = @"
+UPDATE region_descriptor
+SET last_export_status = $status,
+    last_error_message = $error,
+    updated_utc = $updated
+WHERE region_hash = $hash;";
+                command.Parameters.AddWithValue("$status", status.ToString());
+                command.Parameters.AddWithValue("$error", (object?)errorMessage ?? DBNull.Value);
+                command.Parameters.AddWithValue("$updated", RegionDescriptorMapper.FormatDateTime(DateTime.UtcNow));
+                command.Parameters.AddWithValue("$hash", regionHash);
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+
+        public async Task DeleteAsync(string regionHash, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(regionHash)) return;
+
+            await EnsureInitializedAsync(cancellationToken);
+
+            RegionDescriptor? descriptor = null;
+
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+            await using (var fetch = connection.CreateCommand())
+            {
+                fetch.Transaction = transaction;
+                fetch.CommandText = "SELECT * FROM region_descriptor WHERE region_hash=$hash LIMIT 1;";
+                fetch.Parameters.AddWithValue("$hash", regionHash);
+                await using var reader = await fetch.ExecuteReaderAsync(cancellationToken);
+                if (await reader.ReadAsync(cancellationToken))
+                    descriptor = RegionDescriptorMapper.ReadDescriptor(reader);
+            }
+
+            await using (var delete = connection.CreateCommand())
+            {
+                delete.Transaction = transaction;
+                delete.CommandText = "DELETE FROM region_descriptor WHERE region_hash=$hash;";
+                delete.Parameters.AddWithValue("$hash", regionHash);
+                await delete.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await using (var fts = connection.CreateCommand())
+            {
+                fts.Transaction = transaction;
+                fts.CommandText = "DELETE FROM region_descriptor_fts WHERE region_hash=$hash;";
+                fts.Parameters.AddWithValue("$hash", regionHash);
+                await fts.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await using (var sessions = connection.CreateCommand())
+            {
+                sessions.Transaction = transaction;
+                sessions.CommandText = "DELETE FROM region_recent_session WHERE region_hash=$hash;";
+                sessions.Parameters.AddWithValue("$hash", regionHash);
+                await sessions.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+
+            if (descriptor is not null)
+            {
+                DeleteDescriptorArtifacts(descriptor);
+            }
+        }
+
+        public async Task SaveSessionAsync(RegionExportResult result, CancellationToken cancellationToken = default)
+        {
+            if (result is null) throw new ArgumentNullException(nameof(result));
+            if (result.Descriptor is null)
+                throw new ArgumentException("Result descriptor must be provided.", nameof(result));
+
+            await EnsureInitializedAsync(cancellationToken);
+
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+            var completed = result.CompletedUtc == default ? DateTime.UtcNow : result.CompletedUtc;
+            var durationMs = (long)Math.Max(0, Math.Round(result.Duration.TotalMilliseconds));
+            var outputsJson = RegionDescriptorMapper.SerializeAdditionalOutputs(result.AdditionalOutputs);
+
+            await UpsertRecentSessionAsync(
+                connection,
+                transaction,
+                result.Descriptor.RegionHash,
+                completed,
+                durationMs,
+                result.WasCached,
+                outputsJson,
+                cancellationToken);
+
+            await TrimRecentSessionsAsync(connection, transaction, cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        }
+
+        public async Task<IReadOnlyList<RegionExportResult>> GetRecentSessionsAsync(int take, CancellationToken cancellationToken = default)
+        {
+            if (take <= 0) return Array.Empty<RegionExportResult>();
+
+            await EnsureInitializedAsync(cancellationToken);
+
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = @"
+SELECT d.*, 
+       s.completed_utc AS session_completed_utc,
+       s.duration_ms AS session_duration_ms,
+       s.was_cached AS session_was_cached,
+       s.additional_outputs AS session_additional_outputs
+FROM region_recent_session s
+JOIN region_descriptor d ON d.region_hash = s.region_hash
+ORDER BY s.completed_utc DESC, s.session_id DESC
+LIMIT $take;";
+            command.Parameters.AddWithValue("$take", take);
+
+            var sessions = new List<RegionExportResult>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+                sessions.Add(RegionDescriptorMapper.ReadExportResult(reader));
+
+            return sessions;
+        }
+
+        private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+        {
+            if (_initialized) return;
+
+            await _initLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_initialized) return;
+
+                var dbPath = _workspace.GetLocalDbPath();
+                var dir = Path.GetDirectoryName(dbPath);
+                if (!string.IsNullOrEmpty(dir))
+                    Directory.CreateDirectory(dir);
+
+                await ExtractionSchemaBootstrapper.EnsureAsync(_workspace, cancellationToken);
+
+                _dbPath = dbPath;
+                _initialized = true;
+            }
+            finally
+            {
+                _initLock.Release();
+            }
+        }
+
+        private SqliteConnection CreateConnection()
+        {
+            if (string.IsNullOrWhiteSpace(_dbPath))
+                throw new InvalidOperationException("Repository has not been initialized.");
+
+            return new SqliteConnection($"Data Source={_dbPath};Mode=ReadWriteCreate;Cache=Shared;");
+        }
+
+        private static async Task UpsertFtsAsync(
+            SqliteConnection connection,
+            SqliteTransaction transaction,
+            RegionDescriptor descriptor,
+            CancellationToken cancellationToken)
+        {
+            await using (var delete = connection.CreateCommand())
+            {
+                delete.Transaction = transaction;
+                delete.CommandText = "DELETE FROM region_descriptor_fts WHERE region_hash=$hash;";
+                delete.Parameters.AddWithValue("$hash", descriptor.RegionHash);
+                await delete.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            var joinedTags = descriptor.Tags.Count == 0
+                ? string.Empty
+                : string.Join(' ', descriptor.Tags.Select(t => t.ToLowerInvariant()));
+
+            await using var insert = connection.CreateCommand();
+            insert.Transaction = transaction;
+            insert.CommandText = @"
+INSERT INTO region_descriptor_fts(
+    region_hash, entry_hub_id, source_rel_path, ocr_text, notes, annotation, tags)
+VALUES($hash, $entry, $source, $ocr, $notes, $annotation, $tags);";
+            insert.Parameters.AddWithValue("$hash", descriptor.RegionHash);
+            insert.Parameters.AddWithValue("$entry", descriptor.EntryHubId);
+            insert.Parameters.AddWithValue("$source", descriptor.SourceRelativePath);
+            insert.Parameters.AddWithValue("$ocr", descriptor.OcrText ?? string.Empty);
+            insert.Parameters.AddWithValue("$notes", descriptor.Notes ?? string.Empty);
+            insert.Parameters.AddWithValue("$annotation", descriptor.Annotation ?? string.Empty);
+            insert.Parameters.AddWithValue("$tags", joinedTags);
+            await insert.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        private static async Task UpsertRecentSessionAsync(
+            SqliteConnection connection,
+            SqliteTransaction transaction,
+            string regionHash,
+            DateTime completedUtc,
+            long? durationMs,
+            bool? wasCached,
+            string? outputsJson,
+            CancellationToken cancellationToken)
+        {
+            await using var cmd = connection.CreateCommand();
+            cmd.Transaction = transaction;
+            cmd.CommandText = @"
+INSERT INTO region_recent_session(region_hash, completed_utc, duration_ms, was_cached, additional_outputs)
+VALUES($hash, $completed, $duration, $cached, $outputs)
+ON CONFLICT(region_hash, completed_utc) DO UPDATE SET
+    duration_ms = COALESCE(excluded.duration_ms, region_recent_session.duration_ms),
+    was_cached = COALESCE(excluded.was_cached, region_recent_session.was_cached),
+    additional_outputs = COALESCE(excluded.additional_outputs, region_recent_session.additional_outputs);";
+            cmd.Parameters.AddWithValue("$hash", regionHash);
+            cmd.Parameters.AddWithValue("$completed", RegionDescriptorMapper.FormatDateTime(completedUtc));
+            cmd.Parameters.AddWithValue("$duration", durationMs.HasValue ? durationMs.Value : (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("$cached", wasCached.HasValue ? (wasCached.Value ? 1 : 0) : (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("$outputs", (object?)outputsJson ?? DBNull.Value);
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        private static async Task TrimRecentSessionsAsync(
+            SqliteConnection connection,
+            SqliteTransaction transaction,
+            CancellationToken cancellationToken)
+        {
+            await using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = @"
+DELETE FROM region_recent_session
+WHERE session_id NOT IN (
+    SELECT session_id
+    FROM region_recent_session
+    ORDER BY completed_utc DESC, session_id DESC
+    LIMIT $limit
+);";
+            command.Parameters.AddWithValue("$limit", SessionRetentionLimit);
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        private async Task PersistDescriptorAsync(RegionDescriptor descriptor, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var path = WorkspaceLayout.ExtractionDescriptorPath(_workspace, descriptor.RegionHash);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var json = RegionDescriptorMapper.SerializeDescriptor(descriptor);
+            await File.WriteAllTextAsync(path, json, cancellationToken);
+        }
+
+        private void DeleteDescriptorArtifacts(RegionDescriptor descriptor)
+        {
+            var descriptorPath = WorkspaceLayout.ExtractionDescriptorPath(_workspace, descriptor.RegionHash);
+            DeleteIfExists(descriptorPath);
+            DeleteIfExists(descriptor.ImagePath);
+            DeleteIfExists(descriptor.OcrTextPath);
+            DeleteIfExists(descriptor.OfficePackagePath);
+        }
+
+        private void DeleteIfExists(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return;
+
+            string absolute = Path.IsPathRooted(path)
+                ? path
+                : _workspace.GetAbsolutePath(path);
+
+            if (File.Exists(absolute))
+            {
+                try { File.Delete(absolute); }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+        }
+
+        private static string BuildMatchExpression(string query)
+        {
+            if (string.IsNullOrWhiteSpace(query)) return string.Empty;
+
+            var tokens = query
+                .Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(SanitizeToken)
+                .Where(t => t.Length > 0)
+                .Select(t => t + "*");
+
+            return string.Join(" AND ", tokens);
+        }
+
+        private static string SanitizeToken(string token)
+        {
+            var builder = new StringBuilder(token.Length);
+            foreach (var ch in token)
+            {
+                if (char.IsLetterOrDigit(ch) || ch is '_' or '-')
+                    builder.Append(char.ToLowerInvariant(ch));
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/src/LM.Infrastructure/LM.Infrastructure.csproj
+++ b/src/LM.Infrastructure/LM.Infrastructure.csproj
@@ -14,6 +14,7 @@
     <!-- Versions are supplied centrally -->
     <PackageReference Include="UglyToad.PdfPig" />
     <PackageReference Include="DocumentFormat.OpenXml" />
+    <PackageReference Include="Microsoft.Data.Sqlite" />
   </ItemGroup>
 
 

--- a/src/LM.Infrastructure/PublicAPI.Unshipped.txt
+++ b/src/LM.Infrastructure/PublicAPI.Unshipped.txt
@@ -24,6 +24,17 @@ LM.Infrastructure.Entries.JsonEntryStore.SearchAsync(LM.Core.Models.Filters.Entr
 LM.Infrastructure.Export.MetadataDebugSlideExporter
 LM.Infrastructure.Export.MetadataDebugSlideExporter.ExportAsync(System.Collections.Generic.IEnumerable<LM.Core.Models.FileMetadata!>! items, string! outPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
 LM.Infrastructure.Export.MetadataDebugSlideExporter.MetadataDebugSlideExporter() -> void
+LM.Infrastructure.Extraction.SqliteExtractionRepository
+LM.Infrastructure.Extraction.SqliteExtractionRepository.DeleteAsync(string! regionHash, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Infrastructure.Extraction.SqliteExtractionRepository.GetAsync(string! regionHash, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.RegionDescriptor?>!
+LM.Infrastructure.Extraction.SqliteExtractionRepository.GetRecentAsync(int take, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.RegionDescriptor!>!>!
+LM.Infrastructure.Extraction.SqliteExtractionRepository.GetRecentSessionsAsync(int take, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.RegionExportResult!>!>!
+LM.Infrastructure.Extraction.SqliteExtractionRepository.ListByEntryAsync(string! entryHubId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<LM.Core.Models.RegionDescriptor!>!
+LM.Infrastructure.Extraction.SqliteExtractionRepository.SaveSessionAsync(LM.Core.Models.RegionExportResult! result, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Infrastructure.Extraction.SqliteExtractionRepository.SearchAsync(string! query, int take, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.RegionDescriptor!>!>!
+LM.Infrastructure.Extraction.SqliteExtractionRepository.SqliteExtractionRepository(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.Infrastructure.Extraction.SqliteExtractionRepository.UpdateStatusAsync(string! regionHash, LM.Core.Models.RegionExportStatus status, string? errorMessage = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Infrastructure.Extraction.SqliteExtractionRepository.UpsertAsync(LM.Core.Models.RegionDescriptor! descriptor, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.Infrastructure.FileSystem.WorkspaceService
 LM.Infrastructure.FileSystem.WorkspaceService.EnsureWorkspaceAsync(string! absoluteWorkspacePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.Infrastructure.FileSystem.WorkspaceService.GetAbsolutePath(string! relativePath) -> string!


### PR DESCRIPTION
## Summary
* add `SqliteExtractionRepository` with SQLite persistence, FTS search, descriptor file writes, and recent-session tracking for extraction records
* introduce `RegionDescriptorMapper` to map between SQLite rows and `RegionDescriptor` / `RegionExportResult`
* create an `ExtractionSchemaBootstrapper`, update `HubSpokeStore.InitializeAsync` to invoke it, and extend `WorkspaceLayout` for extraction buckets
* add repository unit tests covering round-trip persistence, search, cleanup, and session recording

## Testing
* `dotnet test KnowledgeWorks_20250820_082416.sln` *(fails: dotnet is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1465511fc832bb5cdd4ac2fc8f221