### PR TITLE
Add attachment metadata workflow and hooks

### DIFF
--- a/src/LM.App.Wpf.Tests/LibraryViewModelFullTextTests.cs
+++ b/src/LM.App.Wpf.Tests/LibraryViewModelFullTextTests.cs
@@ -1,10 +1,11 @@
 using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-
 using System.Runtime.CompilerServices;
-
+using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using LM.App.Wpf.Common;
@@ -15,6 +16,8 @@ using LM.Core.Abstractions;
 using LM.Core.Models;
 using LM.Core.Models.Filters;
 using LM.Core.Models.Search;
+using LM.HubSpoke.Models;
+using LM.Infrastructure.Hooks;
 using Xunit;
 
 namespace LM.App.Wpf.Tests
@@ -121,13 +124,19 @@ namespace LM.App.Wpf.Tests
             store.EntriesById[entry.Id] = entry;
 
             var storage = new RecordingFileStorageRepository();
-            var vm = CreateViewModel(store, new FakeFullTextSearchService(), temp, storage: storage);
+            var prompt = new StubAttachmentPrompt();
+            var vm = CreateViewModel(store, new FakeFullTextSearchService(), temp, storage: storage, attachmentPrompt: prompt);
             var result = new LibrarySearchResult(entry, null, null);
             vm.Results.Items.Add(result);
             vm.Results.Selected = result;
 
             var filePath = Path.Combine(temp.RootPath, "notes.pdf");
             File.WriteAllText(filePath, "demo");
+
+            prompt.Result = new AttachmentMetadataPromptResult(new[]
+            {
+                new AttachmentMetadataSelection(filePath, "paper", AttachmentKind.Supplement, Array.Empty<string>())
+            });
 
             await vm.Results.HandleFileDropAsync(new[] { filePath });
 
@@ -140,6 +149,25 @@ namespace LM.App.Wpf.Tests
             Assert.Same(vm.Results.Selected, vm.Results.Items[0]);
             Assert.NotSame(result, vm.Results.Selected);
             Assert.Contains(vm.Results.Selected.Entry.Attachments, a => a.RelativePath == attachment.RelativePath);
+            Assert.Equal("paper", attachment.Title);
+            Assert.Equal(AttachmentKind.Supplement, attachment.Kind);
+            var expectedUser = string.IsNullOrWhiteSpace(Environment.UserName) ? "unknown" : Environment.UserName;
+            Assert.Equal(expectedUser, attachment.AddedBy);
+            Assert.NotEqual(default, attachment.AddedUtc);
+
+            var attachmentsHookPath = Path.Combine(temp.RootPath, "entries", entry.Id, "hooks", "attachments.json");
+            Assert.True(File.Exists(attachmentsHookPath));
+            var attachmentsHook = JsonSerializer.Deserialize<AttachmentHook>(File.ReadAllText(attachmentsHookPath));
+            Assert.NotNull(attachmentsHook);
+            Assert.Single(attachmentsHook!.Attachments);
+            Assert.Equal("paper", attachmentsHook.Attachments[0].Title);
+
+            var changelogPath = Path.Combine(temp.RootPath, "entries", entry.Id, "hooks", "changelog.json");
+            Assert.True(File.Exists(changelogPath));
+            var changeLog = JsonSerializer.Deserialize<EntryChangeLogHook>(File.ReadAllText(changelogPath));
+            Assert.NotNull(changeLog);
+            Assert.Single(changeLog!.Events);
+            Assert.Equal(expectedUser, changeLog.Events[0].PerformedBy);
         }
 
         [Fact]
@@ -153,7 +181,8 @@ namespace LM.App.Wpf.Tests
             store.EntriesById[entryB.Id] = entryB;
 
             var storage = new RecordingFileStorageRepository();
-            var vm = CreateViewModel(store, new FakeFullTextSearchService(), temp, storage: storage);
+            var prompt = new StubAttachmentPrompt();
+            var vm = CreateViewModel(store, new FakeFullTextSearchService(), temp, storage: storage, attachmentPrompt: prompt);
             var resultA = new LibrarySearchResult(entryA, null, null);
             var resultB = new LibrarySearchResult(entryB, null, null);
             vm.Results.Items.Add(resultA);
@@ -163,6 +192,11 @@ namespace LM.App.Wpf.Tests
             var filePath = Path.Combine(temp.RootPath, "paper.pdf");
             File.WriteAllText(filePath, "demo");
 
+            prompt.Result = new AttachmentMetadataPromptResult(new[]
+            {
+                new AttachmentMetadataSelection(filePath, "slides", AttachmentKind.Presentation, Array.Empty<string>())
+            });
+
             await vm.Results.HandleFileDropAsync(new[] { filePath }, resultB);
 
             Assert.Equal(Path.Combine("attachments", entryB.Id), storage.TargetDirs[0]);
@@ -170,6 +204,9 @@ namespace LM.App.Wpf.Tests
             Assert.Equal(entryB.Id, vm.Results.Items[1].Entry.Id);
             Assert.Equal(entryB.Id, vm.Results.Selected.Entry.Id);
             Assert.Contains(vm.Results.Selected.Entry.Attachments, a => a.RelativePath == storage.SavedRelativePaths[0]);
+            var added = vm.Results.Selected.Entry.Attachments.First(a => a.RelativePath == storage.SavedRelativePaths[0]);
+            Assert.Equal("slides", added.Title);
+            Assert.Equal(AttachmentKind.Presentation, added.Kind);
         }
 
         [Fact]
@@ -194,11 +231,17 @@ namespace LM.App.Wpf.Tests
                 PathFactory = _ => existingPath
             };
 
-            var vm = CreateViewModel(store, new FakeFullTextSearchService(), temp, storage: storage);
+            var prompt = new StubAttachmentPrompt();
+            var vm = CreateViewModel(store, new FakeFullTextSearchService(), temp, storage: storage, attachmentPrompt: prompt);
             vm.Results.Selected = new LibrarySearchResult(entry, null, null);
 
             var filePath = Path.Combine(temp.RootPath, "notes.pdf");
             File.WriteAllText(filePath, "dup");
+
+            prompt.Result = new AttachmentMetadataPromptResult(new[]
+            {
+                new AttachmentMetadataSelection(filePath, "dup", AttachmentKind.Supplement, Array.Empty<string>())
+            });
 
             await vm.Results.HandleFileDropAsync(new[] { filePath });
 
@@ -256,16 +299,20 @@ namespace LM.App.Wpf.Tests
                                                        IFullTextSearchService search,
                                                        TempWorkspace workspace,
                                                        ILibraryEntryEditor? editor = null,
