### PR TITLE
Add tag vocabulary support and tag match modes to library filters

### DIFF
--- a/src/LM.App.Wpf.Tests/LibraryFilterPresetStoreTests.cs
+++ b/src/LM.App.Wpf.Tests/LibraryFilterPresetStoreTests.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using LM.App.Wpf.Library;
 using LM.Infrastructure.FileSystem;
+using LM.Core.Models.Filters;
 using Xunit;
 
 public class LibraryFilterPresetStoreTests
@@ -21,7 +23,8 @@ public class LibraryFilterPresetStoreTests
             {
                 TitleContains = "title",
                 AuthorContains = "author",
-                TagsCsv = "tag1,tag2",
+                Tags = new List<string> { "tag1", "tag2" },
+                TagMatchMode = TagMatchMode.All,
                 IsInternal = true,
                 YearFrom = 2010,
                 YearTo = 2020,
@@ -51,7 +54,8 @@ public class LibraryFilterPresetStoreTests
 
         Assert.Equal(preset.State.TitleContains, loaded.State.TitleContains);
         Assert.Equal(preset.State.AuthorContains, loaded.State.AuthorContains);
-        Assert.Equal(preset.State.TagsCsv, loaded.State.TagsCsv);
+        Assert.Equal(preset.State.Tags, loaded.State.Tags);
+        Assert.Equal(preset.State.TagMatchMode, loaded.State.TagMatchMode);
         Assert.Equal(preset.State.IsInternal, loaded.State.IsInternal);
         Assert.Equal(preset.State.YearFrom, loaded.State.YearFrom);
         Assert.Equal(preset.State.YearTo, loaded.State.YearTo);

--- a/src/LM.App.Wpf/Composition/Modules/CoreModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/CoreModule.cs
@@ -6,6 +6,7 @@ using LM.HubSpoke.Entries;
 using LM.HubSpoke.Indexing;
 using LM.HubSpoke.Spokes;
 using LM.Infrastructure.Content;
+using LM.Infrastructure.Entries;
 using LM.Infrastructure.FileSystem;
 using LM.Infrastructure.Hooks;
 using LM.Infrastructure.Metadata;
@@ -60,6 +61,7 @@ namespace LM.App.Wpf.Composition.Modules
                 sp.GetRequiredService<IContentExtractor>()));
 
             services.AddSingleton<IEntryStore>(sp => sp.GetRequiredService<HubSpokeStore>());
+            services.AddSingleton<ITagVocabularyProvider, EntryTagVocabularyProvider>();
             services.AddSingleton<IFullTextSearchService>(sp => sp.GetRequiredService<HubSpokeStore>().FullTextSearch);
 
             services.AddSingleton<IWatchedFolderSettingsStore>(sp => new JsonWatchedFolderSettingsStore(sp.GetRequiredService<IWorkSpaceService>()));

