### PR TITLE
Fix library grid column bindings

### DIFF
--- a/src/LM.App.Wpf/Common/ClipboardService.cs
+++ b/src/LM.App.Wpf/Common/ClipboardService.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace LM.App.Wpf.Common
+{
+    /// <summary>
+    /// Default clipboard implementation backed by <see cref="System.Windows.Clipboard" />.
+    /// </summary>
+    public sealed class ClipboardService : IClipboardService
+    {
+        public void SetText(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                text = string.Empty;
+            }
+
+            System.Windows.Clipboard.SetText(text);
+        }
+    }
+}
+

--- a/src/LM.App.Wpf/Common/FileExplorerService.cs
+++ b/src/LM.App.Wpf/Common/FileExplorerService.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace LM.App.Wpf.Common
+{
+    /// <summary>
+    /// Opens folders or selects files via Windows Explorer.
+    /// </summary>
+    public sealed class FileExplorerService : IFileExplorerService
+    {
+        public void RevealInExplorer(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                throw new ArgumentException("Path must be provided.", nameof(path));
+
+            var absolute = Path.GetFullPath(path);
+
+            try
+            {
+                if (File.Exists(absolute))
+                {
+                    var info = new ProcessStartInfo
+                    {
+                        FileName = "explorer.exe",
+                        Arguments = $"/select,\"{absolute}\"",
+                        UseShellExecute = true
+                    };
+
+                    Process.Start(info);
+                    return;
+                }
+
+                if (!Directory.Exists(absolute))
+                    throw new DirectoryNotFoundException($"Directory not found: {absolute}");
+
+                var openFolder = new ProcessStartInfo
+                {
+                    FileName = absolute,
+                    UseShellExecute = true
+                };
+
+                Process.Start(openFolder);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to open Explorer for '{absolute}'.", ex);
+            }
+        }
+    }
+}
+

--- a/src/LM.App.Wpf/Common/IClipboardService.cs
+++ b/src/LM.App.Wpf/Common/IClipboardService.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace LM.App.Wpf.Common
+{
+    /// <summary>
+    /// Provides clipboard operations that can be mocked in unit tests.
+    /// </summary>
+    public interface IClipboardService
+    {
+        void SetText(string text);
+    }
+}
+

--- a/src/LM.App.Wpf/Common/IFileExplorerService.cs
+++ b/src/LM.App.Wpf/Common/IFileExplorerService.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace LM.App.Wpf.Common
+{
+    /// <summary>
+    /// Launches Explorer windows for workspace content.
+    /// </summary>
+    public interface IFileExplorerService
+    {
+        void RevealInExplorer(string path);
+    }
+}
+

--- a/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
@@ -6,9 +6,12 @@ using LM.App.Wpf.ViewModels;
 using LM.App.Wpf.ViewModels.Dialogs;
 using LM.App.Wpf.ViewModels.Library;
 using LM.Core.Abstractions;
+using LM.Core.Abstractions.Configuration;
 using LM.Infrastructure.Hooks;