-                                                       IFileStorageRepository? storage = null)
+                                                       IFileStorageRepository? storage = null,
+                                                       IAttachmentMetadataPrompt? attachmentPrompt = null,
+                                                       HookOrchestrator? orchestrator = null)
         {
             var ws = new TestWorkspaceService(workspace.RootPath);
             var presetStore = new LibraryFilterPresetStore(ws);
             var prompt = new StubPresetPrompt();
             editor ??= new NoopEntryEditor();
             storage ??= new RecordingFileStorageRepository();
+            attachmentPrompt ??= new NoopAttachmentPrompt();
+            orchestrator ??= new HookOrchestrator(ws);
             var filters = new LibraryFiltersViewModel(presetStore, prompt);
             var documents = new NoopDocumentService();
-            var results = new LibraryResultsViewModel(store, storage, editor, documents);
+            var results = new LibraryResultsViewModel(store, storage, editor, documents, attachmentPrompt, orchestrator);
             return new LibraryViewModel(store, search, filters, results);
         }
 
@@ -288,6 +335,24 @@ namespace LM.App.Wpf.Tests
             {
                 LastEdited = entry;
                 return Task.FromResult(false);
+            }
+        }
+
+        private sealed class NoopAttachmentPrompt : IAttachmentMetadataPrompt
+        {
+            public Task<AttachmentMetadataPromptResult?> RequestMetadataAsync(AttachmentMetadataPromptContext context)
+                => Task.FromResult<AttachmentMetadataPromptResult?>(null);
+        }
+
+        private sealed class StubAttachmentPrompt : IAttachmentMetadataPrompt
+        {
+            public AttachmentMetadataPromptContext? LastContext { get; private set; }
+            public AttachmentMetadataPromptResult? Result { get; set; }
+
+            public Task<AttachmentMetadataPromptResult?> RequestMetadataAsync(AttachmentMetadataPromptContext context)
+            {
+                LastContext = context;
+                return Task.FromResult(Result);
             }
         }
 

--- a/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
@@ -1,10 +1,12 @@
 using LM.App.Wpf.Common;
 using LM.App.Wpf.Library;
 using LM.App.Wpf.Views;
+using LM.App.Wpf.Views.Library;
 using LM.App.Wpf.ViewModels;
 using LM.App.Wpf.ViewModels.Dialogs;
 using LM.App.Wpf.ViewModels.Library;
 using LM.Core.Abstractions;
+using LM.Infrastructure.Hooks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -25,6 +27,8 @@ namespace LM.App.Wpf.Composition.Modules
             services.AddTransient<EntryEditorViewModel>();
             services.AddSingleton<ILibraryEntryEditor, LibraryEntryEditor>();
             services.AddSingleton<ILibraryDocumentService>(sp => new LibraryDocumentService(sp.GetRequiredService<IWorkSpaceService>()));
