### PR TITLE
Expose saved library presets in UI

### DIFF
--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -363,7 +363,9 @@ LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextInTitle.get -> boo
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextInTitle.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextQuery.get -> string?
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextQuery.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.HasSavedPresets.get -> bool
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.GetNormalizedFullTextQuery() -> string?
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.IsInternal.get -> bool?
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.IsInternal.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.IsMetadataSearch.get -> bool
@@ -373,6 +375,7 @@ LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.PmidContains.get -> string
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.PmidContains.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.SourceContains.get -> string?
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.SourceContains.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.SavedPresets.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Common.LibraryPresetSummary!>!
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TagsCsv.get -> string?
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TagsCsv.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TitleContains.get -> string?

--- a/src/LM.App.Wpf/ViewModels/LibraryViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/LibraryViewModel.cs
@@ -31,6 +31,7 @@ namespace LM.App.Wpf.ViewModels
             Filters = filters ?? throw new ArgumentNullException(nameof(filters));
             Results = results ?? throw new ArgumentNullException(nameof(results));
 
+            _ = Filters.InitializeAsync();
         }
 
         public LibraryFiltersViewModel Filters { get; }

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -118,6 +118,41 @@
           <Button Content="Manage presets"
                   Command="{Binding ManagePresetsCommand}"/>
         </StackPanel>
+        <StackPanel Margin="0,16,0,0">
+          <TextBlock Text="Saved presets" FontWeight="SemiBold"/>
+          <TextBlock Text="No saved presets yet."
+                     Margin="0,4,0,0"
+                     Foreground="DimGray"
+                     FontStyle="Italic">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock">
+                <Setter Property="Visibility" Value="Visible"/>
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding HasSavedPresets}" Value="True">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+          <ItemsControl ItemsSource="{Binding SavedPresets}"
+                        Margin="0,8,0,0"
+                        Visibility="{Binding HasSavedPresets, Converter={StaticResource BoolToVisibilityConverter}}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <Button Command="{Binding DataContext.ApplyPresetCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                        CommandParameter="{Binding}"
+                        Margin="0,0,0,6"
+                        HorizontalContentAlignment="Stretch">
+                  <StackPanel>
+                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding SavedUtc, StringFormat='Saved {0:yyyy-MM-dd HH:mm}'}" FontSize="12" Opacity="0.7"/>
+                  </StackPanel>
+                </Button>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </StackPanel>
       </StackPanel>
     </ScrollViewer>
 


### PR DESCRIPTION
## Summary
- surface saved library presets from the store via `LibraryFiltersViewModel`, including initialization and quick-apply command support
- render a saved preset list in the Library view for one-click loading and empty-state messaging
- trigger preset initialization when the Library view model is constructed and keep the public API file in sync

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: existing test analyzer errors in LM.Infrastructure.Tests)*
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: existing analyzer/test failures in solution)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c6ec6810832b8e10563930ebee34