--- a/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
@@ -52,6 +52,7 @@ namespace LM.App.Wpf.Composition.Modules
             services.AddSingleton(sp => new LibraryViewModel(
                 sp.GetRequiredService<IEntryStore>(),
                 sp.GetRequiredService<IFullTextSearchService>(),
+                sp.GetRequiredService<ITagVocabularyProvider>(),
                 sp.GetRequiredService<LibraryFiltersViewModel>(),
                 sp.GetRequiredService<LibraryResultsViewModel>(),
                 sp.GetRequiredService<IWorkSpaceService>(),

--- a/src/LM.App.Wpf/Library/LibraryFilterPresetStore.cs
+++ b/src/LM.App.Wpf/Library/LibraryFilterPresetStore.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using LM.Core.Abstractions;
+using LM.Core.Models.Filters;
 
 namespace LM.App.Wpf.Library
 {
@@ -140,7 +141,8 @@ namespace LM.App.Wpf.Library
         public bool FullTextInContent { get; set; } = true;
         public string? TitleContains { get; set; }
         public string? AuthorContains { get; set; }
-        public string? TagsCsv { get; set; }
+        public List<string> Tags { get; set; } = new();
+        public TagMatchMode TagMatchMode { get; set; } = TagMatchMode.Any;
         public bool? IsInternal { get; set; }
         public int? YearFrom { get; set; }
         public int? YearTo { get; set; }
@@ -160,6 +162,10 @@ namespace LM.App.Wpf.Library
         public bool TypeOther { get; set; } = true;
 
         internal LibraryFilterState Clone()
-            => (LibraryFilterState)MemberwiseClone();
+        {
+            var clone = (LibraryFilterState)MemberwiseClone();
+            clone.Tags = Tags is null ? new List<string>() : new List<string>(Tags);
+            return clone;
+        }
     }
 }

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -19,6 +19,10 @@ LM.App.Wpf.Common.BooleanToOpacityConverter.FalseOpacity.get -> double
 LM.App.Wpf.Common.BooleanToOpacityConverter.FalseOpacity.set -> void
 LM.App.Wpf.Common.BooleanToOpacityConverter.TrueOpacity.get -> double
 LM.App.Wpf.Common.BooleanToOpacityConverter.TrueOpacity.set -> void
+LM.App.Wpf.Views.Converters.EnumEqualsConverter
+LM.App.Wpf.Views.Converters.EnumEqualsConverter.Convert(object! value, System.Type! targetType, object! parameter, System.Globalization.CultureInfo! culture) -> object!
+LM.App.Wpf.Views.Converters.EnumEqualsConverter.ConvertBack(object! value, System.Type! targetType, object! parameter, System.Globalization.CultureInfo! culture) -> object!
+LM.App.Wpf.Views.Converters.EnumEqualsConverter.EnumEqualsConverter() -> void
 LM.App.Wpf.Common.Dialogs.DialogCloseRequestedEventArgs
 LM.App.Wpf.Common.Dialogs.DialogCloseRequestedEventArgs.DialogCloseRequestedEventArgs(bool? dialogResult) -> void
 LM.App.Wpf.Common.Dialogs.DialogCloseRequestedEventArgs.DialogResult.get -> bool?
@@ -170,8 +174,10 @@ LM.App.Wpf.Library.LibraryFilterState.PmidContains.get -> string?
 LM.App.Wpf.Library.LibraryFilterState.PmidContains.set -> void
 LM.App.Wpf.Library.LibraryFilterState.SourceContains.get -> string?
 LM.App.Wpf.Library.LibraryFilterState.SourceContains.set -> void
-LM.App.Wpf.Library.LibraryFilterState.TagsCsv.get -> string?
-LM.App.Wpf.Library.LibraryFilterState.TagsCsv.set -> void
+LM.App.Wpf.Library.LibraryFilterState.TagMatchMode.get -> LM.Core.Models.Filters.TagMatchMode
+LM.App.Wpf.Library.LibraryFilterState.TagMatchMode.set -> void
+LM.App.Wpf.Library.LibraryFilterState.Tags.get -> System.Collections.Generic.List<string!>!
+LM.App.Wpf.Library.LibraryFilterState.Tags.set -> void
 LM.App.Wpf.Library.LibraryFilterState.TitleContains.get -> string?
 LM.App.Wpf.Library.LibraryFilterState.TitleContains.set -> void
 LM.App.Wpf.Library.LibraryFilterState.TypeOther.get -> bool
@@ -419,8 +425,12 @@ LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.PmidContains.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.SourceContains.get -> string?
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.SourceContains.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.SavedPresets.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Common.LibraryPresetSummary!>!
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TagsCsv.get -> string?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TagsCsv.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.SelectedTags.get -> System.Collections.ObjectModel.ObservableCollection<string!>!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TagMatchMode.get -> LM.Core.Models.Filters.TagMatchMode
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TagMatchMode.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TagVocabulary.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TagVocabulary.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.UpdateTagVocabulary(System.Collections.Generic.IEnumerable<string!>! tags) -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TitleContains.get -> string?
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TitleContains.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypeOther.get -> bool
@@ -474,7 +484,7 @@ LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectedItems.get -> Syste
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectionChanged -> System.EventHandler?
 LM.App.Wpf.ViewModels.LibraryViewModel
 LM.App.Wpf.ViewModels.LibraryViewModel.Filters.get -> LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel!
-LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel! filters, LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel! results, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.Configuration.IUserPreferencesStore! preferencesStore, LM.App.Wpf.Common.IClipboardService! clipboard, LM.App.Wpf.Common.IFileExplorerService! fileExplorer, LM.App.Wpf.Library.ILibraryDocumentService! documentService) -> void
+LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.Core.Abstractions.ITagVocabularyProvider! tagVocabularyProvider, LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel! filters, LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel! results, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.Configuration.IUserPreferencesStore! preferencesStore, LM.App.Wpf.Common.IClipboardService! clipboard, LM.App.Wpf.Common.IFileExplorerService! fileExplorer, LM.App.Wpf.Library.ILibraryDocumentService! documentService) -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.Results.get -> LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel!
 LM.App.Wpf.ViewModels.LibraryViewModel.ColumnOptions.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.Library.LibraryColumnOption!>!
 LM.App.Wpf.ViewModels.LibraryViewModel.ColumnVisibility.get -> LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility!