+using LM.Infrastructure.Settings;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace LM.App.Wpf.Composition.Modules
 {
@@ -18,6 +21,9 @@ namespace LM.App.Wpf.Composition.Modules
         {
             var services = builder.Services;
 
+            services.TryAddSingleton<IUserPreferencesStore, JsonUserPreferencesStore>();
+            services.AddSingleton<IClipboardService, ClipboardService>();
+            services.AddSingleton<IFileExplorerService, FileExplorerService>();
             services.AddSingleton<LibraryFilterPresetStore>();
             services.AddSingleton<ILibraryPresetPrompt, LibraryPresetPrompt>();
             services.AddTransient<LibraryPresetSaveDialogViewModel>();
@@ -47,7 +53,12 @@ namespace LM.App.Wpf.Composition.Modules
                 sp.GetRequiredService<IEntryStore>(),
                 sp.GetRequiredService<IFullTextSearchService>(),
                 sp.GetRequiredService<LibraryFiltersViewModel>(),
-                sp.GetRequiredService<LibraryResultsViewModel>()));
+                sp.GetRequiredService<LibraryResultsViewModel>(),
+                sp.GetRequiredService<IWorkSpaceService>(),
+                sp.GetRequiredService<IUserPreferencesStore>(),
+                sp.GetRequiredService<IClipboardService>(),
+                sp.GetRequiredService<IFileExplorerService>(),
+                sp.GetRequiredService<ILibraryDocumentService>()));
         }
     }
 }

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -32,6 +32,16 @@ LM.App.Wpf.Common.Dialogs.WpfDialogService.WpfDialogService(System.IServiceProvi
 LM.App.Wpf.Common.ILibraryPresetPrompt
 LM.App.Wpf.Common.ILibraryPresetPrompt.RequestSaveAsync(LM.App.Wpf.Common.LibraryPresetSaveContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.LibraryPresetSaveResult?>!
 LM.App.Wpf.Common.ILibraryPresetPrompt.RequestSelectionAsync(LM.App.Wpf.Common.LibraryPresetSelectionContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.LibraryPresetSelectionResult?>!
+LM.App.Wpf.Common.IClipboardService
+LM.App.Wpf.Common.IClipboardService.SetText(string! text) -> void
+LM.App.Wpf.Common.ClipboardService
+LM.App.Wpf.Common.ClipboardService.ClipboardService() -> void
+LM.App.Wpf.Common.ClipboardService.SetText(string! text) -> void
+LM.App.Wpf.Common.IFileExplorerService
+LM.App.Wpf.Common.IFileExplorerService.RevealInExplorer(string! path) -> void
+LM.App.Wpf.Common.FileExplorerService
+LM.App.Wpf.Common.FileExplorerService.FileExplorerService() -> void
+LM.App.Wpf.Common.FileExplorerService.RevealInExplorer(string! path) -> void
 LM.App.Wpf.Common.ISearchSavePrompt
 LM.App.Wpf.Common.ISearchSavePrompt.RequestAsync(LM.App.Wpf.Common.SearchSavePromptContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.SearchSavePromptResult?>!
 LM.App.Wpf.Common.SearchSavePromptContext
@@ -431,6 +441,19 @@ LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.YearFrom.get -> int?
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.YearFrom.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.YearTo.get -> int?
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.YearTo.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryColumnOption
+LM.App.Wpf.ViewModels.Library.LibraryColumnOption.DisplayName.get -> string!
+LM.App.Wpf.ViewModels.Library.LibraryColumnOption.IsVisible.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryColumnOption.IsVisible.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryColumnOption.Key.get -> string!
+LM.App.Wpf.ViewModels.Library.LibraryColumnOption.LibraryColumnOption(string! key, string! displayName, bool isVisible) -> void
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility.this[string! key].get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility.this[string! key].set -> void
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility.LibraryColumnVisibility() -> void
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility.LoadFrom(System.Collections.Generic.IReadOnlyDictionary<string!, bool>! source) -> void
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility.Snapshot() -> System.Collections.Generic.IReadOnlyDictionary<string!, bool>!
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.Clear() -> void
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.Items.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.LibrarySearchResult!>!
@@ -444,10 +467,22 @@ LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.Selected.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.HasLinkItems.get -> bool
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.HasLinkItems.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.LinkItems.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.Library.LibraryLinkItem!>!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.EditEntryAsync(LM.App.Wpf.ViewModels.LibrarySearchResult? target) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.HandleSelectionChangedCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.HasSelection.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectedItems.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.LibrarySearchResult!>!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectionChanged -> System.EventHandler?
 LM.App.Wpf.ViewModels.LibraryViewModel
 LM.App.Wpf.ViewModels.LibraryViewModel.Filters.get -> LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel!
-LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel! filters, LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel! results) -> void
+LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel! filters, LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel! results, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.Configuration.IUserPreferencesStore! preferencesStore, LM.App.Wpf.Common.IClipboardService! clipboard, LM.App.Wpf.Common.IFileExplorerService! fileExplorer, LM.App.Wpf.Library.ILibraryDocumentService! documentService) -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.Results.get -> LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel!
+LM.App.Wpf.ViewModels.LibraryViewModel.ColumnOptions.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.Library.LibraryColumnOption!>!
+LM.App.Wpf.ViewModels.LibraryViewModel.ColumnVisibility.get -> LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility!
+LM.App.Wpf.ViewModels.LibraryViewModel.CopyMetadataCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.LibraryViewModel.CopyWorkspacePathCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.LibraryViewModel.EditEntryCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.LibraryViewModel.OpenContainingFolderCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.LibraryViewModel.OpenEntryCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.SearchItemViewModel
 LM.App.Wpf.ViewModels.SearchItemViewModel.Header.get -> string!
 LM.App.Wpf.ViewModels.SearchItemViewModel.SearchItemViewModel(string! header, LM.App.Wpf.ViewModels.LibraryViewModel! vm) -> void
@@ -606,6 +641,10 @@ LM.App.Wpf.Views.LibraryPresetPrompt.RequestSelectionAsync(LM.App.Wpf.Common.Lib
 LM.App.Wpf.Views.SearchSavePrompt
 LM.App.Wpf.Views.SearchSavePrompt.RequestAsync(LM.App.Wpf.Common.SearchSavePromptContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.SearchSavePromptResult?>!
 LM.App.Wpf.Views.SearchSavePrompt.SearchSavePrompt(System.IServiceProvider! services) -> void
+LM.App.Wpf.Views.Behaviors.DataGridColumnVisibilityBehavior
+LM.App.Wpf.Views.Behaviors.DataGridColumnVisibilityBehavior.DataGridColumnVisibilityBehavior() -> void
+LM.App.Wpf.Views.Behaviors.DataGridColumnVisibilityBehavior.VisibilityMap.get -> LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility?
+LM.App.Wpf.Views.Behaviors.DataGridColumnVisibilityBehavior.VisibilityMap.set -> void
 LM.App.Wpf.Views.SearchView
 LM.App.Wpf.Views.SearchView.InitializeComponent() -> void
 LM.App.Wpf.Views.SearchView.SearchView() -> void

--- a/src/LM.App.Wpf/ViewModels/Library/LibraryColumnOption.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LibraryColumnOption.cs
@@ -1,0 +1,23 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace LM.App.Wpf.ViewModels.Library
+{
+    /// <summary>Represents a togglable column in the Library results grid.</summary>
+    public sealed partial class LibraryColumnOption : ObservableObject
+    {
+        public LibraryColumnOption(string key, string displayName, bool isVisible)
+        {
+            Key = key;
+            DisplayName = displayName;
+            this.isVisible = isVisible;
+        }
+
+        public string Key { get; }
+
+        public string DisplayName { get; }
+
+        [ObservableProperty]
+        private bool isVisible;
+    }
+}
+

--- a/src/LM.App.Wpf/ViewModels/Library/LibraryColumnVisibility.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LibraryColumnVisibility.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace LM.App.Wpf.ViewModels.Library
+{
+    /// <summary>Tracks column visibility values and notifies WPF bindings.</summary>
+    public sealed class LibraryColumnVisibility : INotifyPropertyChanged
+    {
+        private readonly Dictionary<string, bool> _states;
+
+        public LibraryColumnVisibility()
+        {
+            _states = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public bool this[string key]
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(key))
+                    return true;
+
+                return _states.TryGetValue(key, out var value) ? value : true;
+            }
+            set
+            {
+                if (string.IsNullOrWhiteSpace(key))
+                    return;
+
+                if (_states.TryGetValue(key, out var current) && current == value)
+                    return;
+
+                _states[key] = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
+            }
+        }
+
+        public IReadOnlyDictionary<string, bool> Snapshot() => new Dictionary<string, bool>(_states);
+
+        public void LoadFrom(IReadOnlyDictionary<string, bool> source)
+        {
+            _states.Clear();
+            foreach (var kvp in source)
+            {
+                _states[kvp.Key] = kvp.Value;
+            }
+
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
+        }
+    }
+}
+

--- a/src/LM.App.Wpf/ViewModels/LibraryViewModel.Commands.cs
+++ b/src/LM.App.Wpf/ViewModels/LibraryViewModel.Commands.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using LM.App.Wpf.Common;
+using LM.App.Wpf.Library;
+using LM.App.Wpf.ViewModels.Library;
+using LM.Core.Abstractions;
+using LM.Core.Abstractions.Configuration;
+using LM.Core.Models;
+using LM.Infrastructure.Utils;
+
+namespace LM.App.Wpf.ViewModels
+{
+    public sealed partial class LibraryViewModel
+    {
+        private static readonly (string Key, string Display)[] s_columnDefinitions =
+        {
+            ("Title", "Title"),
+            ("Score", "Score"),
+            ("Source", "Source"),
+            ("Type", "Type"),
+            ("Year", "Year"),
+            ("AddedOn", "Added on"),
+            ("AddedBy", "Added by"),
+            ("InternalId", "Internal ID"),
+            ("Doi", "DOI"),
+            ("Pmid", "PMID"),
+            ("Nct", "NCT"),
+            ("Authors", "Authors"),
+            ("Tags", "Tags"),
+            ("IsInternal", "Internal"),
+            ("Snippet", "Snippet")
+        };
+
+        private readonly IWorkSpaceService _workspace;
+        private readonly IUserPreferencesStore _preferencesStore;
+        private readonly IClipboardService _clipboard;
+        private readonly IFileExplorerService _fileExplorer;
+        private readonly ILibraryDocumentService _documentService;
+        private readonly LibraryColumnVisibility _columnVisibility = new();
+        private readonly List<LibraryColumnOption> _columnOptions = new();
+        private readonly TaskCompletionSource<bool> _preferencesReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private UserPreferences _preferences = new();
+        private bool _suppressColumnPersistence;
+
+        public LibraryColumnVisibility ColumnVisibility => _columnVisibility;
+
+        public IReadOnlyList<LibraryColumnOption> ColumnOptions => _columnOptions;
+
+        private void InitializeColumns()
+        {
+            foreach (var (key, display) in s_columnDefinitions)
+            {
+                var option = new LibraryColumnOption(key, display, true);
+                option.PropertyChanged += OnColumnOptionChanged;
+                _columnOptions.Add(option);
+                _columnVisibility[key] = true;
+            }
+        }
+
+        private void OnResultsSelectionChanged(object? sender, EventArgs e)
+        {
+            OpenEntryCommand.NotifyCanExecuteChanged();
+            OpenContainingFolderCommand.NotifyCanExecuteChanged();
+            CopyMetadataCommand.NotifyCanExecuteChanged();
+            CopyWorkspacePathCommand.NotifyCanExecuteChanged();
+            EditEntryCommand.NotifyCanExecuteChanged();
+        }
+
+        private void OnColumnOptionChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (sender is not LibraryColumnOption option)
+                return;
+
+            if (e.PropertyName is not nameof(LibraryColumnOption.IsVisible))
+                return;
+
+            _columnVisibility[option.Key] = option.IsVisible;
+            if (_suppressColumnPersistence)
+                return;
+
+            _ = PersistColumnPreferencesAsync();
+        }
+
+        private async Task LoadPreferencesAsync()
+        {
+            try
+            {
+                var loaded = await _preferencesStore.LoadAsync(CancellationToken.None).ConfigureAwait(false);
+                if (loaded is not null)
+                {
+                    _preferences = loaded;
+                    ApplyColumnPreferences(loaded.Library);
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[LibraryViewModel] Failed to load preferences: {ex}");
+            }
+            finally
+            {
+                _preferencesReady.TrySetResult(true);
+            }
+        }
+
+        private void ApplyColumnPreferences(LibraryPreferences? preferences)
+        {
+            if (preferences is null)
+                return;
+
+            var visible = preferences.VisibleColumns ?? Array.Empty<string>();
+            var visibleSet = new HashSet<string>(visible, StringComparer.OrdinalIgnoreCase);
+            var hasCustom = visibleSet.Count > 0;
+
+            _suppressColumnPersistence = true;
+            try
+            {
+                foreach (var option in _columnOptions)
+                {
+                    var isVisible = !hasCustom || visibleSet.Contains(option.Key);
+                    option.IsVisible = isVisible;
+                    _columnVisibility[option.Key] = isVisible;
+                }
+            }
+            finally
+            {
+                _suppressColumnPersistence = false;
+            }
+        }
+
+        private async Task PersistColumnPreferencesAsync()
+        {
+            try
+            {
+                await _preferencesReady.Task.ConfigureAwait(false);
+                var visibleColumns = _columnOptions
+                    .Where(option => option.IsVisible)
+                    .Select(option => option.Key)
+                    .ToArray();
+
+                var updated = _preferences with
+                {
+                    Library = new LibraryPreferences
+                    {
+                        VisibleColumns = visibleColumns,
+                        LastUpdatedUtc = DateTimeOffset.UtcNow
+                    }
+                };
+
+                _preferences = updated;
+                await _preferencesStore.SaveAsync(updated, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[LibraryViewModel] Failed to persist column preferences: {ex}");
+            }
+        }
+
+        private LibrarySearchResult? GetSelection(LibrarySearchResult? candidate, bool updateSelection)
+        {
+            if (candidate is not null && updateSelection && !ReferenceEquals(Results.Selected, candidate))
+            {
+                Results.Selected = candidate;
+            }
+
+            return candidate ?? Results.Selected;
+        }
+
+        private bool CanOpenEntry(LibrarySearchResult? result) => GetSelection(result, updateSelection: false) is not null;
+
+        [RelayCommand(CanExecute = nameof(CanOpenEntry))]
+        private void OpenEntry(LibrarySearchResult? result)
+        {
+            var target = GetSelection(result, updateSelection: true);
+            if (target is null)
+                return;
+
+            try
+            {
+                _documentService.OpenEntry(target.Entry);
+            }
+            catch (Exception ex)
+            {
+                System.Windows.MessageBox.Show(
+                    $"Failed to open entry:\n{ex.Message}",
+                    "Open Entry",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+            }
+        }
+
+        private bool CanOpenContainingFolder(LibrarySearchResult? result)
+        {
+            var target = GetSelection(result, updateSelection: false);
+            if (target?.Entry is null)
+                return false;
+
+            return !string.IsNullOrWhiteSpace(target.Entry.MainFilePath);
+        }
+
+        [RelayCommand(CanExecute = nameof(CanOpenContainingFolder))]
+        private void OpenContainingFolder(LibrarySearchResult? result)
+        {
+            var target = GetSelection(result, updateSelection: true);
+            var entry = target?.Entry;
+            if (entry is null)
+                return;
+
+            if (string.IsNullOrWhiteSpace(entry.MainFilePath))
+            {
+                System.Windows.MessageBox.Show(
+                    "Entry does not have an associated file.",
+                    "Open Containing Folder",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Information);
+                return;
+            }
+
+            try
+            {
+                var absolute = _workspace.GetAbsolutePath(entry.MainFilePath);
+                _fileExplorer.RevealInExplorer(absolute);
+            }
+            catch (Exception ex)
+            {
+                System.Windows.MessageBox.Show(
+                    $"Failed to open containing folder:\n{ex.Message}",
+                    "Open Containing Folder",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+            }
+        }
+
+        private bool CanCopyMetadata(LibrarySearchResult? result)
+        {
+            var target = GetSelection(result, updateSelection: false);
+            return target?.Entry is not null;
+        }
+
+        [RelayCommand(CanExecute = nameof(CanCopyMetadata))]
+        private void CopyMetadata(LibrarySearchResult? result)
+        {
+            var target = GetSelection(result, updateSelection: true);
+            var entry = target?.Entry;
+            if (entry is null)
+                return;
+
+            var components = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(entry.ShortTitle))
+                components.Add(entry.ShortTitle!);
+            else if (!string.IsNullOrWhiteSpace(entry.DisplayName))
+                components.Add(entry.DisplayName!);
+            else
+                components.Add(BibliographyHelper.GenerateShortTitle(entry.Title, entry.Authors, entry.Source, entry.Year));
+
+            if (!string.IsNullOrWhiteSpace(entry.Doi))
+            {
+                var doi = entry.Doi!.Trim();
+                if (!doi.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                    doi = $"https://doi.org/{doi}";
+                components.Add(doi);
+            }
+
+            try
+            {
+                var payload = string.Join(Environment.NewLine, components.Where(static part => !string.IsNullOrWhiteSpace(part)));
+                _clipboard.SetText(payload);
+            }
+            catch (Exception ex)
+            {
+                System.Windows.MessageBox.Show(
+                    $"Failed to copy metadata:\n{ex.Message}",
+                    "Copy Citation / DOI",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+            }
+        }
+
+        private bool CanCopyWorkspacePath(LibrarySearchResult? result)
+        {
+            var target = GetSelection(result, updateSelection: false);
+            var entry = target?.Entry;
+            return entry is not null && !string.IsNullOrWhiteSpace(entry.MainFilePath);
+        }
+
+        [RelayCommand(CanExecute = nameof(CanCopyWorkspacePath))]
+        private void CopyWorkspacePath(LibrarySearchResult? result)
+        {
+            var target = GetSelection(result, updateSelection: true);
+            var entry = target?.Entry;
+            if (entry is null)
+                return;
+
+            if (string.IsNullOrWhiteSpace(entry.MainFilePath))
+            {
+                System.Windows.MessageBox.Show(
+                    "Entry does not have a stored file path.",
+                    "Copy Workspace Path",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Information);
+                return;
+            }
+
+            try
+            {
+                var absolute = _workspace.GetAbsolutePath(entry.MainFilePath);
+                _clipboard.SetText(absolute);
+            }
+            catch (Exception ex)
+            {
+                System.Windows.MessageBox.Show(
+                    $"Failed to copy workspace path:\n{ex.Message}",
+                    "Copy Workspace Path",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+            }
+        }
+
+        private bool CanEditEntry(LibrarySearchResult? result) => GetSelection(result, updateSelection: false) is not null;
+
+        [RelayCommand(CanExecute = nameof(CanEditEntry))]
+        private async Task EditEntryAsync(LibrarySearchResult? result)
+        {
+            var target = GetSelection(result, updateSelection: true);
+            if (target is null)
+                return;
+
+            await Results.EditEntryAsync(target).ConfigureAwait(false);
+        }
+    }
+}
+

--- a/src/LM.App.Wpf/ViewModels/LibraryViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/LibraryViewModel.cs
@@ -5,8 +5,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using LM.App.Wpf.Common;
+using LM.App.Wpf.Library;
 using LM.App.Wpf.ViewModels.Library;
 using LM.Core.Abstractions;
+using LM.Core.Abstractions.Configuration;
 using LM.Core.Models;
 using LM.Core.Models.Filters;
 using LM.Core.Models.Search;
@@ -24,14 +26,29 @@ namespace LM.App.Wpf.ViewModels
         public LibraryViewModel(IEntryStore store,
                                 IFullTextSearchService fullTextSearch,
                                 LibraryFiltersViewModel filters,
-                                LibraryResultsViewModel results)
+                                LibraryResultsViewModel results,
+                                IWorkSpaceService workspace,
+                                IUserPreferencesStore preferencesStore,
+                                IClipboardService clipboard,
+                                IFileExplorerService fileExplorer,
+                                ILibraryDocumentService documentService)
         {
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _fullTextSearch = fullTextSearch ?? throw new ArgumentNullException(nameof(fullTextSearch));
             Filters = filters ?? throw new ArgumentNullException(nameof(filters));
             Results = results ?? throw new ArgumentNullException(nameof(results));
 
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+            _preferencesStore = preferencesStore ?? throw new ArgumentNullException(nameof(preferencesStore));
+            _clipboard = clipboard ?? throw new ArgumentNullException(nameof(clipboard));
+            _fileExplorer = fileExplorer ?? throw new ArgumentNullException(nameof(fileExplorer));
+            _documentService = documentService ?? throw new ArgumentNullException(nameof(documentService));
+
+            Results.SelectionChanged += OnResultsSelectionChanged;
+
             _ = Filters.InitializeAsync();
+            InitializeColumns();
+            _ = LoadPreferencesAsync();
         }
 
         public LibraryFiltersViewModel Filters { get; }

--- a/src/LM.App.Wpf/Views/Behaviors/DataGridColumnVisibilityBehavior.cs
+++ b/src/LM.App.Wpf/Views/Behaviors/DataGridColumnVisibilityBehavior.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Specialized;
+using System.Text;
+using LM.App.Wpf.ViewModels.Library;
+using Microsoft.Xaml.Behaviors;
+
+namespace LM.App.Wpf.Views.Behaviors
+{
+    /// <summary>
+    /// Binds data grid column visibility to <see cref="LibraryColumnVisibility" />.
+    /// </summary>
+    public sealed class DataGridColumnVisibilityBehavior : Behavior<System.Windows.Controls.DataGrid>
+    {
+        private static readonly System.Windows.DependencyProperty VisibilityMapProperty = System.Windows.DependencyProperty.Register(
+            nameof(VisibilityMap),
+            typeof(LibraryColumnVisibility),
+            typeof(DataGridColumnVisibilityBehavior),
+            new System.Windows.PropertyMetadata(null, OnVisibilityMapChanged));
+
+        public LibraryColumnVisibility? VisibilityMap
+        {
+            get => (LibraryColumnVisibility?)GetValue(VisibilityMapProperty);
+            set => SetValue(VisibilityMapProperty, value);
+        }
+
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+            if (AssociatedObject is null)
+            {
+                return;
+            }
+
+            AssociatedObject.Loaded += OnLoaded;
+            AssociatedObject.Columns.CollectionChanged += OnColumnsChanged;
+            ApplyBindings();
+        }
+
+        protected override void OnDetaching()
+        {
+            if (AssociatedObject is not null)
+            {
+                AssociatedObject.Loaded -= OnLoaded;
+                AssociatedObject.Columns.CollectionChanged -= OnColumnsChanged;
+            }
+
+            base.OnDetaching();
+        }
+
+        private static void OnVisibilityMapChanged(System.Windows.DependencyObject d, System.Windows.DependencyPropertyChangedEventArgs e)
+        {
+            if (d is DataGridColumnVisibilityBehavior behavior)
+            {
+                behavior.ApplyBindings();
+            }
+        }
+
+        private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            ApplyBindings();
+        }
+
+        private void OnColumnsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            ApplyBindings();
+        }
+
+        private void ApplyBindings()
+        {
+            if (AssociatedObject is null || VisibilityMap is null)
+            {
+                return;
+            }
+
+            foreach (var column in AssociatedObject.Columns)
+            {
+                if (column is null)
+                {
+                    continue;
+                }
+
+                var key = ResolveColumnKey(column);
+                if (string.IsNullOrWhiteSpace(key))
+                {
+                    continue;
+                }
+
+                var binding = new System.Windows.Data.Binding($"[{key}]")
+                {
+                    Source = VisibilityMap,
+                    Converter = new System.Windows.Controls.BooleanToVisibilityConverter(),
+                    Mode = System.Windows.Data.BindingMode.OneWay
+                };
+
+                System.Windows.Data.BindingOperations.SetBinding(
+                    column,
+                    System.Windows.Controls.DataGridColumn.VisibilityProperty,
+                    binding);
+            }
+        }
+
+        private static string? ResolveColumnKey(System.Windows.Controls.DataGridColumn column)
+        {
+            if (column.Header is null)
+            {
+                return null;
+            }
+
+            var headerText = column.Header switch
+            {
+                string text => text,
+                System.Windows.Controls.TextBlock textBlock => textBlock.Text,
+                _ => column.Header.ToString()
+            };
+
+            if (string.IsNullOrWhiteSpace(headerText))
+            {
+                return null;
+            }
+
+            var segments = headerText
+                .Split(new[] { ' ', '\t', '-', '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length == 0)
+            {
+                return null;
+            }
+
+            var builder = new System.Text.StringBuilder();
+            foreach (var segment in segments)
+            {
+                if (segment.Length == 0)
+                {
+                    continue;
+                }
+
+                builder.Append(char.ToUpperInvariant(segment[0]));
+                if (segment.Length > 1)
+                {
+                    builder.Append(segment.Substring(1).ToLowerInvariant());
+                }
+            }
+
+            return builder.Length > 0 ? builder.ToString() : null;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -21,6 +21,7 @@
   <Grid>
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="310"/>
+      <ColumnDefinition Width="5"/>
       <ColumnDefinition Width="*"/>
       <ColumnDefinition Width="5"/>
       <ColumnDefinition Width="360"/>
@@ -156,8 +157,15 @@
       </StackPanel>
     </ScrollViewer>
 
+    <GridSplitter Grid.Column="1"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch"
+                  Background="#FFE0E0E0"
+                  ShowsPreview="True"
+                  Width="5"/>
+
     <!-- Results -->
-    <Grid Grid.Column="1" DataContext="{Binding Results}">
+    <Grid Grid.Column="2" DataContext="{Binding Results}">
       <Grid.RowDefinitions>
         <RowDefinition Height="Auto"/>
         <RowDefinition Height="*"/>
@@ -170,6 +178,20 @@
                    Margin="8,0,0,0"
                    Foreground="DimGray"
                    Visibility="{Binding ResultsAreFullText, Converter={StaticResource BoolToVisibilityConverter}}"/>
+        <Menu Margin="12,0,0,0"
+              VerticalAlignment="Center"
+              DataContext="{Binding DataContext, RelativeSource={RelativeSource AncestorType=UserControl}}">
+          <MenuItem Header="Columns"
+                    ItemsSource="{Binding ColumnOptions}">
+            <MenuItem.ItemContainerStyle>
+              <Style TargetType="MenuItem">
+                <Setter Property="Header" Value="{Binding DisplayName}" />
+                <Setter Property="IsCheckable" Value="True" />
+                <Setter Property="IsChecked" Value="{Binding IsVisible, Mode=TwoWay}" />
+              </Style>
+            </MenuItem.ItemContainerStyle>
+          </MenuItem>
+        </Menu>
       </StackPanel>
 
       <DataGrid Grid.Row="1"
@@ -177,12 +199,50 @@
                 SelectedItem="{Binding Selected}"
                 Margin="12"
                 IsReadOnly="True"
-                AllowDrop="True">
+                AllowDrop="True"
+                CanUserReorderColumns="True"
+                CanUserResizeColumns="True"
+                SelectionMode="Extended"
+                SelectionUnit="FullRow">
+        <DataGrid.Resources>
+          <Style TargetType="DataGridRow">
+            <Setter Property="Tag" Value="{Binding DataContext, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+            <Setter Property="ContextMenu">
+              <Setter.Value>
+                <ContextMenu>
+                  <MenuItem Header="Open"
+                            Command="{Binding PlacementTarget.Tag.OpenEntryCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                            CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                  <MenuItem Header="Open containing folder"
+                            Command="{Binding PlacementTarget.Tag.OpenContainingFolderCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                            CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                  <MenuItem Header="Copy citation / DOI"
+                            Command="{Binding PlacementTarget.Tag.CopyMetadataCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                            CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                  <MenuItem Header="Copy workspace path"
+                            Command="{Binding PlacementTarget.Tag.CopyWorkspacePathCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                            CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                  <Separator />
+                  <MenuItem Header="Edit entry"
+                            Command="{Binding PlacementTarget.Tag.EditEntryCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                            CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                </ContextMenu>
+              </Setter.Value>
+            </Setter>
+          </Style>
+        </DataGrid.Resources>
         <i:Interaction.Behaviors>
           <behaviors:FileDropBehavior UseDataGridRowContext="True"
                                       PreviewDragOverCommand="{Binding PreviewDropCommand}"
                                       DropCommand="{Binding DropCommand}" />
+          <behaviors:DataGridColumnVisibilityBehavior VisibilityMap="{Binding DataContext.ColumnVisibility, RelativeSource={RelativeSource AncestorType=UserControl}}" />
         </i:Interaction.Behaviors>
+        <i:Interaction.Triggers>
+          <i:EventTrigger EventName="SelectionChanged">
+            <i:InvokeCommandAction Command="{Binding HandleSelectionChangedCommand}"
+                                   CommandParameter="{Binding SelectedItems, RelativeSource={RelativeSource AncestorType=DataGrid}}" />
+          </i:EventTrigger>
+        </i:Interaction.Triggers>
         <DataGrid.Columns>
           <StaticResource ResourceKey="LibraryResultsColumn.Title" />
           <StaticResource ResourceKey="LibraryResultsColumn.Score" />
@@ -203,18 +263,19 @@
       </DataGrid>
 
       <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="12">
-        <Button Content="Open" Command="{Binding OpenCommand}"/>
+        <Button Content="Open"
+                Command="{Binding DataContext.OpenEntryCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
       </StackPanel>
     </Grid>
 
-    <GridSplitter Grid.Column="2"
+    <GridSplitter Grid.Column="3"
                   HorizontalAlignment="Stretch"
                   VerticalAlignment="Stretch"
                   Background="#FFE0E0E0"
                   ShowsPreview="True"
                   Width="5"/>
 
-    <Border Grid.Column="3" BorderBrush="#FFE0E0E0" BorderThickness="1,0,0,0" Background="#FFFDFDFD">
+    <Border Grid.Column="4" BorderBrush="#FFE0E0E0" BorderThickness="1,0,0,0" Background="#FFFDFDFD">
       <ScrollViewer VerticalScrollBarVisibility="Auto"
                     AllowDrop="True"
                     DataContext="{Binding Results}">

--- a/src/LM.App.Wpf/Views/Templates/LibraryResultsColumns.xaml
+++ b/src/LM.App.Wpf/Views/Templates/LibraryResultsColumns.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:behaviors="clr-namespace:LM.App.Wpf.Views.Behaviors">
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="../Library/LibraryCommonResources.xaml" />
   </ResourceDictionary.MergedDictionaries>

--- a/src/LM.Core/Models/UserPreferences.cs
+++ b/src/LM.Core/Models/UserPreferences.cs
@@ -6,12 +6,20 @@ namespace LM.Core.Models
     public sealed record class UserPreferences
     {
         public SearchPreferences Search { get; init; } = new();
+        public LibraryPreferences Library { get; init; } = new();
     }
 
     /// <summary>Preferences specific to the search experience.</summary>
     public sealed record class SearchPreferences
     {
         public SearchDatabase LastSelectedDatabase { get; init; } = SearchDatabase.PubMed;
+        public DateTimeOffset LastUpdatedUtc { get; init; } = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>Preferences specific to the library grid presentation.</summary>
+    public sealed record class LibraryPreferences
+    {
+        public string[] VisibleColumns { get; init; } = Array.Empty<string>();
         public DateTimeOffset LastUpdatedUtc { get; init; } = DateTimeOffset.UtcNow;
     }
 }

--- a/src/LM.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Core/PublicAPI.Unshipped.txt
@@ -408,11 +408,18 @@ LM.Core.Models.Search.SearchExecutionResult.Request.init -> void
 LM.Core.Models.UserPreferences
 LM.Core.Models.UserPreferences.Search.get -> LM.Core.Models.SearchPreferences!
 LM.Core.Models.UserPreferences.Search.init -> void
+LM.Core.Models.UserPreferences.Library.get -> LM.Core.Models.LibraryPreferences!
+LM.Core.Models.UserPreferences.Library.init -> void
 LM.Core.Models.SearchPreferences
 LM.Core.Models.SearchPreferences.LastSelectedDatabase.get -> LM.Core.Models.SearchDatabase
 LM.Core.Models.SearchPreferences.LastSelectedDatabase.init -> void
 LM.Core.Models.SearchPreferences.LastUpdatedUtc.get -> System.DateTimeOffset
 LM.Core.Models.SearchPreferences.LastUpdatedUtc.init -> void
+LM.Core.Models.LibraryPreferences
+LM.Core.Models.LibraryPreferences.VisibleColumns.get -> string![]!
+LM.Core.Models.LibraryPreferences.VisibleColumns.init -> void
+LM.Core.Models.LibraryPreferences.LastUpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.LibraryPreferences.LastUpdatedUtc.init -> void
 LM.Core.Models.WatchedFolderSettings
 LM.Core.Models.WatchedFolderSettings.Folders.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.WatchedFolderSettingsFolder!>!
 LM.Core.Models.WatchedFolderSettings.Folders.init -> void


### PR DESCRIPTION
## Summary
- resolve WPF ambiguity errors by fully qualifying System.Windows usages in the column-visibility behavior and computing keys from column headers
- clean up library column option initialization and column resource dictionaries after removing DataGridColumn.Tag usage
- adjust public API annotations for updated preference models

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: Microsoft.WindowsDesktop.App 9.0.0 runtime not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f3f60fb4832bbd97980be8f6fe55