+            services.AddTransient<AttachmentMetadataDialogViewModel>();
+            services.AddSingleton<IAttachmentMetadataPrompt, AttachmentMetadataPrompt>();
 
             services.AddSingleton(sp => new LibraryFiltersViewModel(
                 sp.GetRequiredService<LibraryFilterPresetStore>(),
@@ -34,7 +38,9 @@ namespace LM.App.Wpf.Composition.Modules
                 sp.GetRequiredService<IEntryStore>(),
                 sp.GetRequiredService<IFileStorageRepository>(),
                 sp.GetRequiredService<ILibraryEntryEditor>(),
-                sp.GetRequiredService<ILibraryDocumentService>()));
+                sp.GetRequiredService<ILibraryDocumentService>(),
+                sp.GetRequiredService<IAttachmentMetadataPrompt>(),
+                sp.GetRequiredService<HookOrchestrator>()));
 
             services.AddSingleton(sp => new LibraryViewModel(
                 sp.GetRequiredService<IEntryStore>(),

--- a/src/LM.App.Wpf/Library/AttachmentMetadataPrompt.cs
+++ b/src/LM.App.Wpf/Library/AttachmentMetadataPrompt.cs
@@ -1,0 +1,50 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using LM.App.Wpf.ViewModels.Library;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LM.App.Wpf.Library
+{
+    internal sealed class AttachmentMetadataPrompt : IAttachmentMetadataPrompt
+    {
+        private readonly IServiceProvider _services;
+
+        public AttachmentMetadataPrompt(IServiceProvider services)
+        {
+            _services = services ?? throw new ArgumentNullException(nameof(services));
+        }
+
+        public Task<AttachmentMetadataPromptResult?> RequestMetadataAsync(AttachmentMetadataPromptContext context)
+        {
+            if (context is null)
+                throw new ArgumentNullException(nameof(context));
+
+            var dispatcher = System.Windows.Application.Current?.Dispatcher
+                ?? throw new InvalidOperationException("Application dispatcher is not available.");
+
+            if (!dispatcher.CheckAccess())
+            {
+                var operation = dispatcher.InvokeAsync(() => ShowDialogAsync(context));
+                return operation.Task.Unwrap();
+            }
+
+            return ShowDialogAsync(context);
+        }
+
+        private Task<AttachmentMetadataPromptResult?> ShowDialogAsync(AttachmentMetadataPromptContext context)
+        {
+            using var scope = _services.CreateScope();
+            var viewModel = scope.ServiceProvider.GetRequiredService<AttachmentMetadataDialogViewModel>();
+            viewModel.Initialize(context);
+
+            var window = new Views.Library.AttachmentMetadataDialog(viewModel)
+            {
+                Owner = System.Windows.Application.Current?.MainWindow
+            };
+
+            var result = window.ShowDialog();
+            return Task.FromResult(result == true ? viewModel.BuildResult() : null);
+        }
+    }
+}

--- a/src/LM.App.Wpf/Library/IAttachmentMetadataPrompt.cs
+++ b/src/LM.App.Wpf/Library/IAttachmentMetadataPrompt.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LM.Core.Models;
+
+namespace LM.App.Wpf.Library
+{
+    public interface IAttachmentMetadataPrompt
+    {
+        Task<AttachmentMetadataPromptResult?> RequestMetadataAsync(AttachmentMetadataPromptContext context);
+    }
+
+    public sealed record AttachmentMetadataPromptContext(string EntryTitle, IReadOnlyList<string> FilePaths);
+
+    public sealed record AttachmentMetadataSelection(string SourcePath,
+                                                     string Title,
+                                                     AttachmentKind Kind,
+                                                     IReadOnlyList<string> Tags);
+
+    public sealed record AttachmentMetadataPromptResult(IReadOnlyList<AttachmentMetadataSelection> Attachments);
+}

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -335,6 +335,28 @@ LM.App.Wpf.Library.ILibraryDocumentService.OpenEntry(LM.Core.Models.Entry! entry
 LM.App.Wpf.Library.LibraryDocumentService
 LM.App.Wpf.Library.LibraryDocumentService.LibraryDocumentService(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
 LM.App.Wpf.Library.LibraryDocumentService.OpenEntry(LM.Core.Models.Entry! entry) -> void
+LM.App.Wpf.Library.IAttachmentMetadataPrompt
+LM.App.Wpf.Library.IAttachmentMetadataPrompt.RequestMetadataAsync(LM.App.Wpf.Library.AttachmentMetadataPromptContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.AttachmentMetadataPromptResult?>!
+LM.App.Wpf.Library.AttachmentMetadataPromptContext
+LM.App.Wpf.Library.AttachmentMetadataPromptContext.EntryTitle.get -> string!
+LM.App.Wpf.Library.AttachmentMetadataPromptContext.EntryTitle.init -> void
+LM.App.Wpf.Library.AttachmentMetadataPromptContext.FilePaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.Library.AttachmentMetadataPromptContext.FilePaths.init -> void
+LM.App.Wpf.Library.AttachmentMetadataPromptContext.AttachmentMetadataPromptContext(string! EntryTitle, System.Collections.Generic.IReadOnlyList<string!>! FilePaths) -> void
+LM.App.Wpf.Library.AttachmentMetadataPromptResult
+LM.App.Wpf.Library.AttachmentMetadataPromptResult.Attachments.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Library.AttachmentMetadataSelection!>!
+LM.App.Wpf.Library.AttachmentMetadataPromptResult.Attachments.init -> void
+LM.App.Wpf.Library.AttachmentMetadataPromptResult.AttachmentMetadataPromptResult(System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Library.AttachmentMetadataSelection!>! Attachments) -> void
+LM.App.Wpf.Library.AttachmentMetadataSelection
+LM.App.Wpf.Library.AttachmentMetadataSelection.AttachmentMetadataSelection(string! SourcePath, string! Title, LM.Core.Models.AttachmentKind Kind, System.Collections.Generic.IReadOnlyList<string!>! Tags) -> void
+LM.App.Wpf.Library.AttachmentMetadataSelection.Kind.get -> LM.Core.Models.AttachmentKind
+LM.App.Wpf.Library.AttachmentMetadataSelection.Kind.init -> void
+LM.App.Wpf.Library.AttachmentMetadataSelection.SourcePath.get -> string!
+LM.App.Wpf.Library.AttachmentMetadataSelection.SourcePath.init -> void
+LM.App.Wpf.Library.AttachmentMetadataSelection.Tags.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.Library.AttachmentMetadataSelection.Tags.init -> void
+LM.App.Wpf.Library.AttachmentMetadataSelection.Title.get -> string!
+LM.App.Wpf.Library.AttachmentMetadataSelection.Title.init -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.LibraryFiltersViewModel(LM.App.Wpf.Library.LibraryFilterPresetStore! presetStore, LM.App.Wpf.Common.ILibraryPresetPrompt! presetPrompt) -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.AddedByContains.get -> string?
@@ -398,7 +420,7 @@ LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.YearTo.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.Clear() -> void
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.Items.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.LibrarySearchResult!>!
-LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.LibraryResultsViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.App.Wpf.Library.ILibraryEntryEditor! entryEditor, LM.App.Wpf.Library.ILibraryDocumentService! documentService) -> void
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.LibraryResultsViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.App.Wpf.Library.ILibraryEntryEditor! entryEditor, LM.App.Wpf.Library.ILibraryDocumentService! documentService, LM.App.Wpf.Library.IAttachmentMetadataPrompt! attachmentPrompt, LM.Infrastructure.Hooks.HookOrchestrator! hookOrchestrator) -> void
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.LoadFullTextResultsAsync(System.Collections.Generic.IReadOnlyList<LM.Core.Models.Search.FullTextSearchHit!>! hits) -> System.Threading.Tasks.Task!
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.LoadMetadataResults(System.Collections.Generic.IEnumerable<LM.Core.Models.Entry!>! entries) -> void
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.MarkAsMetadataResults() -> void
@@ -551,6 +573,9 @@ LM.App.Wpf.Views.LibraryPresetPickerDialog.InitializeComponent() -> void
 LM.App.Wpf.Views.LibraryPresetPickerDialog.LibraryPresetPickerDialog(LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel! viewModel) -> void
 LM.App.Wpf.Views.LibraryPresetPickerDialog.ViewModel.get -> LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel!
 LM.App.Wpf.Views.LibraryPresetPrompt.LibraryPresetPrompt(System.IServiceProvider! services) -> void
+LM.App.Wpf.Views.Library.AttachmentMetadataDialog
+LM.App.Wpf.Views.Library.AttachmentMetadataDialog.InitializeComponent() -> void
+LM.App.Wpf.Views.Library.AttachmentMetadataDialog.AttachmentMetadataDialog(LM.App.Wpf.ViewModels.Library.AttachmentMetadataDialogViewModel! viewModel) -> void
 LM.App.Wpf.Views.LibraryPresetSaveDialog
 LM.App.Wpf.Views.LibraryPresetSaveDialog.InitializeComponent() -> void
 LM.App.Wpf.Views.LibraryPresetSaveDialog.LibraryPresetSaveDialog(LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel! viewModel) -> void
@@ -573,6 +598,7 @@ LM.App.Wpf.Views.ShellWindow.ShellWindow() -> void
 LM.App.Wpf.Views.StagingEditorWindow
 LM.App.Wpf.Views.StagingEditorWindow.InitializeComponent() -> void
 LM.App.Wpf.Views.StagingEditorWindow.StagingEditorWindow(LM.App.Wpf.ViewModels.Dialogs.StagingEditorViewModel! viewModel) -> void
+override LM.App.Wpf.Views.Library.AttachmentMetadataDialog.OnClosed(System.EventArgs! e) -> void
 LM.App.Wpf.Views.WorkspaceChooser
 LM.App.Wpf.Views.WorkspaceChooser.InitializeComponent() -> void
 LM.App.Wpf.Views.WorkspaceChooser.SelectedWorkspacePath.get -> string?

--- a/src/LM.App.Wpf/ViewModels/Add/AddPipeline.cs
+++ b/src/LM.App.Wpf/ViewModels/Add/AddPipeline.cs
@@ -252,9 +252,17 @@ namespace LM.App.Wpf.ViewModels
 
                     // Append to target entry (Attachment has only RelativePath in your model)
                     target.Attachments ??= new List<Attachment>();
+                    var now = DateTime.UtcNow;
+                    var addedBy = Environment.UserName ?? string.Empty;
+                    var title = Path.GetFileNameWithoutExtension(r.FilePath) ?? string.Empty;
                     target.Attachments.Add(new Attachment
                     {
-                        RelativePath = attachmentRel
+                        RelativePath = attachmentRel,
+                        Title = string.IsNullOrWhiteSpace(title) ? attachmentRel : title!,
+                        Kind = AttachmentKind.Supplement,
+                        Tags = new List<string>(),
+                        AddedBy = addedBy,
+                        AddedUtc = now
                     });
 
                     // Persist updated target

--- a/src/LM.App.Wpf/ViewModels/Library/AttachmentMetadataDialogViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/AttachmentMetadataDialogViewModel.cs
@@ -1,0 +1,139 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LM.App.Wpf.Common.Dialogs;
+using LM.App.Wpf.Library;
+using LM.Core.Models;
+
+namespace LM.App.Wpf.ViewModels.Library
+{
+    internal sealed partial class AttachmentMetadataDialogViewModel : DialogViewModelBase
+    {
+        private AttachmentMetadataPromptResult? _result;
+
+        public AttachmentMetadataDialogViewModel()
+        {
+            Items = new ObservableCollection<AttachmentMetadataItemViewModel>();
+            Title = "Add attachments";
+            KindOptions = Enum.GetValues(typeof(AttachmentKind));
+        }
+
+        public ObservableCollection<AttachmentMetadataItemViewModel> Items { get; }
+
+        public string Title { get; private set; }
+
+        public string EntryTitle { get; private set; } = string.Empty;
+
+        public Array KindOptions { get; }
+
+        public void Initialize(AttachmentMetadataPromptContext context)
+        {
+            if (context is null)
+                throw new ArgumentNullException(nameof(context));
+
+            Items.Clear();
+            EntryTitle = context.EntryTitle ?? string.Empty;
+            _result = null;
+
+            foreach (var path in context.FilePaths)
+            {
+                if (string.IsNullOrWhiteSpace(path))
+                    continue;
+
+                var displayName = Path.GetFileName(path) ?? path;
+                var defaultTitle = Path.GetFileNameWithoutExtension(path);
+
+                Items.Add(new AttachmentMetadataItemViewModel(path, displayName)
+                {
+                    Title = string.IsNullOrWhiteSpace(defaultTitle) ? displayName : defaultTitle!,
+                    Kind = AttachmentKind.Supplement,
+                    Tags = string.Empty
+                });
+            }
+        }
+
+        public AttachmentMetadataPromptResult? BuildResult() => _result;
+
+        [RelayCommand]
+        private void Cancel()
+        {
+            _result = null;
+            RequestClose(false);
+        }
+
+        [RelayCommand]
+        private void Save()
+        {
+            var selections = new List<AttachmentMetadataSelection>();
+
+            foreach (var item in Items)
+            {
+                if (item is null)
+                    continue;
+
+                if (string.IsNullOrWhiteSpace(item.Title))
+                {
+                    System.Windows.MessageBox.Show(
+                        "Each attachment must have a title.",
+                        "Add Attachments",
+                        System.Windows.MessageBoxButton.OK,
+                        System.Windows.MessageBoxImage.Warning);
+                    return;
+                }
+
+                var tags = ParseTags(item.Tags);
+                selections.Add(new AttachmentMetadataSelection(item.SourcePath, item.Title.Trim(), item.Kind, tags));
+            }
+
+            _result = new AttachmentMetadataPromptResult(selections);
+            RequestClose(true);
+        }
+
+        private static IReadOnlyList<string> ParseTags(string? tags)
+        {
+            if (string.IsNullOrWhiteSpace(tags))
+                return Array.Empty<string>();
+
+            var split = tags.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (split.Length == 0)
+                return Array.Empty<string>();
+
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var list = new List<string>();
+
+            foreach (var tag in split)
+            {
+                if (set.Add(tag))
+                    list.Add(tag);
+            }
+
+            return list;
+        }
+    }
+
+    internal sealed partial class AttachmentMetadataItemViewModel : ObservableObject
+    {
+        public AttachmentMetadataItemViewModel(string sourcePath, string displayName)
+        {
+            SourcePath = sourcePath ?? throw new ArgumentNullException(nameof(sourcePath));
+            DisplayName = displayName ?? string.Empty;
+        }
+
+        public string SourcePath { get; }
+
+        public string DisplayName { get; }
+
+        [ObservableProperty]
+        private string title = string.Empty;
+
+        [ObservableProperty]
+        private AttachmentKind kind = AttachmentKind.Supplement;
+
+        [ObservableProperty]
+        private string tags = string.Empty;
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Library/EntryEditorViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/EntryEditorViewModel.cs
@@ -177,7 +177,11 @@ namespace LM.App.Wpf.ViewModels.Library
                     Id = a.Id,
                     RelativePath = a.RelativePath,
                     Notes = a.Notes,
-                    Tags = a.Tags?.ToList() ?? new List<string>()
+                    Tags = a.Tags?.ToList() ?? new List<string>(),
+                    Title = a.Title,
+                    Kind = a.Kind,
+                    AddedBy = a.AddedBy,
+                    AddedUtc = a.AddedUtc
                 }).ToList() ?? new List<Attachment>(),
                 Relations = source.Relations?.Select(r => new Relation
                 {

--- a/src/LM.App.Wpf/Views/Library/AttachmentMetadataDialog.xaml
+++ b/src/LM.App.Wpf/Views/Library/AttachmentMetadataDialog.xaml
@@ -1,0 +1,108 @@
+<Window x:Class="LM.App.Wpf.Views.Library.AttachmentMetadataDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:ClassModifier="internal"
+        Title="{Binding Title}"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        MinWidth="520"
+        MinHeight="360">
+  <Grid Margin="20">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="8" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="12" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="16" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+
+    <TextBlock Text="Provide details for each attachment before saving." />
+
+    <Border Grid.Row="2"
+            Padding="8"
+            Background="#FFF6F6F6"
+            BorderBrush="#FFE0E0E0"
+            BorderThickness="1">
+      <StackPanel Orientation="Horizontal">
+        <TextBlock Text="Entry:" FontWeight="SemiBold" />
+        <TextBlock Text=" " />
+        <TextBlock Text="{Binding EntryTitle}" />
+      </StackPanel>
+    </Border>
+
+    <ScrollViewer Grid.Row="4"
+                  VerticalScrollBarVisibility="Auto"
+                  MaxHeight="420">
+      <ItemsControl ItemsSource="{Binding Items}">
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <Border BorderBrush="#FFE0E0E0"
+                    BorderThickness="1"
+                    Padding="12"
+                    Margin="0,0,0,12">
+              <StackPanel>
+                <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
+                <Grid Margin="0,8,0,0">
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="12" />
+                    <ColumnDefinition Width="*" />
+                  </Grid.ColumnDefinitions>
+                  <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="8" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="8" />
+                    <RowDefinition Height="Auto" />
+                  </Grid.RowDefinitions>
+
+                  <TextBlock Grid.Row="0"
+                             Grid.Column="0"
+                             VerticalAlignment="Center"
+                             Text="Title:" />
+                  <TextBox Grid.Row="0"
+                           Grid.Column="2"
+                           Text="{Binding Title, UpdateSourceTrigger=PropertyChanged}"
+                           MinWidth="240" />
+
+                  <TextBlock Grid.Row="2"
+                             Grid.Column="0"
+                             VerticalAlignment="Center"
+                             Text="Type:" />
+                  <ComboBox Grid.Row="2"
+                            Grid.Column="2"
+                            ItemsSource="{Binding DataContext.KindOptions, RelativeSource={RelativeSource AncestorType=Window}}"
+                            SelectedItem="{Binding Kind}" />
+
+                  <TextBlock Grid.Row="4"
+                             Grid.Column="0"
+                             VerticalAlignment="Center"
+                             Text="Tags:" />
+                  <TextBox Grid.Row="4"
+                           Grid.Column="2"
+                           Text="{Binding Tags, UpdateSourceTrigger=PropertyChanged}"
+                           ToolTip="Comma or semicolon separated tags." />
+                </Grid>
+              </StackPanel>
+            </Border>
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+    </ScrollViewer>
+
+    <StackPanel Grid.Row="6"
+                Orientation="Horizontal"
+                HorizontalAlignment="Right"
+                Style="{StaticResource DialogButtonPanelStyle}">
+      <Button Content="Cancel"
+              Style="{StaticResource DialogCancelButtonStyle}"
+              Command="{Binding CancelCommand}" />
+      <Button Content="Attach"
+              Style="{StaticResource DialogPrimaryButtonStyle}"
+              Command="{Binding SaveCommand}" />
+    </StackPanel>
+  </Grid>
+</Window>

--- a/src/LM.App.Wpf/Views/Library/AttachmentMetadataDialog.xaml.cs
+++ b/src/LM.App.Wpf/Views/Library/AttachmentMetadataDialog.xaml.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using System;
+using LM.App.Wpf.Common.Dialogs;
+using LM.App.Wpf.ViewModels.Library;
+
+namespace LM.App.Wpf.Views.Library
+{
+    internal partial class AttachmentMetadataDialog : System.Windows.Window
+    {
+        private readonly AttachmentMetadataDialogViewModel _viewModel;
+
+        public AttachmentMetadataDialog(AttachmentMetadataDialogViewModel viewModel)
+        {
+            InitializeComponent();
+            _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+            DataContext = _viewModel;
+            _viewModel.CloseRequested += OnCloseRequested;
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _viewModel.CloseRequested -= OnCloseRequested;
+            base.OnClosed(e);
+        }
+
+        private void OnCloseRequested(object? sender, DialogCloseRequestedEventArgs e)
+        {
+            DialogResult = e.DialogResult;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/Library/LibraryEntryDetailTemplate.xaml
+++ b/src/LM.App.Wpf/Views/Library/LibraryEntryDetailTemplate.xaml
@@ -224,7 +224,17 @@
                     Padding="8"
                     Margin="0,0,0,8">
               <StackPanel>
-                <TextBlock Text="{Binding RelativePath}" FontWeight="SemiBold" />
+                <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                <TextBlock Text="{Binding RelativePath}" Style="{StaticResource OptionalSectionTextStyle}" />
+                <TextBlock Margin="0,4,0,0">
+                  <Run Text="Type: " />
+                  <Run Text="{Binding Kind}" />
+                </TextBlock>
+                <TextBlock Text="{Binding AddedBy, StringFormat=Added by {0}}"
+                           Margin="0,2,0,0"
+                           Style="{StaticResource OptionalSectionTextStyle}" />
+                <TextBlock Text="{Binding AddedUtc, StringFormat=Added on {0:yyyy-MM-dd HH:mm}}"
+                           Margin="0,2,0,0" />
                 <TextBlock Text="{Binding Notes}" Style="{StaticResource AttachmentNotesTextStyle}" />
                 <TextBlock Style="{StaticResource AttachmentTagsTextStyle}">
                   <Run Text="Tags: " />

--- a/src/LM.Core/Models/EntryModels.cs
+++ b/src/LM.Core/Models/EntryModels.cs
@@ -14,6 +14,14 @@ namespace LM.Core.Models
         LitSearch
     }
 
+    public enum AttachmentKind
+    {
+        Supplement,
+        Version,
+        Presentation,
+        ExternalNotes
+    }
+
     /// <summary>
     /// Source-of-truth entry, serialized as entries\{id}\entry.json (camelCase).
     /// </summary>
@@ -70,6 +78,10 @@ namespace LM.Core.Models
         public string RelativePath { get; set; } = string.Empty; // relative to workspace
         public List<string> Tags { get; set; } = new();
         public string? Notes { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public AttachmentKind Kind { get; set; } = AttachmentKind.Supplement;
+        public string AddedBy { get; set; } = string.Empty;
+        public DateTime AddedUtc { get; set; } = DateTime.UtcNow;
     }
 
     /// <summary>

--- a/src/LM.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Core/PublicAPI.Unshipped.txt
@@ -55,6 +55,19 @@ LM.Core.Models.Attachment.RelativePath.get -> string!
 LM.Core.Models.Attachment.RelativePath.set -> void
 LM.Core.Models.Attachment.Tags.get -> System.Collections.Generic.List<string!>!
 LM.Core.Models.Attachment.Tags.set -> void
+LM.Core.Models.Attachment.Title.get -> string!
+LM.Core.Models.Attachment.Title.set -> void
+LM.Core.Models.Attachment.Kind.get -> LM.Core.Models.AttachmentKind
+LM.Core.Models.Attachment.Kind.set -> void
+LM.Core.Models.Attachment.AddedBy.get -> string!
+LM.Core.Models.Attachment.AddedBy.set -> void
+LM.Core.Models.Attachment.AddedUtc.get -> System.DateTime
+LM.Core.Models.Attachment.AddedUtc.set -> void
+LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.Supplement = 0 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.Version = 1 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.Presentation = 2 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.ExternalNotes = 3 -> LM.Core.Models.AttachmentKind
 LM.Core.Models.AuthorName
 LM.Core.Models.AuthorName.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
 LM.Core.Models.AuthorName.Affiliations.init -> void

--- a/src/LM.HubAndSpoke/Models/AttachmentHook.cs
+++ b/src/LM.HubAndSpoke/Models/AttachmentHook.cs
@@ -1,0 +1,46 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using LM.Core.Models;
+
+namespace LM.HubSpoke.Models
+{
+    public sealed class AttachmentHook
+    {
+        [JsonPropertyName("schemaVersion")]
+        public string SchemaVersion { get; init; } = "1.0";
+
+        [JsonPropertyName("attachments")]
+        public List<AttachmentHookItem> Attachments { get; set; } = new();
+    }
+
+    public sealed class AttachmentHookItem
+    {
+        [JsonPropertyName("attachmentId")]
+        public string AttachmentId { get; init; } = string.Empty;
+
+        [JsonPropertyName("title")]
+        public string Title { get; init; } = string.Empty;
+
+        [JsonPropertyName("libraryPath")]
+        public string LibraryPath { get; init; } = string.Empty;
+
+        [JsonPropertyName("tags")]
+        public List<string> Tags { get; init; } = new();
+
+        [JsonPropertyName("notes")]
+        public string? Notes { get; init; }
+
+        [JsonPropertyName("purpose")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public AttachmentKind Purpose { get; init; } = AttachmentKind.Supplement;
+
+        [JsonPropertyName("addedBy")]
+        public string AddedBy { get; init; } = string.Empty;
+
+        [JsonPropertyName("addedUtc")]
+        [JsonConverter(typeof(UtcDateTimeConverter))]
+        public DateTime AddedUtc { get; init; } = DateTime.UtcNow;
+    }
+}

--- a/src/LM.HubAndSpoke/Models/EntryChangeLogHook.cs
+++ b/src/LM.HubAndSpoke/Models/EntryChangeLogHook.cs
@@ -1,0 +1,55 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using LM.Core.Models;
+
+namespace LM.HubSpoke.Models
+{
+    public sealed class EntryChangeLogHook
+    {
+        [JsonPropertyName("schemaVersion")]
+        public string SchemaVersion { get; init; } = "1.0";
+
+        [JsonPropertyName("events")]
+        public List<EntryChangeLogEvent> Events { get; set; } = new();
+    }
+
+    public sealed class EntryChangeLogEvent
+    {
+        [JsonPropertyName("eventId")]
+        public string EventId { get; init; } = Guid.NewGuid().ToString("N");
+
+        [JsonPropertyName("timestampUtc")]
+        [JsonConverter(typeof(UtcDateTimeConverter))]
+        public DateTime TimestampUtc { get; init; } = DateTime.UtcNow;
+
+        [JsonPropertyName("performedBy")]
+        public string PerformedBy { get; init; } = string.Empty;
+
+        [JsonPropertyName("action")]
+        public string Action { get; init; } = string.Empty;
+
+        [JsonPropertyName("details")]
+        public ChangeLogAttachmentDetails? Details { get; init; }
+    }
+
+    public sealed class ChangeLogAttachmentDetails
+    {
+        [JsonPropertyName("attachmentId")]
+        public string AttachmentId { get; init; } = string.Empty;
+
+        [JsonPropertyName("title")]
+        public string Title { get; init; } = string.Empty;
+
+        [JsonPropertyName("libraryPath")]
+        public string LibraryPath { get; init; } = string.Empty;
+
+        [JsonPropertyName("purpose")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public AttachmentKind Purpose { get; init; } = AttachmentKind.Supplement;
+
+        [JsonPropertyName("tags")]
+        public List<string> Tags { get; init; } = new();
+    }
+}

--- a/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
+++ b/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
@@ -73,6 +73,30 @@ LM.HubSpoke.Models.Affiliation.Email.get -> string?
 LM.HubSpoke.Models.Affiliation.Email.init -> void
 LM.HubSpoke.Models.Affiliation.Text.get -> string!
 LM.HubSpoke.Models.Affiliation.Text.init -> void
+LM.HubSpoke.Models.AttachmentHook
+LM.HubSpoke.Models.AttachmentHook.AttachmentHook() -> void
+LM.HubSpoke.Models.AttachmentHook.Attachments.get -> System.Collections.Generic.List<LM.HubSpoke.Models.AttachmentHookItem!>!
+LM.HubSpoke.Models.AttachmentHook.Attachments.set -> void
+LM.HubSpoke.Models.AttachmentHook.SchemaVersion.get -> string!
+LM.HubSpoke.Models.AttachmentHook.SchemaVersion.init -> void
+LM.HubSpoke.Models.AttachmentHookItem
+LM.HubSpoke.Models.AttachmentHookItem.AddedBy.get -> string!
+LM.HubSpoke.Models.AttachmentHookItem.AddedBy.init -> void
+LM.HubSpoke.Models.AttachmentHookItem.AddedUtc.get -> System.DateTime
+LM.HubSpoke.Models.AttachmentHookItem.AddedUtc.init -> void
+LM.HubSpoke.Models.AttachmentHookItem.AttachmentHookItem() -> void
+LM.HubSpoke.Models.AttachmentHookItem.AttachmentId.get -> string!
+LM.HubSpoke.Models.AttachmentHookItem.AttachmentId.init -> void
+LM.HubSpoke.Models.AttachmentHookItem.LibraryPath.get -> string!
+LM.HubSpoke.Models.AttachmentHookItem.LibraryPath.init -> void
+LM.HubSpoke.Models.AttachmentHookItem.Notes.get -> string?
+LM.HubSpoke.Models.AttachmentHookItem.Notes.init -> void
+LM.HubSpoke.Models.AttachmentHookItem.Purpose.get -> LM.Core.Models.AttachmentKind
+LM.HubSpoke.Models.AttachmentHookItem.Purpose.init -> void
+LM.HubSpoke.Models.AttachmentHookItem.Tags.get -> System.Collections.Generic.List<string!>!
+LM.HubSpoke.Models.AttachmentHookItem.Tags.init -> void
+LM.HubSpoke.Models.AttachmentHookItem.Title.get -> string!
+LM.HubSpoke.Models.AttachmentHookItem.Title.init -> void
 LM.HubSpoke.Models.ArticleAbstract
 LM.HubSpoke.Models.ArticleAbstract.ArticleAbstract() -> void
 LM.HubSpoke.Models.ArticleAbstract.Sections.get -> System.Collections.Generic.List<LM.HubSpoke.Models.AbstractSection!>!
@@ -198,6 +222,18 @@ LM.HubSpoke.Models.Author.LastName.get -> string?
 LM.HubSpoke.Models.Author.LastName.init -> void
 LM.HubSpoke.Models.Author.ORCID.get -> string?
 LM.HubSpoke.Models.Author.ORCID.init -> void
+LM.HubSpoke.Models.ChangeLogAttachmentDetails
+LM.HubSpoke.Models.ChangeLogAttachmentDetails.AttachmentId.get -> string!
+LM.HubSpoke.Models.ChangeLogAttachmentDetails.AttachmentId.init -> void
+LM.HubSpoke.Models.ChangeLogAttachmentDetails.ChangeLogAttachmentDetails() -> void
+LM.HubSpoke.Models.ChangeLogAttachmentDetails.LibraryPath.get -> string!
+LM.HubSpoke.Models.ChangeLogAttachmentDetails.LibraryPath.init -> void
+LM.HubSpoke.Models.ChangeLogAttachmentDetails.Purpose.get -> LM.Core.Models.AttachmentKind
+LM.HubSpoke.Models.ChangeLogAttachmentDetails.Purpose.init -> void
+LM.HubSpoke.Models.ChangeLogAttachmentDetails.Tags.get -> System.Collections.Generic.List<string!>!
+LM.HubSpoke.Models.ChangeLogAttachmentDetails.Tags.init -> void
+LM.HubSpoke.Models.ChangeLogAttachmentDetails.Title.get -> string!
+LM.HubSpoke.Models.ChangeLogAttachmentDetails.Title.init -> void
 LM.HubSpoke.Models.Chemical
 LM.HubSpoke.Models.Chemical.Chemical() -> void
 LM.HubSpoke.Models.Chemical.Name.get -> string!
@@ -243,6 +279,24 @@ LM.HubSpoke.Models.DocumentType.Presentation = 0 -> LM.HubSpoke.Models.DocumentT
 LM.HubSpoke.Models.DocumentType.Report = 2 -> LM.HubSpoke.Models.DocumentType
 LM.HubSpoke.Models.DocumentType.StandardOperatingProcedure = 3 -> LM.HubSpoke.Models.DocumentType
 LM.HubSpoke.Models.DocumentType.Whitepaper = 4 -> LM.HubSpoke.Models.DocumentType
+LM.HubSpoke.Models.EntryChangeLogEvent
+LM.HubSpoke.Models.EntryChangeLogEvent.Action.get -> string!
+LM.HubSpoke.Models.EntryChangeLogEvent.Action.init -> void
+LM.HubSpoke.Models.EntryChangeLogEvent.Details.get -> LM.HubSpoke.Models.ChangeLogAttachmentDetails?
+LM.HubSpoke.Models.EntryChangeLogEvent.Details.init -> void
+LM.HubSpoke.Models.EntryChangeLogEvent.EntryChangeLogEvent() -> void
+LM.HubSpoke.Models.EntryChangeLogEvent.EventId.get -> string!
+LM.HubSpoke.Models.EntryChangeLogEvent.EventId.init -> void
+LM.HubSpoke.Models.EntryChangeLogEvent.PerformedBy.get -> string!
+LM.HubSpoke.Models.EntryChangeLogEvent.PerformedBy.init -> void
+LM.HubSpoke.Models.EntryChangeLogEvent.TimestampUtc.get -> System.DateTime
+LM.HubSpoke.Models.EntryChangeLogEvent.TimestampUtc.init -> void
+LM.HubSpoke.Models.EntryChangeLogHook
+LM.HubSpoke.Models.EntryChangeLogHook.EntryChangeLogHook() -> void
+LM.HubSpoke.Models.EntryChangeLogHook.Events.get -> System.Collections.Generic.List<LM.HubSpoke.Models.EntryChangeLogEvent!>!
+LM.HubSpoke.Models.EntryChangeLogHook.Events.set -> void
+LM.HubSpoke.Models.EntryChangeLogHook.SchemaVersion.get -> string!
+LM.HubSpoke.Models.EntryChangeLogHook.SchemaVersion.init -> void
 LM.HubSpoke.Models.EntryHooks
 LM.HubSpoke.Models.EntryHooks.Article.get -> string?
 LM.HubSpoke.Models.EntryHooks.Article.init -> void

--- a/src/LM.Infrastructure.Tests/HookOrchestratorTests.cs
+++ b/src/LM.Infrastructure.Tests/HookOrchestratorTests.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+using LM.Core.Models;
 using LM.Infrastructure.Hooks;
 using LM.Infrastructure.FileSystem;   // WorkspaceService
 using HookM = LM.HubSpoke.Models;
@@ -45,6 +47,125 @@ namespace LM.Infrastructure.Tests.Hooks
             var abs = doc.RootElement.GetProperty("abstract");
             Assert.Equal("Plain", abs.GetProperty("text").GetString());
             Assert.Equal("Hello", abs.GetProperty("sections")[0].GetProperty("content").GetString());
+        }
+
+        [Fact]
+        public async Task ProcessAsync_WithAttachments_WritesAttachmentsJson()
+        {
+            using var temp = new TempDir();
+
+            var ws = new WorkspaceService();
+            await ws.EnsureWorkspaceAsync(temp.Path);
+
+            var orch = new HookOrchestrator(ws);
+
+            var ctx = new HookContext
+            {
+                Attachments = new HookM.AttachmentHook
+                {
+                    Attachments = new List<HookM.AttachmentHookItem>
+                    {
+                        new HookM.AttachmentHookItem
+                        {
+                            AttachmentId = "att-1",
+                            Title = "supplement",
+                            LibraryPath = "library/aa/bb/file.pdf",
+                            Tags = new List<string> { "data" },
+                            Purpose = AttachmentKind.Supplement,
+                            AddedBy = "tester",
+                            AddedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                        }
+                    }
+                }
+            };
+
+            await orch.ProcessAsync("id123", ctx, CancellationToken.None);
+
+            var path = Path.Combine(temp.Path, "entries", "id123", "hooks", "attachments.json");
+            Assert.True(File.Exists(path), $"Expected attachments hook at {path}");
+
+            var hook = JsonSerializer.Deserialize<HookM.AttachmentHook>(await File.ReadAllTextAsync(path));
+            Assert.NotNull(hook);
+            Assert.Single(hook!.Attachments);
+            Assert.Equal("supplement", hook.Attachments[0].Title);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_WithChangeLog_AppendsEvents()
+        {
+            using var temp = new TempDir();
+
+            var ws = new WorkspaceService();
+            await ws.EnsureWorkspaceAsync(temp.Path);
+
+            var orch = new HookOrchestrator(ws);
+
+            var initial = new HookContext
+            {
+                ChangeLog = new HookM.EntryChangeLogHook
+                {
+                    Events = new List<HookM.EntryChangeLogEvent>
+                    {
+                        new HookM.EntryChangeLogEvent
+                        {
+                            EventId = "evt-1",
+                            TimestampUtc = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+                            PerformedBy = "tester",
+                            Action = "AttachmentAdded",
+                            Details = new HookM.ChangeLogAttachmentDetails
+                            {
+                                AttachmentId = "att-1",
+                                Title = "supplement",
+                                LibraryPath = "library/aa/bb/file.pdf",
+                                Purpose = AttachmentKind.Supplement,
+                                Tags = new List<string> { "data" }
+                            }
+                        }
+                    }
+                }
+            };
+
+            await orch.ProcessAsync("id123", initial, CancellationToken.None);
+
+            var path = Path.Combine(temp.Path, "entries", "id123", "hooks", "changelog.json");
+            Assert.True(File.Exists(path));
+
+            var hook = JsonSerializer.Deserialize<HookM.EntryChangeLogHook>(await File.ReadAllTextAsync(path));
+            Assert.NotNull(hook);
+            Assert.Single(hook!.Events);
+            Assert.Equal("tester", hook.Events[0].PerformedBy);
+
+            var append = new HookContext
+            {
+                ChangeLog = new HookM.EntryChangeLogHook
+                {
+                    Events = new List<HookM.EntryChangeLogEvent>
+                    {
+                        new HookM.EntryChangeLogEvent
+                        {
+                            EventId = "evt-2",
+                            TimestampUtc = new DateTime(2024, 1, 3, 0, 0, 0, DateTimeKind.Utc),
+                            PerformedBy = "tester2",
+                            Action = "AttachmentAdded",
+                            Details = new HookM.ChangeLogAttachmentDetails
+                            {
+                                AttachmentId = "att-2",
+                                Title = "slides",
+                                LibraryPath = "library/cc/dd/file.pdf",
+                                Purpose = AttachmentKind.Presentation,
+                                Tags = new List<string>()
+                            }
+                        }
+                    }
+                }
+            };
+
+            await orch.ProcessAsync("id123", append, CancellationToken.None);
+
+            hook = JsonSerializer.Deserialize<HookM.EntryChangeLogHook>(await File.ReadAllTextAsync(path));
+            Assert.NotNull(hook);
+            Assert.Equal(2, hook!.Events.Count);
+            Assert.Equal("tester2", hook.Events[1].PerformedBy);
         }
 
         private sealed class TempDir : IDisposable

--- a/src/LM.Infrastructure/Hooks/AttachmentHookComposer.cs
+++ b/src/LM.Infrastructure/Hooks/AttachmentHookComposer.cs
@@ -1,0 +1,22 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LM.Infrastructure.Hooks
+{
+    internal sealed class AttachmentHookComposer : IHookComposer
+    {
+        private readonly HookWriter _writer;
+
+        public AttachmentHookComposer(HookWriter writer)
+        {
+            _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        }
+
+        public bool CanCompose(HookContext ctx) => ctx.Attachments is not null;
+
+        public Task PersistAsync(string entryId, HookContext ctx, CancellationToken ct)
+            => _writer.SaveAttachmentsAsync(entryId, ctx.Attachments!, ct);
+    }
+}

--- a/src/LM.Infrastructure/Hooks/ChangeLogHookComposer.cs
+++ b/src/LM.Infrastructure/Hooks/ChangeLogHookComposer.cs
@@ -1,0 +1,23 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LM.Infrastructure.Hooks
+{
+    internal sealed class ChangeLogHookComposer : IHookComposer
+    {
+        private readonly HookWriter _writer;
+
+        public ChangeLogHookComposer(HookWriter writer)
+        {
+            _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        }
+
+        public bool CanCompose(HookContext ctx)
+            => ctx.ChangeLog is { Events.Count: > 0 };
+
+        public Task PersistAsync(string entryId, HookContext ctx, CancellationToken ct)
+            => _writer.AppendChangeLogAsync(entryId, ctx.ChangeLog!, ct);
+    }
+}

--- a/src/LM.Infrastructure/Hooks/HookContext.cs
+++ b/src/LM.Infrastructure/Hooks/HookContext.cs
@@ -9,5 +9,7 @@ namespace LM.Infrastructure.Hooks
     public sealed class HookContext
     {
         public HookM.ArticleHook? Article { get; init; }
+        public HookM.AttachmentHook? Attachments { get; init; }
+        public HookM.EntryChangeLogHook? ChangeLog { get; init; }
     }
 }

--- a/src/LM.Infrastructure/Hooks/HookOrchestrator.cs
+++ b/src/LM.Infrastructure/Hooks/HookOrchestrator.cs
@@ -22,7 +22,9 @@ namespace LM.Infrastructure.Hooks
             var writer = new HookWriter(workspace);     // internal
             _composers = new List<IHookComposer>
             {
-                new ArticleHookComposer(writer)         // add more composers here later
+                new ArticleHookComposer(writer),
+                new AttachmentHookComposer(writer),
+                new ChangeLogHookComposer(writer)
             };
         }
 

--- a/src/LM.Infrastructure/Hooks/HookWriter.cs
+++ b/src/LM.Infrastructure/Hooks/HookWriter.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading;
@@ -53,6 +54,92 @@ namespace LM.Infrastructure.Hooks
                 useAsync: true);
 
             await JsonSerializer.SerializeAsync(fs, hook, s_jsonOptions, ct).ConfigureAwait(false);
+            await fs.FlushAsync(ct).ConfigureAwait(false);
+        }
+
+        public async Task SaveAttachmentsAsync(string entryId, HookM.AttachmentHook hook, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(entryId))
+                throw new ArgumentException("Entry id must be non-empty.", nameof(entryId));
+            if (hook is null)
+                throw new ArgumentNullException(nameof(hook));
+
+            var relDir = Path.Combine("entries", entryId, "hooks");
+            var absDir = _workspace.GetAbsolutePath(relDir);
+            Directory.CreateDirectory(absDir);
+
+            var absPath = Path.Combine(absDir, "attachments.json");
+
+            await using var fs = new FileStream(
+                absPath,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 4096,
+                useAsync: true);
+
+            await JsonSerializer.SerializeAsync(fs, hook, s_jsonOptions, ct).ConfigureAwait(false);
+            await fs.FlushAsync(ct).ConfigureAwait(false);
+        }
+
+        public async Task AppendChangeLogAsync(string entryId, HookM.EntryChangeLogHook hook, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(entryId))
+                throw new ArgumentException("Entry id must be non-empty.", nameof(entryId));
+            if (hook is null)
+                throw new ArgumentNullException(nameof(hook));
+            if (hook.Events is null || hook.Events.Count == 0)
+                return;
+
+            var relDir = Path.Combine("entries", entryId, "hooks");
+            var absDir = _workspace.GetAbsolutePath(relDir);
+            Directory.CreateDirectory(absDir);
+
+            var absPath = Path.Combine(absDir, "changelog.json");
+            HookM.EntryChangeLogHook existing;
+
+            if (File.Exists(absPath))
+            {
+                try
+                {
+                    await using var readStream = new FileStream(
+                        absPath,
+                        FileMode.Open,
+                        FileAccess.Read,
+                        FileShare.Read,
+                        bufferSize: 4096,
+                        useAsync: true);
+
+                    existing = await JsonSerializer.DeserializeAsync<HookM.EntryChangeLogHook>(readStream, s_jsonOptions, ct).ConfigureAwait(false)
+                               ?? new HookM.EntryChangeLogHook();
+                }
+                catch
+                {
+                    existing = new HookM.EntryChangeLogHook();
+                }
+            }
+            else
+            {
+                existing = new HookM.EntryChangeLogHook();
+            }
+
+            existing.Events ??= new List<HookM.EntryChangeLogEvent>();
+
+            foreach (var evt in hook.Events)
+            {
+                if (evt is not null)
+                    existing.Events.Add(evt);
+            }
+
+            await using var fs = new FileStream(
+                absPath,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 4096,
+                useAsync: true);
+
+            await JsonSerializer.SerializeAsync(fs, existing, s_jsonOptions, ct).ConfigureAwait(false);
             await fs.FlushAsync(ct).ConfigureAwait(false);
         }
     }

--- a/src/LM.Infrastructure/PublicAPI.Unshipped.txt
+++ b/src/LM.Infrastructure/PublicAPI.Unshipped.txt
@@ -35,6 +35,10 @@ LM.Infrastructure.Hooks.ArticleHookFactory
 LM.Infrastructure.Hooks.HookContext
 LM.Infrastructure.Hooks.HookContext.Article.get -> LM.HubSpoke.Models.ArticleHook?
 LM.Infrastructure.Hooks.HookContext.Article.init -> void
+LM.Infrastructure.Hooks.HookContext.Attachments.get -> LM.HubSpoke.Models.AttachmentHook?
+LM.Infrastructure.Hooks.HookContext.Attachments.init -> void
+LM.Infrastructure.Hooks.HookContext.ChangeLog.get -> LM.HubSpoke.Models.EntryChangeLogHook?
+LM.Infrastructure.Hooks.HookContext.ChangeLog.init -> void
 LM.Infrastructure.Hooks.HookContext.HookContext() -> void
 LM.Infrastructure.Hooks.HookOrchestrator
 LM.Infrastructure.Hooks.HookOrchestrator.HookOrchestrator(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void


### PR DESCRIPTION
## Summary
- add the attachment metadata prompt view, view model, and orchestration so drag/drop files can collect user context
- persist attachment and change-log hooks including new Hub&Spoke models for attachment metadata
- extend library view models, templates, and tests to surface attachment info with author attribution

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug`
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: Microsoft.WindowsDesktop.App 9.0.0 runtime is not available in this Linux environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f123bac8832b902a60237fef757f