@@ -635,6 +645,16 @@ LM.App.Wpf.Views.LibraryPresetSaveDialog.ViewModel.get -> LM.App.Wpf.ViewModels.
 LM.App.Wpf.Views.LibraryView
 LM.App.Wpf.Views.LibraryView.InitializeComponent() -> void
 LM.App.Wpf.Views.LibraryView.LibraryView() -> void
+LM.App.Wpf.Views.Library.TagTokenSelector
+LM.App.Wpf.Views.Library.TagTokenSelector.InitializeComponent() -> void
+LM.App.Wpf.Views.Library.TagTokenSelector.FilteredSuggestions.get -> System.Collections.ObjectModel.ObservableCollection<string!>!
+LM.App.Wpf.Views.Library.TagTokenSelector.SelectedTags.get -> System.Collections.ObjectModel.ObservableCollection<string!>?
+LM.App.Wpf.Views.Library.TagTokenSelector.SelectedTags.set -> void
+LM.App.Wpf.Views.Library.TagTokenSelector.TagTokenSelector() -> void
+LM.App.Wpf.Views.Library.TagTokenSelector.TagVocabulary.get -> System.Collections.Generic.IEnumerable<string!>!
+LM.App.Wpf.Views.Library.TagTokenSelector.TagVocabulary.set -> void
+field System.Windows.DependencyProperty! LM.App.Wpf.Views.Library.TagTokenSelector.SelectedTagsProperty
+field System.Windows.DependencyProperty! LM.App.Wpf.Views.Library.TagTokenSelector.TagVocabularyProperty
 LM.App.Wpf.Views.LibraryPresetPrompt
 LM.App.Wpf.Views.LibraryPresetPrompt.RequestSaveAsync(LM.App.Wpf.Common.LibraryPresetSaveContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.LibraryPresetSaveResult?>!
 LM.App.Wpf.Views.LibraryPresetPrompt.RequestSelectionAsync(LM.App.Wpf.Common.LibraryPresetSelectionContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.LibraryPresetSelectionResult?>!

--- a/src/LM.App.Wpf/Views/Converters/EnumEqualsConverter.cs
+++ b/src/LM.App.Wpf/Views/Converters/EnumEqualsConverter.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System;
+using System.Globalization;
+
+namespace LM.App.Wpf.Views.Converters
+{
+    [System.Windows.Data.ValueConversion(typeof(Enum), typeof(bool))]
+    public sealed class EnumEqualsConverter : System.Windows.Data.IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is null || parameter is null)
+            {
+                return false;
+            }
+
+            if (value.Equals(parameter))
+            {
+                return true;
+            }
+
+            if (value is Enum enumValue)
+            {
+                if (parameter is Enum enumParameter && enumParameter.GetType() == enumValue.GetType())
+                {
+                    return enumValue.Equals(enumParameter);
+                }
+
+                if (parameter is string text)
+                {
+                    try
+                    {
+                        var parsed = (Enum)Enum.Parse(enumValue.GetType(), text, ignoreCase: true);
+                        return enumValue.Equals(parsed);
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool b && b && parameter is not null)
+            {
+                return parameter;
+            }
+
+            return System.Windows.Data.Binding.DoNothing;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/Library/TagTokenSelector.xaml
+++ b/src/LM.App.Wpf/Views/Library/TagTokenSelector.xaml
@@ -1,0 +1,66 @@
+<UserControl x:Class="LM.App.Wpf.Views.Library.TagTokenSelector"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignWidth="260"
+             d:DesignHeight="120">
+  <StackPanel>
+    <Border BorderBrush="#FFD0D0D0" BorderThickness="1" CornerRadius="4" Padding="6">
+      <StackPanel>
+        <ItemsControl ItemsSource="{Binding SelectedTags, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                      Margin="0,0,0,6">
+          <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+              <WrapPanel />
+            </ItemsPanelTemplate>
+          </ItemsControl.ItemsPanel>
+          <ItemsControl.ItemTemplate>
+            <DataTemplate>
+              <Border Background="#FFEEF2FF" CornerRadius="12" Margin="0,0,6,6" Padding="8,4">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                  <TextBlock Text="{Binding}" Margin="0,0,8,0" />
+                  <Button Content="✕"
+                          Width="18"
+                          Height="18"
+                          Padding="0"
+                          HorizontalAlignment="Center"
+                          VerticalAlignment="Center"
+                          CommandParameter="{Binding}"
+                          Click="OnRemoveTagClick"/>
+                </StackPanel>
+              </Border>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+        <TextBox x:Name="InputBox"
+                 Margin="0,0,0,0"
+                 PreviewKeyDown="OnInputPreviewKeyDown"
+                 TextChanged="OnInputTextChanged"
+                 MinWidth="120"
+                 ToolTip="Type to search tags. Press Enter, Tab, or comma to add."/>
+      </StackPanel>
+    </Border>
+    <ListBox x:Name="SuggestionList"
+             Margin="0,4,0,0"
+             ItemsSource="{Binding FilteredSuggestions, RelativeSource={RelativeSource AncestorType=UserControl}}"
+             PreviewMouseLeftButtonUp="OnSuggestionClick"
+             PreviewKeyDown="OnSuggestionKeyDown"
+             MaxHeight="160">
+      <ListBox.Style>
+        <Style TargetType="ListBox">
+          <Setter Property="Visibility" Value="Collapsed" />
+          <Setter Property="BorderThickness" Value="1" />
+          <Setter Property="BorderBrush" Value="#FFD0D0D0" />
+          <Setter Property="Background" Value="White" />
+          <Style.Triggers>
+            <DataTrigger Binding="{Binding HasItems, RelativeSource={RelativeSource Self}}" Value="True">
+              <Setter Property="Visibility" Value="Visible" />
+            </DataTrigger>
+          </Style.Triggers>
+        </Style>
+      </ListBox.Style>
+    </ListBox>
+  </StackPanel>
+</UserControl>

--- a/src/LM.App.Wpf/Views/Library/TagTokenSelector.xaml.cs
+++ b/src/LM.App.Wpf/Views/Library/TagTokenSelector.xaml.cs
@@ -1,0 +1,305 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace LM.App.Wpf.Views.Library
+{
+    public partial class TagTokenSelector : System.Windows.Controls.UserControl
+    {
+        internal static readonly System.Windows.DependencyProperty SelectedTagsProperty =
+            System.Windows.DependencyProperty.Register(
+                nameof(SelectedTags),
+                typeof(ObservableCollection<string>),
+                typeof(TagTokenSelector),
+                new System.Windows.PropertyMetadata(null, OnSelectedTagsChanged));
+
+        internal static readonly System.Windows.DependencyProperty TagVocabularyProperty =
+            System.Windows.DependencyProperty.Register(
+                nameof(TagVocabulary),
+                typeof(IEnumerable<string>),
+                typeof(TagTokenSelector),
+                new System.Windows.PropertyMetadata(Array.Empty<string>(), OnTagVocabularyChanged));
+
+        private readonly ObservableCollection<string> _filteredSuggestions = new();
+        private readonly HashSet<string> _selectedTagSet = new(StringComparer.OrdinalIgnoreCase);
+        private string _currentInput = string.Empty;
+
+        public TagTokenSelector()
+        {
+            InitializeComponent();
+        }
+
+        public ObservableCollection<string>? SelectedTags
+        {
+            get => (ObservableCollection<string>?)GetValue(SelectedTagsProperty);
+            set => SetValue(SelectedTagsProperty, value);
+        }
+
+        public IEnumerable<string> TagVocabulary
+        {
+            get => (IEnumerable<string>)GetValue(TagVocabularyProperty);
+            set => SetValue(TagVocabularyProperty, value);
+        }
+
+        public ObservableCollection<string> FilteredSuggestions => _filteredSuggestions;
+
+        private static void OnSelectedTagsChanged(System.Windows.DependencyObject d, System.Windows.DependencyPropertyChangedEventArgs e)
+        {
+            var control = (TagTokenSelector)d;
+            control.HandleSelectedTagsChanged(e.OldValue as ObservableCollection<string>, e.NewValue as ObservableCollection<string>);
+        }
+
+        private static void OnTagVocabularyChanged(System.Windows.DependencyObject d, System.Windows.DependencyPropertyChangedEventArgs e)
+        {
+            var control = (TagTokenSelector)d;
+            control.UpdateSuggestions(control._currentInput);
+        }
+
+        private void HandleSelectedTagsChanged(ObservableCollection<string>? oldValue, ObservableCollection<string>? newValue)
+        {
+            if (oldValue is not null)
+            {
+                oldValue.CollectionChanged -= OnSelectedTagsCollectionChanged;
+            }
+
+            if (newValue is null)
+            {
+                newValue = new ObservableCollection<string>();
+                SetValue(SelectedTagsProperty, newValue);
+                return;
+            }
+
+            newValue.CollectionChanged += OnSelectedTagsCollectionChanged;
+
+            RebuildSelectedSet();
+            UpdateSuggestions(_currentInput);
+        }
+
+        private void OnSelectedTagsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            RebuildSelectedSet();
+            UpdateSuggestions(_currentInput);
+        }
+
+        private void RebuildSelectedSet()
+        {
+            _selectedTagSet.Clear();
+            if (SelectedTags is null)
+            {
+                return;
+            }
+
+            foreach (var tag in SelectedTags)
+            {
+                if (string.IsNullOrWhiteSpace(tag))
+                {
+                    continue;
+                }
+
+                var trimmed = tag.Trim();
+                if (trimmed.Length == 0)
+                {
+                    continue;
+                }
+
+                _selectedTagSet.Add(trimmed);
+            }
+        }
+
+        private void OnInputTextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        {
+            _currentInput = InputBox.Text;
+            UpdateSuggestions(_currentInput);
+        }
+
+        private void OnInputPreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Enter || e.Key == System.Windows.Input.Key.Tab)
+            {
+                if (!TryAcceptHighlightedSuggestion())
+                {
+                    CommitInputText();
+                }
+
+                e.Handled = true;
+            }
+            else if (e.Key == System.Windows.Input.Key.OemComma)
+            {
+                CommitInputText();
+                e.Handled = true;
+            }
+            else if (e.Key == System.Windows.Input.Key.Back && string.IsNullOrWhiteSpace(InputBox.Text))
+            {
+                RemoveLastTag();
+                e.Handled = true;
+            }
+        }
+
+        private void OnSuggestionClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (sender is System.Windows.Controls.ListBox listBox && listBox.SelectedItem is string tag)
+            {
+                if (AddTag(tag))
+                {
+                    ClearInput();
+                    e.Handled = true;
+                }
+
+                listBox.SelectedItem = null;
+            }
+        }
+
+        private void OnSuggestionKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Enter && sender is System.Windows.Controls.ListBox listBox && listBox.SelectedItem is string tag)
+            {
+                if (AddTag(tag))
+                {
+                    ClearInput();
+                }
+
+                e.Handled = true;
+            }
+        }
+
+        private void OnRemoveTagClick(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (sender is System.Windows.Controls.Button button && button.CommandParameter is string tag)
+            {
+                RemoveTag(tag);
+            }
+        }
+
+        private void CommitInputText()
+        {
+            if (AddTag(_currentInput))
+            {
+                ClearInput();
+            }
+        }
+
+        private bool TryAcceptHighlightedSuggestion()
+        {
+            if (SuggestionList.SelectedItem is string tag && AddTag(tag))
+            {
+                ClearInput();
+                return true;
+            }
+
+            return TryAcceptFirstSuggestion();
+        }
+
+        private bool TryAcceptFirstSuggestion()
+        {
+            var first = _filteredSuggestions.FirstOrDefault();
+            if (first is null)
+            {
+                return false;
+            }
+
+            if (AddTag(first))
+            {
+                ClearInput();
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool AddTag(string? tag)
+        {
+            if (string.IsNullOrWhiteSpace(tag))
+            {
+                return false;
+            }
+
+            var trimmed = tag.Trim();
+            if (trimmed.Length == 0)
+            {
+                return false;
+            }
+
+            if (_selectedTagSet.Contains(trimmed))
+            {
+                return false;
+            }
+
+            SelectedTags ??= new ObservableCollection<string>();
+            SelectedTags.Add(trimmed);
+            _selectedTagSet.Add(trimmed);
+            return true;
+        }
+
+        private void RemoveTag(string? tag)
+        {
+            if (string.IsNullOrWhiteSpace(tag) || SelectedTags is null)
+            {
+                return;
+            }
+
+            var trimmed = tag.Trim();
+            for (var i = SelectedTags.Count - 1; i >= 0; i--)
+            {
+                if (string.Equals(SelectedTags[i], trimmed, StringComparison.OrdinalIgnoreCase))
+                {
+                    SelectedTags.RemoveAt(i);
+                    break;
+                }
+            }
+
+            _selectedTagSet.Remove(trimmed);
+            UpdateSuggestions(_currentInput);
+        }
+
+        private void RemoveLastTag()
+        {
+            if (SelectedTags is null || SelectedTags.Count == 0)
+            {
+                return;
+            }
+
+            var last = SelectedTags[^1];
+            SelectedTags.RemoveAt(SelectedTags.Count - 1);
+            _selectedTagSet.Remove(last);
+            UpdateSuggestions(_currentInput);
+        }
+
+        private void ClearInput()
+        {
+            _currentInput = string.Empty;
+            InputBox.Text = string.Empty;
+            UpdateSuggestions(_currentInput);
+            InputBox.Focus();
+        }
+
+        private void UpdateSuggestions(string? filter)
+        {
+            var vocabulary = TagVocabulary ?? Array.Empty<string>();
+            var trimmed = (filter ?? string.Empty).Trim();
+
+            var candidates = vocabulary
+                .Where(static tag => !string.IsNullOrWhiteSpace(tag))
+                .Select(static tag => tag.Trim())
+                .Where(tag => tag.Length > 0 && !_selectedTagSet.Contains(tag));
+
+            if (!string.IsNullOrEmpty(trimmed))
+            {
+                candidates = candidates.Where(tag => tag.IndexOf(trimmed, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+
+            var ordered = candidates
+                .OrderBy(tag => tag, StringComparer.OrdinalIgnoreCase)
+                .Take(20)
+                .ToArray();
+
+            _filteredSuggestions.Clear();
+            foreach (var suggestion in ordered)
+            {
+                _filteredSuggestions.Add(suggestion);
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -4,6 +4,9 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviors="clr-namespace:LM.App.Wpf.Views.Behaviors"
+             xmlns:libraryViews="clr-namespace:LM.App.Wpf.Views.Library"
+             xmlns:filters="clr-namespace:LM.Core.Models.Filters;assembly=LM.Core"
+             xmlns:converters="clr-namespace:LM.App.Wpf.Views.Converters"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 
              mc:Ignorable="d"
@@ -15,6 +18,7 @@
         <ResourceDictionary Source="Library/LibraryEntryDetailTemplate.xaml" />
         <ResourceDictionary Source="Templates/LibraryResultsColumns.xaml" />
       </ResourceDictionary.MergedDictionaries>
+      <converters:EnumEqualsConverter x:Key="EnumEqualsConverter" />
     </ResourceDictionary>
 
   </UserControl.Resources>
@@ -51,8 +55,23 @@
         <TextBlock Text="Author contains"/>
         <TextBox Text="{Binding AuthorContains, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <TextBlock Text="Tags (comma-separated)"/>
-        <TextBox Text="{Binding TagsCsv, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Text="Tags"/>
+        <libraryViews:TagTokenSelector SelectedTags="{Binding SelectedTags}"
+                                       TagVocabulary="{Binding TagVocabulary}"/>
+        <StackPanel Orientation="Horizontal" Margin="0,6,0,6">
+          <TextBlock Text="Match mode:" VerticalAlignment="Center" Margin="0,0,8,0"/>
+          <RadioButton Content="Any"
+                       GroupName="TagMatchMode"
+                       Margin="0,0,6,0"
+                       IsChecked="{Binding TagMatchMode, Mode=TwoWay, Converter={StaticResource EnumEqualsConverter}, ConverterParameter={x:Static filters:TagMatchMode.Any}}"/>
+          <RadioButton Content="All"
+                       GroupName="TagMatchMode"
+                       Margin="0,0,6,0"
+                       IsChecked="{Binding TagMatchMode, Mode=TwoWay, Converter={StaticResource EnumEqualsConverter}, ConverterParameter={x:Static filters:TagMatchMode.All}}"/>
+          <RadioButton Content="Not"
+                       GroupName="TagMatchMode"
+                       IsChecked="{Binding TagMatchMode, Mode=TwoWay, Converter={StaticResource EnumEqualsConverter}, ConverterParameter={x:Static filters:TagMatchMode.Not}}"/>
+        </StackPanel>
 
         <TextBlock Text="Source contains"/>
         <TextBox Text="{Binding SourceContains, UpdateSourceTrigger=PropertyChanged}"/>

--- a/src/LM.Core/Abstractions/ITagVocabularyProvider.cs
+++ b/src/LM.Core/Abstractions/ITagVocabularyProvider.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LM.Core.Abstractions
+{
+    public interface ITagVocabularyProvider
+    {
+        Task<IReadOnlyList<string>> GetAllTagsAsync(CancellationToken ct = default);
+    }
+}

--- a/src/LM.Core/Models/Filters.cs
+++ b/src/LM.Core/Models/Filters.cs
@@ -7,11 +7,19 @@ namespace LM.Core.Models.Filters
     /// <summary>
     /// Fielded filters for Library (metadata-only for now).
     /// </summary>
+    public enum TagMatchMode
+    {
+        Any,
+        All,
+        Not
+    }
+
     public sealed class EntryFilter
     {
         public string? TitleContains { get; set; }
         public string? AuthorContains { get; set; }
-        public List<string> TagsAny { get; set; } = new();
+        public List<string> Tags { get; set; } = new();
+        public TagMatchMode TagMatchMode { get; set; } = TagMatchMode.Any;
         public EntryType[]? TypesAny { get; set; }
         public int? YearFrom { get; set; }
         public int? YearTo { get; set; }

--- a/src/LM.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Core/PublicAPI.Unshipped.txt
@@ -32,6 +32,8 @@ LM.Core.Abstractions.IPmidNormalizer
 LM.Core.Abstractions.IPmidNormalizer.Normalize(string? raw) -> string?
 LM.Core.Abstractions.ISimilarityService
 LM.Core.Abstractions.ISimilarityService.ComputeFileSimilarityAsync(string! filePathA, string! filePathB, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<double>!
+LM.Core.Abstractions.ITagVocabularyProvider
+LM.Core.Abstractions.ITagVocabularyProvider.GetAllTagsAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
 LM.Core.Abstractions.IWorkSpaceService
 LM.Core.Abstractions.IWorkSpaceService.EnsureWorkspaceAsync(string! absoluteWorkspacePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.Core.Abstractions.IWorkSpaceService.GetAbsolutePath(string! relativePath) -> string!
@@ -205,8 +207,14 @@ LM.Core.Models.Filters.EntryFilter.AuthorContains.set -> void
 LM.Core.Models.Filters.EntryFilter.EntryFilter() -> void
 LM.Core.Models.Filters.EntryFilter.IsInternal.get -> bool?
 LM.Core.Models.Filters.EntryFilter.IsInternal.set -> void
-LM.Core.Models.Filters.EntryFilter.TagsAny.get -> System.Collections.Generic.List<string!>!
-LM.Core.Models.Filters.EntryFilter.TagsAny.set -> void
+LM.Core.Models.Filters.EntryFilter.TagMatchMode.get -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.EntryFilter.TagMatchMode.set -> void
+LM.Core.Models.Filters.EntryFilter.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Filters.EntryFilter.Tags.set -> void
+LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.TagMatchMode.Any = 0 -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.TagMatchMode.All = 1 -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.TagMatchMode.Not = 2 -> LM.Core.Models.Filters.TagMatchMode
 LM.Core.Models.Filters.EntryFilter.TitleContains.get -> string?
 LM.Core.Models.Filters.EntryFilter.TitleContains.set -> void
 LM.Core.Models.Filters.EntryFilter.TypesAny.get -> LM.Core.Models.EntryType[]?

--- a/src/LM.Infrastructure/Entries/EntryTagVocabularyProvider.cs
+++ b/src/LM.Infrastructure/Entries/EntryTagVocabularyProvider.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Abstractions;
+
+namespace LM.Infrastructure.Entries
+{
+    public sealed class EntryTagVocabularyProvider : ITagVocabularyProvider
+    {
+        private readonly IEntryStore _store;
+
+        public EntryTagVocabularyProvider(IEntryStore store)
+        {
+            _store = store ?? throw new System.ArgumentNullException(nameof(store));
+        }
+
+        public async Task<IReadOnlyList<string>> GetAllTagsAsync(CancellationToken ct = default)
+        {
+            var tags = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+
+            await foreach (var entry in _store.EnumerateAsync(ct).ConfigureAwait(false))
+            {
+                if (entry.Tags is null)
+                {
+                    continue;
+                }
+
+                foreach (var tag in entry.Tags)
+                {
+                    if (string.IsNullOrWhiteSpace(tag))
+                    {
+                        continue;
+                    }
+
+                    var trimmed = tag.Trim();
+                    if (trimmed.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    tags.Add(trimmed);
+                }
+            }
+
+            return tags
+                .OrderBy(static t => t, System.StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+    }
+}

--- a/src/LM.Infrastructure/Entries/JsonEntryStore.cs
+++ b/src/LM.Infrastructure/Entries/JsonEntryStore.cs
@@ -202,10 +202,17 @@ namespace LM.Infrastructure.Entries
                 var flag = f.IsInternal.Value;
                 q = q.Where(e => e.IsInternal == flag);
             }
-            if (f.TagsAny.Count > 0)
+            if (f.Tags.Count > 0)
             {
-                var tags = new HashSet<string>(f.TagsAny, StringComparer.OrdinalIgnoreCase);
-                q = q.Where(e => e.Tags?.Any(t => tags.Contains(t)) ?? false);
+                var tags = new HashSet<string>(f.Tags, StringComparer.OrdinalIgnoreCase);
+                q = f.TagMatchMode switch
+                {
+                    TagMatchMode.All => q.Where(e =>
+                        e.Tags is not null && tags.All(tag => e.Tags.Any(t => string.Equals(t, tag, StringComparison.OrdinalIgnoreCase)))),
+                    TagMatchMode.Not => q.Where(e =>
+                        !(e.Tags?.Any(t => tags.Contains(t)) ?? false)),
+                    _ => q.Where(e => e.Tags?.Any(t => tags.Contains(t)) ?? false)
+                };
             }
 
             if (!string.IsNullOrWhiteSpace(f.InternalIdContains))

--- a/src/LM.Infrastructure/PublicAPI.Unshipped.txt
+++ b/src/LM.Infrastructure/PublicAPI.Unshipped.txt
@@ -21,6 +21,9 @@ LM.Infrastructure.Entries.JsonEntryStore.InitializeAsync(System.Threading.Cancel
 LM.Infrastructure.Entries.JsonEntryStore.JsonEntryStore(LM.Core.Abstractions.IWorkSpaceService! ws, LM.Core.Abstractions.IDoiNormalizer? doiNormalizer = null, LM.Core.Abstractions.IPmidNormalizer? pmidNormalizer = null) -> void
 LM.Infrastructure.Entries.JsonEntryStore.SaveAsync(LM.Core.Models.Entry! entry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.Infrastructure.Entries.JsonEntryStore.SearchAsync(LM.Core.Models.Filters.EntryFilter! f, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Infrastructure.Entries.EntryTagVocabularyProvider
+LM.Infrastructure.Entries.EntryTagVocabularyProvider.EntryTagVocabularyProvider(LM.Core.Abstractions.IEntryStore! store) -> void
+LM.Infrastructure.Entries.EntryTagVocabularyProvider.GetAllTagsAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
 LM.Infrastructure.Export.MetadataDebugSlideExporter
 LM.Infrastructure.Export.MetadataDebugSlideExporter.ExportAsync(System.Collections.Generic.IEnumerable<LM.Core.Models.FileMetadata!>! items, string! outPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
 LM.Infrastructure.Export.MetadataDebugSlideExporter.MetadataDebugSlideExporter() -> void


### PR DESCRIPTION
## Summary
- add an entry tag vocabulary provider and register it for library consumption
- replace the tags textbox with a tokenizing selector and persist the selected tag match mode in filters and presets
- expand search filtering and tests to honor ANY/ALL/NOT tag modes and ensure selections survive searches

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug`
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: missing Microsoft.WindowsDesktop.App runtime on linux-x64)*

------
https://chatgpt.com/codex/tasks/task_e_68d50e8cac20832baa81fd57fddd9c59