### PR TITLE
Implement unified library search and navigation

### DIFF
--- a/src/LM.App.Wpf.Tests/LibraryFilterPresetStoreTests.cs
+++ b/src/LM.App.Wpf.Tests/LibraryFilterPresetStoreTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using LM.App.Wpf.Library;
 using LM.Infrastructure.FileSystem;
-using LM.Core.Models.Filters;
 using Xunit;
 
 public class LibraryFilterPresetStoreTests
@@ -21,27 +20,12 @@ public class LibraryFilterPresetStoreTests
             Name = "My Preset",
             State = new LibraryFilterState
             {
-                TitleContains = "title",
-                AuthorContains = "author",
-                Tags = new List<string> { "tag1", "tag2" },
-                TagMatchMode = TagMatchMode.All,
-                IsInternal = true,
-                YearFrom = 2010,
-                YearTo = 2020,
-                SourceContains = "source",
-                InternalIdContains = "internal",
-                DoiContains = "doi",
-                PmidContains = "pmid",
-                NctContains = "nct",
-                AddedByContains = "adder",
-                AddedOnFrom = new DateTime(2024, 1, 1),
-                AddedOnTo = new DateTime(2024, 12, 31),
-                TypePublication = false,
-                TypePresentation = true,
-                TypeWhitePaper = false,
-                TypeSlideDeck = true,
-                TypeReport = false,
-                TypeOther = true
+                UseFullTextSearch = true,
+                UnifiedQuery = "title:heart",
+                FullTextQuery = "heart",
+                FullTextInTitle = false,
+                FullTextInAbstract = true,
+                FullTextInContent = false
             }
         };
 
@@ -52,27 +36,12 @@ public class LibraryFilterPresetStoreTests
         Assert.Equal("My Preset", loaded.Name);
         Assert.True((DateTime.UtcNow - loaded.SavedUtc) < TimeSpan.FromMinutes(1));
 
-        Assert.Equal(preset.State.TitleContains, loaded.State.TitleContains);
-        Assert.Equal(preset.State.AuthorContains, loaded.State.AuthorContains);
-        Assert.Equal(preset.State.Tags, loaded.State.Tags);
-        Assert.Equal(preset.State.TagMatchMode, loaded.State.TagMatchMode);
-        Assert.Equal(preset.State.IsInternal, loaded.State.IsInternal);
-        Assert.Equal(preset.State.YearFrom, loaded.State.YearFrom);
-        Assert.Equal(preset.State.YearTo, loaded.State.YearTo);
-        Assert.Equal(preset.State.SourceContains, loaded.State.SourceContains);
-        Assert.Equal(preset.State.InternalIdContains, loaded.State.InternalIdContains);
-        Assert.Equal(preset.State.DoiContains, loaded.State.DoiContains);
-        Assert.Equal(preset.State.PmidContains, loaded.State.PmidContains);
-        Assert.Equal(preset.State.NctContains, loaded.State.NctContains);
-        Assert.Equal(preset.State.AddedByContains, loaded.State.AddedByContains);
-        Assert.Equal(preset.State.AddedOnFrom, loaded.State.AddedOnFrom);
-        Assert.Equal(preset.State.AddedOnTo, loaded.State.AddedOnTo);
-        Assert.Equal(preset.State.TypePublication, loaded.State.TypePublication);
-        Assert.Equal(preset.State.TypePresentation, loaded.State.TypePresentation);
-        Assert.Equal(preset.State.TypeWhitePaper, loaded.State.TypeWhitePaper);
-        Assert.Equal(preset.State.TypeSlideDeck, loaded.State.TypeSlideDeck);
-        Assert.Equal(preset.State.TypeReport, loaded.State.TypeReport);
-        Assert.Equal(preset.State.TypeOther, loaded.State.TypeOther);
+        Assert.Equal(preset.State.UseFullTextSearch, loaded.State.UseFullTextSearch);
+        Assert.Equal(preset.State.UnifiedQuery, loaded.State.UnifiedQuery);
+        Assert.Equal(preset.State.FullTextQuery, loaded.State.FullTextQuery);
+        Assert.Equal(preset.State.FullTextInTitle, loaded.State.FullTextInTitle);
+        Assert.Equal(preset.State.FullTextInAbstract, loaded.State.FullTextInAbstract);
+        Assert.Equal(preset.State.FullTextInContent, loaded.State.FullTextInContent);
 
         var fetched = await store.TryGetPresetAsync("my preset");
         Assert.NotNull(fetched);

--- a/src/LM.App.Wpf.Tests/LibrarySearchParserTests.cs
+++ b/src/LM.App.Wpf.Tests/LibrarySearchParserTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using LM.App.Wpf.Library.Search;
+using LM.Core.Models;
+using Xunit;
+
+namespace LM.App.Wpf.Tests
+{
+    public sealed class LibrarySearchParserTests
+    {
+        private readonly LibrarySearchParser _parser = new();
+        private readonly LibrarySearchEvaluator _evaluator = new();
+
+        [Fact]
+        public void Parse_ReturnsNullForEmptyQuery()
+        {
+            Assert.Null(_parser.Parse(null));
+            Assert.Null(_parser.Parse(string.Empty));
+            Assert.Null(_parser.Parse("   "));
+        }
+
+        [Fact]
+        public void ImplicitAnd_MatchesEntriesWithAllTerms()
+        {
+            var node = _parser.Parse("title:heart author:smith");
+            Assert.NotNull(node);
+
+            var matching = new Entry
+            {
+                Title = "Heart Health", 
+                Authors = new List<string> { "Jane Smith" }
+            };
+            var nonMatching = new Entry
+            {
+                Title = "Heart Health",
+                Authors = new List<string> { "Alex Johnson" }
+            };
+
+            Assert.True(_evaluator.Matches(matching, node));
+            Assert.False(_evaluator.Matches(nonMatching, node));
+        }
+
+        [Fact]
+        public void BooleanOperators_RespectGrouping()
+        {
+            var node = _parser.Parse("title:heart AND (author:smith OR author:doe)");
+            Assert.NotNull(node);
+
+            var smith = new Entry { Title = "Heart Insights", Authors = new List<string> { "John Smith" } };
+            var doe = new Entry { Title = "Heart Insights", Authors = new List<string> { "Mary Doe" } };
+            var other = new Entry { Title = "Heart Insights", Authors = new List<string> { "Alex Johnson" } };
+
+            Assert.True(_evaluator.Matches(smith, node));
+            Assert.True(_evaluator.Matches(doe, node));
+            Assert.False(_evaluator.Matches(other, node));
+        }
+
+        [Fact]
+        public void NotOperator_ExcludesMatchingEntries()
+        {
+            var node = _parser.Parse("NOT internal:true");
+            Assert.NotNull(node);
+
+            var internalEntry = new Entry { IsInternal = true };
+            var externalEntry = new Entry { IsInternal = false };
+
+            Assert.False(_evaluator.Matches(internalEntry, node));
+            Assert.True(_evaluator.Matches(externalEntry, node));
+        }
+
+        [Fact]
+        public void NumericAndDateOperators_FilterCorrectly()
+        {
+            var node = _parser.Parse("year:>=2020 AND addedon:2024-03-15");
+            Assert.NotNull(node);
+
+            var matching = new Entry
+            {
+                Year = 2021,
+                AddedOnUtc = new DateTime(2024, 3, 15, 10, 30, 0, DateTimeKind.Utc)
+            };
+            var wrongYear = new Entry
+            {
+                Year = 2019,
+                AddedOnUtc = matching.AddedOnUtc
+            };
+            var wrongDate = new Entry
+            {
+                Year = matching.Year,
+                AddedOnUtc = new DateTime(2024, 3, 14, 0, 0, 0, DateTimeKind.Utc)
+            };
+
+            Assert.True(_evaluator.Matches(matching, node));
+            Assert.False(_evaluator.Matches(wrongYear, node));
+            Assert.False(_evaluator.Matches(wrongDate, node));
+        }
+
+        [Fact]
+        public void SetOperators_HandleTags()
+        {
+            var node = _parser.Parse("tags:cardio,vascular");
+            Assert.NotNull(node);
+
+            var withCardio = new Entry { Tags = new List<string> { "cardiology", "urgent" } };
+            var withVascular = new Entry { Tags = new List<string> { "vascular clinic" } };
+            var unrelated = new Entry { Tags = new List<string> { "oncology" } };
+
+            Assert.True(_evaluator.Matches(withCardio, node));
+            Assert.True(_evaluator.Matches(withVascular, node));
+            Assert.False(_evaluator.Matches(unrelated, node));
+        }
+    }
+}

--- a/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
@@ -38,7 +38,9 @@ namespace LM.App.Wpf.Composition.Modules
 
             services.AddSingleton(sp => new LibraryFiltersViewModel(
                 sp.GetRequiredService<LibraryFilterPresetStore>(),
-                sp.GetRequiredService<ILibraryPresetPrompt>()));
+                sp.GetRequiredService<ILibraryPresetPrompt>(),
+                sp.GetRequiredService<IEntryStore>(),
+                sp.GetRequiredService<IWorkSpaceService>()));
 
             services.AddSingleton(sp => new LibraryResultsViewModel(
                 sp.GetRequiredService<IEntryStore>(),
@@ -52,7 +54,6 @@ namespace LM.App.Wpf.Composition.Modules
             services.AddSingleton(sp => new LibraryViewModel(
                 sp.GetRequiredService<IEntryStore>(),
                 sp.GetRequiredService<IFullTextSearchService>(),
-                sp.GetRequiredService<ITagVocabularyProvider>(),
                 sp.GetRequiredService<LibraryFiltersViewModel>(),
                 sp.GetRequiredService<LibraryResultsViewModel>(),
                 sp.GetRequiredService<IWorkSpaceService>(),

--- a/src/LM.App.Wpf/Library/LibraryFilterPresetStore.cs
+++ b/src/LM.App.Wpf/Library/LibraryFilterPresetStore.cs
@@ -7,7 +7,6 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using LM.Core.Abstractions;
-using LM.Core.Models.Filters;
 
 namespace LM.App.Wpf.Library
 {
@@ -135,37 +134,13 @@ namespace LM.App.Wpf.Library
     public sealed class LibraryFilterState
     {
         public bool UseFullTextSearch { get; set; }
+        public string? UnifiedQuery { get; set; }
         public string? FullTextQuery { get; set; }
         public bool FullTextInTitle { get; set; } = true;
         public bool FullTextInAbstract { get; set; } = true;
         public bool FullTextInContent { get; set; } = true;
-        public string? TitleContains { get; set; }
-        public string? AuthorContains { get; set; }
-        public List<string> Tags { get; set; } = new();
-        public TagMatchMode TagMatchMode { get; set; } = TagMatchMode.Any;
-        public bool? IsInternal { get; set; }
-        public int? YearFrom { get; set; }
-        public int? YearTo { get; set; }
-        public string? SourceContains { get; set; }
-        public string? InternalIdContains { get; set; }
-        public string? DoiContains { get; set; }
-        public string? PmidContains { get; set; }
-        public string? NctContains { get; set; }
-        public string? AddedByContains { get; set; }
-        public DateTime? AddedOnFrom { get; set; }
-        public DateTime? AddedOnTo { get; set; }
-        public bool TypePublication { get; set; } = true;
-        public bool TypePresentation { get; set; } = true;
-        public bool TypeWhitePaper { get; set; } = true;
-        public bool TypeSlideDeck { get; set; } = true;
-        public bool TypeReport { get; set; } = true;
-        public bool TypeOther { get; set; } = true;
 
         internal LibraryFilterState Clone()
-        {
-            var clone = (LibraryFilterState)MemberwiseClone();
-            clone.Tags = Tags is null ? new List<string>() : new List<string>(Tags);
-            return clone;
-        }
+            => (LibraryFilterState)MemberwiseClone();
     }
 }

--- a/src/LM.App.Wpf/Library/Search/LibrarySearchEvaluator.cs
+++ b/src/LM.App.Wpf/Library/Search/LibrarySearchEvaluator.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LM.Core.Models;
+
+namespace LM.App.Wpf.Library.Search
+{
+    internal sealed class LibrarySearchEvaluator
+    {
+        private static readonly StringComparison Comparison = StringComparison.OrdinalIgnoreCase;
+
+        public bool Matches(Entry entry, LibrarySearchNode? node)
+        {
+            if (entry is null)
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+
+            if (node is null)
+            {
+                return true;
+            }
+
+            return EvaluateNode(entry, node);
+        }
+
+        private bool EvaluateNode(Entry entry, LibrarySearchNode node)
+        {
+            switch (node)
+            {
+                case LibrarySearchTermNode termNode:
+                    return EvaluateTerm(entry, termNode.Term);
+                case LibrarySearchUnaryNode unaryNode:
+                    return unaryNode.Operator == LibrarySearchUnaryOperator.Not
+                        ? !EvaluateNode(entry, unaryNode.Operand)
+                        : EvaluateNode(entry, unaryNode.Operand);
+                case LibrarySearchBinaryNode binaryNode:
+                    var left = EvaluateNode(entry, binaryNode.Left);
+                    var right = EvaluateNode(entry, binaryNode.Right);
+                    return binaryNode.Operator == LibrarySearchBinaryOperator.And
+                        ? left && right
+                        : left || right;
+                default:
+                    return true;
+            }
+        }
+
+        private bool EvaluateTerm(Entry entry, LibrarySearchTerm term)
+        {
+            return term.Field switch
+            {
+                LibrarySearchField.Title => Contains(entry.Title, term.Value),
+                LibrarySearchField.Author => entry.Authors?.Any(author => Contains(author, term.Value)) ?? false,
+                LibrarySearchField.Source => Contains(entry.Source, term.Value),
+                LibrarySearchField.InternalId => Contains(entry.InternalId, term.Value),
+                LibrarySearchField.Doi => Contains(entry.Doi, term.Value),
+                LibrarySearchField.Pmid => Contains(entry.Pmid, term.Value),
+                LibrarySearchField.Nct => Contains(entry.Nct, term.Value),
+                LibrarySearchField.AddedBy => Contains(entry.AddedBy, term.Value),
+                LibrarySearchField.Tags => EvaluateTags(entry, term),
+                LibrarySearchField.Type => EvaluateTypes(entry, term),
+                LibrarySearchField.Year => EvaluateYear(entry, term),
+                LibrarySearchField.AddedOn => EvaluateAddedOn(entry, term),
+                LibrarySearchField.Internal => EvaluateInternal(entry, term),
+                LibrarySearchField.Notes => Contains(entry.Notes, term.Value) || Contains(entry.UserNotes, term.Value),
+                _ => EvaluateAny(entry, term.Value)
+            };
+        }
+
+        private static bool EvaluateTags(Entry entry, LibrarySearchTerm term)
+        {
+            if (entry.Tags is null || entry.Tags.Count == 0)
+            {
+                return false;
+            }
+
+            if (term.TextValues is { Count: > 0 })
+            {
+                return term.TextValues.Any(tag => entry.Tags.Any(entryTag => entryTag?.IndexOf(tag, Comparison) >= 0));
+            }
+
+            return entry.Tags.Any(tag => Contains(tag, term.Value));
+        }
+
+        private static bool EvaluateTypes(Entry entry, LibrarySearchTerm term)
+        {
+            if (term.TypeValues is { Count: > 0 })
+            {
+                return term.TypeValues.Contains(entry.Type);
+            }
+
+            if (Enum.TryParse<EntryType>(term.Value, true, out var parsed))
+            {
+                return entry.Type == parsed;
+            }
+
+            return false;
+        }
+
+        private static bool EvaluateYear(Entry entry, LibrarySearchTerm term)
+        {
+            if (!entry.Year.HasValue)
+            {
+                return false;
+            }
+
+            var year = entry.Year.Value;
+            return term.Operation switch
+            {
+                LibrarySearchTermOperation.Equals => term.NumberValue.HasValue && year == term.NumberValue.Value,
+                LibrarySearchTermOperation.GreaterThan => term.NumberValue.HasValue && year > term.NumberValue.Value,
+                LibrarySearchTermOperation.GreaterThanOrEqual => term.NumberValue.HasValue && year >= term.NumberValue.Value,
+                LibrarySearchTermOperation.LessThan => term.NumberValue.HasValue && year < term.NumberValue.Value,
+                LibrarySearchTermOperation.LessThanOrEqual => term.NumberValue.HasValue && year <= term.NumberValue.Value,
+                LibrarySearchTermOperation.Between => term.NumberValue.HasValue && term.SecondaryNumberValue.HasValue &&
+                    year >= Math.Min(term.NumberValue.Value, term.SecondaryNumberValue.Value) &&
+                    year <= Math.Max(term.NumberValue.Value, term.SecondaryNumberValue.Value),
+                _ => Contains(year.ToString(), term.Value)
+            };
+        }
+
+        private static bool EvaluateAddedOn(Entry entry, LibrarySearchTerm term)
+        {
+            var date = entry.AddedOnUtc.ToLocalTime().Date;
+            return term.Operation switch
+            {
+                LibrarySearchTermOperation.Equals => term.DateValue.HasValue && date == term.DateValue.Value.Date,
+                LibrarySearchTermOperation.GreaterThan => term.DateValue.HasValue && date > term.DateValue.Value.Date,
+                LibrarySearchTermOperation.GreaterThanOrEqual => term.DateValue.HasValue && date >= term.DateValue.Value.Date,
+                LibrarySearchTermOperation.LessThan => term.DateValue.HasValue && date < term.DateValue.Value.Date,
+                LibrarySearchTermOperation.LessThanOrEqual => term.DateValue.HasValue && date <= term.DateValue.Value.Date,
+                LibrarySearchTermOperation.Between => term.DateValue.HasValue && term.SecondaryDateValue.HasValue &&
+                    date >= term.DateValue.Value.Date && date <= term.SecondaryDateValue.Value.Date,
+                _ => Contains(date.ToString("yyyy-MM-dd"), term.Value)
+            };
+        }
+
+        private static bool EvaluateInternal(Entry entry, LibrarySearchTerm term)
+        {
+            if (term.BooleanValue.HasValue)
+            {
+                return entry.IsInternal == term.BooleanValue.Value;
+            }
+
+            return term.Value.Equals("true", StringComparison.OrdinalIgnoreCase)
+                ? entry.IsInternal
+                : !entry.IsInternal;
+        }
+
+        private static bool EvaluateAny(Entry entry, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return true;
+            }
+
+            return Contains(entry.Title, value)
+                || entry.Authors?.Any(author => Contains(author, value)) == true
+                || Contains(entry.Source, value)
+                || Contains(entry.InternalId, value)
+                || Contains(entry.Doi, value)
+                || Contains(entry.Pmid, value)
+                || Contains(entry.Nct, value)
+                || entry.Tags?.Any(tag => Contains(tag, value)) == true
+                || Contains(entry.Notes, value)
+                || Contains(entry.UserNotes, value);
+        }
+
+        private static bool Contains(string? source, string value)
+        {
+            if (string.IsNullOrWhiteSpace(source) || string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            return source.IndexOf(value.Trim(), Comparison) >= 0;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Library/Search/LibrarySearchField.cs
+++ b/src/LM.App.Wpf/Library/Search/LibrarySearchField.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using LM.Core.Models;
+
+namespace LM.App.Wpf.Library.Search
+{
+    internal enum LibrarySearchField
+    {
+        Any,
+        Title,
+        Author,
+        Tags,
+        Source,
+        InternalId,
+        Doi,
+        Pmid,
+        Nct,
+        Type,
+        Year,
+        AddedBy,
+        AddedOn,
+        Internal,
+        Notes
+    }
+
+    internal static class LibrarySearchFieldMap
+    {
+        private static readonly Dictionary<string, LibrarySearchField> _map = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["title"] = LibrarySearchField.Title,
+            ["t"] = LibrarySearchField.Title,
+            ["author"] = LibrarySearchField.Author,
+            ["authors"] = LibrarySearchField.Author,
+            ["a"] = LibrarySearchField.Author,
+            ["tag"] = LibrarySearchField.Tags,
+            ["tags"] = LibrarySearchField.Tags,
+            ["source"] = LibrarySearchField.Source,
+            ["journal"] = LibrarySearchField.Source,
+            ["internalid"] = LibrarySearchField.InternalId,
+            ["id"] = LibrarySearchField.InternalId,
+            ["doi"] = LibrarySearchField.Doi,
+            ["pmid"] = LibrarySearchField.Pmid,
+            ["nct"] = LibrarySearchField.Nct,
+            ["type"] = LibrarySearchField.Type,
+            ["entrytype"] = LibrarySearchField.Type,
+            ["year"] = LibrarySearchField.Year,
+            ["addedby"] = LibrarySearchField.AddedBy,
+            ["createdby"] = LibrarySearchField.AddedBy,
+            ["addedon"] = LibrarySearchField.AddedOn,
+            ["created"] = LibrarySearchField.AddedOn,
+            ["internal"] = LibrarySearchField.Internal,
+            ["visibility"] = LibrarySearchField.Internal,
+            ["notes"] = LibrarySearchField.Notes,
+            ["summary"] = LibrarySearchField.Notes
+        };
+
+        public static LibrarySearchField Resolve(string? token)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return LibrarySearchField.Any;
+            }
+
+            if (_map.TryGetValue(token.Trim(), out var field))
+            {
+                return field;
+            }
+
+            if (Enum.TryParse<EntryType>(token, ignoreCase: true, out _))
+            {
+                return LibrarySearchField.Type;
+            }
+
+            return LibrarySearchField.Any;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Library/Search/LibrarySearchLexer.cs
+++ b/src/LM.App.Wpf/Library/Search/LibrarySearchLexer.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LM.App.Wpf.Library.Search
+{
+    internal enum LibrarySearchTokenKind
+    {
+        Word,
+        String,
+        Colon,
+        LeftParen,
+        RightParen,
+        And,
+        Or,
+        Not
+    }
+
+    internal readonly struct LibrarySearchToken
+    {
+        public LibrarySearchToken(LibrarySearchTokenKind kind, string text)
+        {
+            Kind = kind;
+            Text = text;
+        }
+
+        public LibrarySearchTokenKind Kind { get; }
+        public string Text { get; }
+        public override string ToString() => $"{Kind}:{Text}";
+    }
+
+    internal sealed class LibrarySearchLexer
+    {
+        private readonly string _text;
+        private int _index;
+
+        public LibrarySearchLexer(string text)
+        {
+            _text = text ?? string.Empty;
+        }
+
+        public List<LibrarySearchToken> Tokenize()
+        {
+            var tokens = new List<LibrarySearchToken>();
+            while (TryReadNext(out var token))
+            {
+                tokens.Add(token);
+            }
+
+            return tokens;
+        }
+
+        private bool TryReadNext(out LibrarySearchToken token)
+        {
+            SkipWhitespace();
+            if (EndOfText)
+            {
+                token = default;
+                return false;
+            }
+
+            var ch = _text[_index];
+            switch (ch)
+            {
+                case ':':
+                    _index++;
+                    token = new LibrarySearchToken(LibrarySearchTokenKind.Colon, ":");
+                    return true;
+                case '(':
+                    _index++;
+                    token = new LibrarySearchToken(LibrarySearchTokenKind.LeftParen, "(");
+                    return true;
+                case ')':
+                    _index++;
+                    token = new LibrarySearchToken(LibrarySearchTokenKind.RightParen, ")");
+                    return true;
+                case '"':
+                    token = ReadString();
+                    return true;
+                default:
+                    token = ReadWord();
+                    return true;
+            }
+        }
+
+        private LibrarySearchToken ReadString()
+        {
+            var sb = new StringBuilder();
+            _index++; // skip opening quote
+            while (!EndOfText)
+            {
+                var ch = _text[_index++];
+                if (ch == '"')
+                {
+                    break;
+                }
+
+                if (ch == '\\' && !EndOfText)
+                {
+                    var escape = _text[_index++];
+                    sb.Append(escape);
+                    continue;
+                }
+
+                sb.Append(ch);
+            }
+
+            return new LibrarySearchToken(LibrarySearchTokenKind.String, sb.ToString());
+        }
+
+        private LibrarySearchToken ReadWord()
+        {
+            var start = _index;
+            while (!EndOfText)
+            {
+                var ch = _text[_index];
+                if (char.IsWhiteSpace(ch) || ch == ':' || ch == '(' || ch == ')' || ch == '"')
+                {
+                    break;
+                }
+
+                _index++;
+            }
+
+            var text = _text.Substring(start, _index - start);
+            if (text.Equals("AND", StringComparison.OrdinalIgnoreCase))
+            {
+                return new LibrarySearchToken(LibrarySearchTokenKind.And, text);
+            }
+            if (text.Equals("OR", StringComparison.OrdinalIgnoreCase))
+            {
+                return new LibrarySearchToken(LibrarySearchTokenKind.Or, text);
+            }
+            if (text.Equals("NOT", StringComparison.OrdinalIgnoreCase))
+            {
+                return new LibrarySearchToken(LibrarySearchTokenKind.Not, text);
+            }
+
+            return new LibrarySearchToken(LibrarySearchTokenKind.Word, text);
+        }
+
+        private void SkipWhitespace()
+        {
+            while (!EndOfText && char.IsWhiteSpace(_text[_index]))
+            {
+                _index++;
+            }
+        }
+
+        private bool EndOfText => _index >= _text.Length;
+    }
+}

--- a/src/LM.App.Wpf/Library/Search/LibrarySearchNode.cs
+++ b/src/LM.App.Wpf/Library/Search/LibrarySearchNode.cs
@@ -1,0 +1,53 @@
+namespace LM.App.Wpf.Library.Search
+{
+    internal enum LibrarySearchBinaryOperator
+    {
+        And,
+        Or
+    }
+
+    internal enum LibrarySearchUnaryOperator
+    {
+        Not
+    }
+
+    internal abstract class LibrarySearchNode
+    {
+    }
+
+    internal sealed class LibrarySearchTermNode : LibrarySearchNode
+    {
+        public LibrarySearchTermNode(LibrarySearchTerm term)
+        {
+            Term = term;
+        }
+
+        public LibrarySearchTerm Term { get; }
+    }
+
+    internal sealed class LibrarySearchUnaryNode : LibrarySearchNode
+    {
+        public LibrarySearchUnaryNode(LibrarySearchUnaryOperator op, LibrarySearchNode operand)
+        {
+            Operator = op;
+            Operand = operand;
+        }
+
+        public LibrarySearchUnaryOperator Operator { get; }
+        public LibrarySearchNode Operand { get; }
+    }
+
+    internal sealed class LibrarySearchBinaryNode : LibrarySearchNode
+    {
+        public LibrarySearchBinaryNode(LibrarySearchBinaryOperator op, LibrarySearchNode left, LibrarySearchNode right)
+        {
+            Operator = op;
+            Left = left;
+            Right = right;
+        }
+
+        public LibrarySearchBinaryOperator Operator { get; }
+        public LibrarySearchNode Left { get; }
+        public LibrarySearchNode Right { get; }
+    }
+}

--- a/src/LM.App.Wpf/Library/Search/LibrarySearchParser.cs
+++ b/src/LM.App.Wpf/Library/Search/LibrarySearchParser.cs
@@ -1,0 +1,203 @@
+using System.Collections.Generic;
+
+namespace LM.App.Wpf.Library.Search
+{
+    internal sealed class LibrarySearchParser
+    {
+        public LibrarySearchNode? Parse(string? query)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return null;
+            }
+
+            var lexer = new LibrarySearchLexer(query);
+            var tokens = lexer.Tokenize();
+            if (tokens.Count == 0)
+            {
+                return null;
+            }
+
+            var reader = new Reader(tokens);
+            return reader.ParseExpression();
+        }
+
+        private sealed class Reader
+        {
+            private readonly IReadOnlyList<LibrarySearchToken> _tokens;
+            private int _index;
+
+            public Reader(IReadOnlyList<LibrarySearchToken> tokens)
+            {
+                _tokens = tokens;
+            }
+
+            public LibrarySearchNode? ParseExpression()
+            {
+                var node = ParseOr();
+                return node;
+            }
+
+            private LibrarySearchNode? ParseOr()
+            {
+                var left = ParseAnd();
+                if (left is null)
+                {
+                    return null;
+                }
+
+                while (Match(LibrarySearchTokenKind.Or))
+                {
+                    var right = ParseAnd();
+                    if (right is null)
+                    {
+                        break;
+                    }
+
+                    left = new LibrarySearchBinaryNode(LibrarySearchBinaryOperator.Or, left, right);
+                }
+
+                return left;
+            }
+
+            private LibrarySearchNode? ParseAnd()
+            {
+                var left = ParseUnary();
+                if (left is null)
+                {
+                    return null;
+                }
+
+                while (true)
+                {
+                    if (Match(LibrarySearchTokenKind.And))
+                    {
+                        var right = ParseUnary();
+                        if (right is null)
+                        {
+                            break;
+                        }
+
+                        left = new LibrarySearchBinaryNode(LibrarySearchBinaryOperator.And, left, right);
+                        continue;
+                    }
+
+                    if (IsImplicitAndAhead())
+                    {
+                        var right = ParseUnary();
+                        if (right is null)
+                        {
+                            break;
+                        }
+
+                        left = new LibrarySearchBinaryNode(LibrarySearchBinaryOperator.And, left, right);
+                        continue;
+                    }
+
+                    break;
+                }
+
+                return left;
+            }
+
+            private LibrarySearchNode? ParseUnary()
+            {
+                if (Match(LibrarySearchTokenKind.Not))
+                {
+                    var operand = ParseUnary();
+                    if (operand is null)
+                    {
+                        return null;
+                    }
+
+                    return new LibrarySearchUnaryNode(LibrarySearchUnaryOperator.Not, operand);
+                }
+
+                if (Match(LibrarySearchTokenKind.LeftParen))
+                {
+                    var expr = ParseOr();
+                    Match(LibrarySearchTokenKind.RightParen);
+                    return expr;
+                }
+
+                return ParseTerm();
+            }
+
+            private LibrarySearchNode? ParseTerm()
+            {
+                if (Peek(out var current))
+                {
+                    switch (current.Kind)
+                    {
+                        case LibrarySearchTokenKind.String:
+                            Advance();
+                            var literalTerm = LibrarySearchTerm.Create(null, current.Text);
+                            return literalTerm is null ? null : new LibrarySearchTermNode(literalTerm);
+                        case LibrarySearchTokenKind.Word:
+                            Advance();
+                            if (Match(LibrarySearchTokenKind.Colon))
+                            {
+                                string value = string.Empty;
+                                if (Peek(out var next) && (next.Kind == LibrarySearchTokenKind.Word || next.Kind == LibrarySearchTokenKind.String))
+                                {
+                                    value = next.Text;
+                                    Advance();
+                                }
+
+                                var fieldTerm = LibrarySearchTerm.Create(current.Text, value);
+                                return fieldTerm is null ? null : new LibrarySearchTermNode(fieldTerm);
+                            }
+                            else
+                            {
+                                var anyTerm = LibrarySearchTerm.Create(null, current.Text);
+                                return anyTerm is null ? null : new LibrarySearchTermNode(anyTerm);
+                            }
+                    }
+                }
+
+                return null;
+            }
+
+            private bool IsImplicitAndAhead()
+            {
+                if (!Peek(out var next))
+                {
+                    return false;
+                }
+
+                return next.Kind is LibrarySearchTokenKind.Word or LibrarySearchTokenKind.String or LibrarySearchTokenKind.LeftParen or LibrarySearchTokenKind.Not;
+            }
+
+            private bool Match(LibrarySearchTokenKind kind)
+            {
+                if (Peek(out var token) && token.Kind == kind)
+                {
+                    Advance();
+                    return true;
+                }
+
+                return false;
+            }
+
+            private bool Peek(out LibrarySearchToken token)
+            {
+                if (_index >= _tokens.Count)
+                {
+                    token = default;
+                    return false;
+                }
+
+                token = _tokens[_index];
+                return true;
+            }
+
+            private void Advance()
+            {
+                if (_index < _tokens.Count)
+                {
+                    _index++;
+                }
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/Library/Search/LibrarySearchTerm.cs
+++ b/src/LM.App.Wpf/Library/Search/LibrarySearchTerm.cs
@@ -1,0 +1,371 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using LM.Core.Models;
+
+namespace LM.App.Wpf.Library.Search
+{
+    internal enum LibrarySearchTermOperation
+    {
+        Contains,
+        Equals,
+        GreaterThan,
+        GreaterThanOrEqual,
+        LessThan,
+        LessThanOrEqual,
+        Between,
+        InSet
+    }
+
+    internal sealed class LibrarySearchTerm
+    {
+        private LibrarySearchTerm(LibrarySearchField field)
+        {
+            Field = field;
+            Operation = LibrarySearchTermOperation.Contains;
+            Value = string.Empty;
+        }
+
+        public LibrarySearchField Field { get; }
+        public LibrarySearchTermOperation Operation { get; private set; }
+        public string Value { get; private set; }
+        public string? SecondaryValue { get; private set; }
+        public IReadOnlyList<EntryType>? TypeValues { get; private set; }
+        public IReadOnlyList<string>? TextValues { get; private set; }
+        public int? NumberValue { get; private set; }
+        public int? SecondaryNumberValue { get; private set; }
+        public DateTime? DateValue { get; private set; }
+        public DateTime? SecondaryDateValue { get; private set; }
+        public bool? BooleanValue { get; private set; }
+
+        public static LibrarySearchTerm? Create(string? fieldToken, string? rawValue)
+        {
+            var field = LibrarySearchFieldMap.Resolve(fieldToken);
+            var term = new LibrarySearchTerm(field);
+
+            if (string.IsNullOrWhiteSpace(rawValue))
+            {
+                if (field == LibrarySearchField.Any)
+                {
+                    return null;
+                }
+
+                term.Value = string.Empty;
+                return term;
+            }
+
+            var trimmed = rawValue.Trim();
+            term.Value = trimmed;
+
+            switch (field)
+            {
+                case LibrarySearchField.Type:
+                    if (!TryParseTypes(trimmed, out var types))
+                    {
+                        return null;
+                    }
+
+                    term.TypeValues = types;
+                    term.Operation = LibrarySearchTermOperation.InSet;
+                    break;
+
+                case LibrarySearchField.Year:
+                    if (!TryParseIntegerRange(trimmed, out var intResult))
+                    {
+                        return null;
+                    }
+
+                    term.Operation = intResult.Operation;
+                    term.NumberValue = intResult.First;
+                    term.SecondaryNumberValue = intResult.Second;
+                    break;
+
+                case LibrarySearchField.AddedOn:
+                    if (!TryParseDateRange(trimmed, out var dateResult))
+                    {
+                        return null;
+                    }
+
+                    term.Operation = dateResult.Operation;
+                    term.DateValue = dateResult.First;
+                    term.SecondaryDateValue = dateResult.Second;
+                    break;
+
+                case LibrarySearchField.Internal:
+                    if (!TryParseBoolean(trimmed, out var flag))
+                    {
+                        return null;
+                    }
+
+                    term.Operation = LibrarySearchTermOperation.Equals;
+                    term.BooleanValue = flag;
+                    break;
+
+                case LibrarySearchField.Tags:
+                    term.TextValues = SplitValues(trimmed);
+                    term.Operation = LibrarySearchTermOperation.InSet;
+                    break;
+
+                default:
+                    term.Operation = LibrarySearchTermOperation.Contains;
+                    break;
+            }
+
+            return term;
+        }
+
+        private static bool TryParseTypes(string text, out IReadOnlyList<EntryType> values)
+        {
+            var segments = text.Split(new[] { ',', ';', '|' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(segment => segment.Trim())
+                .Where(segment => segment.Length > 0)
+                .ToArray();
+
+            if (segments.Length == 0)
+            {
+                values = Array.Empty<EntryType>();
+                return false;
+            }
+
+            var parsed = new List<EntryType>();
+            foreach (var segment in segments)
+            {
+                if (Enum.TryParse<EntryType>(segment, ignoreCase: true, out var type))
+                {
+                    parsed.Add(type);
+                    continue;
+                }
+
+                switch (segment.ToLowerInvariant())
+                {
+                    case "publication":
+                    case "paper":
+                        parsed.Add(EntryType.Publication);
+                        break;
+                    case "presentation":
+                    case "talk":
+                        parsed.Add(EntryType.Presentation);
+                        break;
+                    case "whitepaper":
+                    case "white-paper":
+                        parsed.Add(EntryType.WhitePaper);
+                        break;
+                    case "slidedeck":
+                    case "slides":
+                    case "deck":
+                        parsed.Add(EntryType.SlideDeck);
+                        break;
+                    case "report":
+                        parsed.Add(EntryType.Report);
+                        break;
+                    case "other":
+                        parsed.Add(EntryType.Other);
+                        break;
+                    case "litsearch":
+                    case "lit-search":
+                        parsed.Add(EntryType.LitSearch);
+                        break;
+                }
+            }
+
+            values = parsed.Distinct().ToArray();
+            return values.Count > 0;
+        }
+
+        private static bool TryParseIntegerRange(string text, out (LibrarySearchTermOperation Operation, int? First, int? Second) result)
+        {
+            result = default;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            text = text.Trim();
+            if (text.Contains("..", StringComparison.Ordinal))
+            {
+                var parts = text.Split("..", StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2 && int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var from) &&
+                    int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var to))
+                {
+                    result = (LibrarySearchTermOperation.Between, from, to);
+                    return true;
+                }
+                return false;
+            }
+
+            if (text.Contains('-') && !text.StartsWith("-", StringComparison.Ordinal))
+            {
+                var parts = text.Split('-', StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2 && int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var fromDash) &&
+                    int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var toDash))
+                {
+                    result = (LibrarySearchTermOperation.Between, fromDash, toDash);
+                    return true;
+                }
+            }
+
+            var comparison = GetComparisonPrefix(text, out var remainder);
+            if (!int.TryParse(remainder, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+            {
+                return false;
+            }
+
+            result = comparison switch
+            {
+                ">" => (LibrarySearchTermOperation.GreaterThan, value, null),
+                ">=" => (LibrarySearchTermOperation.GreaterThanOrEqual, value, null),
+                "<" => (LibrarySearchTermOperation.LessThan, value, null),
+                "<=" => (LibrarySearchTermOperation.LessThanOrEqual, value, null),
+                _ => (LibrarySearchTermOperation.Equals, value, null)
+            };
+            return true;
+        }
+
+        private static bool TryParseDateRange(string text, out (LibrarySearchTermOperation Operation, DateTime? First, DateTime? Second) result)
+        {
+            result = default;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            text = text.Trim();
+            if (text.Contains("..", StringComparison.Ordinal))
+            {
+                var parts = text.Split("..", StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2 && TryParseDate(parts[0], out var from) && TryParseDate(parts[1], out var to))
+                {
+                    result = (LibrarySearchTermOperation.Between, from, to);
+                    return true;
+                }
+                return false;
+            }
+
+            if (text.Contains('-') && CountChar(text, '-') == 2)
+            {
+                // If it's YYYY-MM-DD.. treat as a single date. For ranges we rely on "..".
+            }
+            else if (text.Contains('-', StringComparison.Ordinal) && !text.StartsWith("-", StringComparison.Ordinal))
+            {
+                var parts = text.Split('-', StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2 && TryParseDate(parts[0], out var fromDash) && TryParseDate(parts[1], out var toDash))
+                {
+                    result = (LibrarySearchTermOperation.Between, fromDash, toDash);
+                    return true;
+                }
+            }
+
+            var comparison = GetComparisonPrefix(text, out var remainder);
+            if (!TryParseDate(remainder, out var parsed))
+            {
+                return false;
+            }
+
+            result = comparison switch
+            {
+                ">" => (LibrarySearchTermOperation.GreaterThan, parsed, null),
+                ">=" => (LibrarySearchTermOperation.GreaterThanOrEqual, parsed, null),
+                "<" => (LibrarySearchTermOperation.LessThan, parsed, null),
+                "<=" => (LibrarySearchTermOperation.LessThanOrEqual, parsed, null),
+                _ => (LibrarySearchTermOperation.Equals, parsed, null)
+            };
+            return true;
+        }
+
+        private static bool TryParseBoolean(string text, out bool value)
+        {
+            text = text.Trim();
+            switch (text.ToLowerInvariant())
+            {
+                case "true":
+                case "yes":
+                case "y":
+                case "1":
+                case "internal":
+                case "in":
+                    value = true;
+                    return true;
+                case "false":
+                case "no":
+                case "n":
+                case "0":
+                case "external":
+                case "out":
+                    value = false;
+                    return true;
+                default:
+                    value = false;
+                    return false;
+            }
+        }
+
+        private static IReadOnlyList<string> SplitValues(string text)
+        {
+            return text.Split(new[] { ',', ';', '|' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(part => part.Trim())
+                .Where(part => part.Length > 0)
+                .ToArray();
+        }
+
+        private static string GetComparisonPrefix(string text, out string remainder)
+        {
+            if (text.StartsWith(">=", StringComparison.Ordinal))
+            {
+                remainder = text[2..].Trim();
+                return ">=";
+            }
+
+            if (text.StartsWith("<=", StringComparison.Ordinal))
+            {
+                remainder = text[2..].Trim();
+                return "<=";
+            }
+
+            if (text.StartsWith(">", StringComparison.Ordinal))
+            {
+                remainder = text[1..].Trim();
+                return ">";
+            }
+
+            if (text.StartsWith("<", StringComparison.Ordinal))
+            {
+                remainder = text[1..].Trim();
+                return "<";
+            }
+
+            remainder = text.Trim();
+            return string.Empty;
+        }
+
+        private static bool TryParseDate(string text, out DateTime value)
+        {
+            text = text.Trim();
+            if (DateTime.TryParseExact(text, new[] { "yyyy-MM-dd", "yyyy/MM/dd", "yyyy.MM.dd" }, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out value))
+            {
+                return true;
+            }
+
+            if (DateTime.TryParse(text, CultureInfo.CurrentCulture, DateTimeStyles.AssumeLocal, out value))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static int CountChar(string text, char c)
+        {
+            var count = 0;
+            foreach (var ch in text)
+            {
+                if (ch == c)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+    }
+}

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -145,59 +145,19 @@ LM.App.Wpf.Library.LibraryFilterPresetStore.TryGetPresetAsync(string! name, Syst
 LM.App.Wpf.Library.ILibraryEntryEditor
 LM.App.Wpf.Library.ILibraryEntryEditor.EditEntryAsync(LM.Core.Models.Entry! entry) -> System.Threading.Tasks.Task<System.Boolean>!
 LM.App.Wpf.Library.LibraryFilterState
+LM.App.Wpf.Library.LibraryFilterState.LibraryFilterState() -> void
+LM.App.Wpf.Library.LibraryFilterState.UseFullTextSearch.get -> bool
+LM.App.Wpf.Library.LibraryFilterState.UseFullTextSearch.set -> void
+LM.App.Wpf.Library.LibraryFilterState.UnifiedQuery.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.UnifiedQuery.set -> void
+LM.App.Wpf.Library.LibraryFilterState.FullTextQuery.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.FullTextQuery.set -> void
+LM.App.Wpf.Library.LibraryFilterState.FullTextInTitle.get -> bool
+LM.App.Wpf.Library.LibraryFilterState.FullTextInTitle.set -> void
 LM.App.Wpf.Library.LibraryFilterState.FullTextInAbstract.get -> bool
 LM.App.Wpf.Library.LibraryFilterState.FullTextInAbstract.set -> void
 LM.App.Wpf.Library.LibraryFilterState.FullTextInContent.get -> bool
 LM.App.Wpf.Library.LibraryFilterState.FullTextInContent.set -> void
-LM.App.Wpf.Library.LibraryFilterState.FullTextInTitle.get -> bool
-LM.App.Wpf.Library.LibraryFilterState.FullTextInTitle.set -> void
-LM.App.Wpf.Library.LibraryFilterState.FullTextQuery.get -> string?
-LM.App.Wpf.Library.LibraryFilterState.FullTextQuery.set -> void
-LM.App.Wpf.Library.LibraryFilterState.AddedByContains.get -> string?
-LM.App.Wpf.Library.LibraryFilterState.AddedByContains.set -> void
-LM.App.Wpf.Library.LibraryFilterState.AddedOnFrom.get -> System.DateTime?
-LM.App.Wpf.Library.LibraryFilterState.AddedOnFrom.set -> void
-LM.App.Wpf.Library.LibraryFilterState.AddedOnTo.get -> System.DateTime?
-LM.App.Wpf.Library.LibraryFilterState.AddedOnTo.set -> void
-LM.App.Wpf.Library.LibraryFilterState.AuthorContains.get -> string?
-LM.App.Wpf.Library.LibraryFilterState.AuthorContains.set -> void
-LM.App.Wpf.Library.LibraryFilterState.DoiContains.get -> string?
-LM.App.Wpf.Library.LibraryFilterState.DoiContains.set -> void
-LM.App.Wpf.Library.LibraryFilterState.InternalIdContains.get -> string?
-LM.App.Wpf.Library.LibraryFilterState.InternalIdContains.set -> void
-LM.App.Wpf.Library.LibraryFilterState.IsInternal.get -> bool?
-LM.App.Wpf.Library.LibraryFilterState.IsInternal.set -> void
-LM.App.Wpf.Library.LibraryFilterState.LibraryFilterState() -> void
-LM.App.Wpf.Library.LibraryFilterState.NctContains.get -> string?
-LM.App.Wpf.Library.LibraryFilterState.NctContains.set -> void
-LM.App.Wpf.Library.LibraryFilterState.PmidContains.get -> string?
-LM.App.Wpf.Library.LibraryFilterState.PmidContains.set -> void
-LM.App.Wpf.Library.LibraryFilterState.SourceContains.get -> string?
-LM.App.Wpf.Library.LibraryFilterState.SourceContains.set -> void
-LM.App.Wpf.Library.LibraryFilterState.TagMatchMode.get -> LM.Core.Models.Filters.TagMatchMode
-LM.App.Wpf.Library.LibraryFilterState.TagMatchMode.set -> void
-LM.App.Wpf.Library.LibraryFilterState.Tags.get -> System.Collections.Generic.List<string!>!
-LM.App.Wpf.Library.LibraryFilterState.Tags.set -> void
-LM.App.Wpf.Library.LibraryFilterState.TitleContains.get -> string?
-LM.App.Wpf.Library.LibraryFilterState.TitleContains.set -> void
-LM.App.Wpf.Library.LibraryFilterState.TypeOther.get -> bool
-LM.App.Wpf.Library.LibraryFilterState.TypeOther.set -> void
-LM.App.Wpf.Library.LibraryFilterState.TypePresentation.get -> bool
-LM.App.Wpf.Library.LibraryFilterState.TypePresentation.set -> void
-LM.App.Wpf.Library.LibraryFilterState.TypePublication.get -> bool
-LM.App.Wpf.Library.LibraryFilterState.TypePublication.set -> void
-LM.App.Wpf.Library.LibraryFilterState.TypeReport.get -> bool
-LM.App.Wpf.Library.LibraryFilterState.TypeReport.set -> void
-LM.App.Wpf.Library.LibraryFilterState.TypeSlideDeck.get -> bool
-LM.App.Wpf.Library.LibraryFilterState.TypeSlideDeck.set -> void
-LM.App.Wpf.Library.LibraryFilterState.TypeWhitePaper.get -> bool
-LM.App.Wpf.Library.LibraryFilterState.TypeWhitePaper.set -> void
-LM.App.Wpf.Library.LibraryFilterState.UseFullTextSearch.get -> bool
-LM.App.Wpf.Library.LibraryFilterState.UseFullTextSearch.set -> void
-LM.App.Wpf.Library.LibraryFilterState.YearFrom.get -> int?
-LM.App.Wpf.Library.LibraryFilterState.YearFrom.set -> void
-LM.App.Wpf.Library.LibraryFilterState.YearTo.get -> int?
-LM.App.Wpf.Library.LibraryFilterState.YearTo.set -> void
 LM.App.Wpf.ViewModels.AddPipeline
 LM.App.Wpf.ViewModels.AddPipeline.AddPipeline(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.ISimilarityService! similarity, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IMetadataExtractor! metadata, IPublicationLookup! publicationLookup, LM.Core.Abstractions.IDoiNormalizer! doiNormalizer, LM.Infrastructure.Hooks.HookOrchestrator! orchestrator, LM.Core.Abstractions.IPmidNormalizer! pmidNormalizer, LM.HubSpoke.Abstractions.ISimilarityLog? simLog = null) -> void
 LM.App.Wpf.ViewModels.AddPipeline.AddPipeline(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.ISimilarityService! similarity, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IMetadataExtractor! metadata, LM.HubSpoke.Abstractions.ISimilarityLog? simLog = null) -> void
@@ -257,8 +217,6 @@ LM.App.Wpf.ViewModels.Dialogs.WorkspaceChooserViewModel
 LM.App.Wpf.ViewModels.Dialogs.WorkspaceChooserViewModel.SelectedWorkspacePath.get -> string?
 LM.App.Wpf.ViewModels.Dialogs.WorkspaceChooserViewModel.Title.get -> string!
 LM.App.Wpf.ViewModels.Dialogs.WorkspaceChooserViewModel.WorkspaceChooserViewModel(LM.App.Wpf.Common.Dialogs.IDialogService! dialogService) -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.InternalIdContains.get -> string?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.InternalIdContains.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.CanAcceptFileDrop(System.Collections.Generic.IEnumerable<string!>? filePaths, LM.App.Wpf.ViewModels.LibrarySearchResult? dropTarget = null) -> bool
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.HandleFileDropAsync(System.Collections.Generic.IEnumerable<string!>? filePaths, LM.App.Wpf.ViewModels.LibrarySearchResult? dropTarget = null) -> System.Threading.Tasks.Task!
 LM.App.Wpf.ViewModels.LibrarySearchResult
@@ -388,22 +346,12 @@ LM.App.Wpf.Library.AttachmentMetadataSelection.Tags.init -> void
 LM.App.Wpf.Library.AttachmentMetadataSelection.Title.get -> string!
 LM.App.Wpf.Library.AttachmentMetadataSelection.Title.init -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.LibraryFiltersViewModel(LM.App.Wpf.Library.LibraryFilterPresetStore! presetStore, LM.App.Wpf.Common.ILibraryPresetPrompt! presetPrompt) -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.AddedByContains.get -> string?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.AddedByContains.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.AddedOnFrom.get -> System.DateTime?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.AddedOnFrom.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.AddedOnTo.get -> System.DateTime?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.AddedOnTo.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.LibraryFiltersViewModel(LM.App.Wpf.Library.LibraryFilterPresetStore! presetStore, LM.App.Wpf.Common.ILibraryPresetPrompt! presetPrompt, LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.ApplyPresetAsync(LM.App.Wpf.Common.LibraryPresetSummary! summary, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.ApplyState(LM.App.Wpf.Library.LibraryFilterState! state) -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.AuthorContains.get -> string?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.AuthorContains.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.BuildEntryFilter() -> LM.Core.Models.Filters.EntryFilter!
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.BuildFullTextQuery(string! queryText) -> LM.Core.Models.Search.FullTextSearchQuery!
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.CaptureState() -> LM.App.Wpf.Library.LibraryFilterState!
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.Clear() -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.DoiContains.get -> string?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.DoiContains.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.BuildFullTextQuery(string! normalizedQuery) -> LM.Core.Models.Search.FullTextSearchQuery!
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextInAbstract.get -> bool
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextInAbstract.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextInContent.get -> bool
@@ -413,44 +361,30 @@ LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextInTitle.set -> voi
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextQuery.get -> string?
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextQuery.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.HasSavedPresets.get -> bool
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.GetNormalizedFullTextQuery() -> string?
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.IsInternal.get -> bool?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.IsInternal.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.IsMetadataSearch.get -> bool
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.NctContains.get -> string?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.NctContains.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.PmidContains.get -> string?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.PmidContains.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.SourceContains.get -> string?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.SourceContains.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.GetNormalizedFullTextQuery() -> string!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.NavigationRoots.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel!>!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.RefreshNavigationAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.SavedPresets.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Common.LibraryPresetSummary!>!
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.SelectedTags.get -> System.Collections.ObjectModel.ObservableCollection<string!>!
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TagMatchMode.get -> LM.Core.Models.Filters.TagMatchMode
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TagMatchMode.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TagVocabulary.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TagVocabulary.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.UpdateTagVocabulary(System.Collections.Generic.IEnumerable<string!>! tags) -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TitleContains.get -> string?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TitleContains.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypeOther.get -> bool
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypeOther.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypePresentation.get -> bool
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypePresentation.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypePublication.get -> bool
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypePublication.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypeReport.get -> bool
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypeReport.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypeSlideDeck.get -> bool
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypeSlideDeck.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypeWhitePaper.get -> bool
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.TypeWhitePaper.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.UnifiedQuery.get -> string?
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.UnifiedQuery.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.UseFullTextSearch.get -> bool
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.UseFullTextSearch.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.YearFrom.get -> int?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.YearFrom.set -> void
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.YearTo.get -> int?
-LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.YearTo.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind.Category = 0 -> LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind.SavedSearch = 1 -> LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind.LitSearchEntry = 2 -> LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind.LitSearchRun = 3 -> LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.LibraryNavigationNodeViewModel(string! name, LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind kind) -> void
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Children.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel!>!
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.HasChildren.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Kind.get -> LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Name.get -> string!
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Payload.get -> object?
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Payload.init -> void
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Subtitle.get -> string?
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Subtitle.set -> void
 LM.App.Wpf.ViewModels.Library.LibraryColumnOption
 LM.App.Wpf.ViewModels.Library.LibraryColumnOption.DisplayName.get -> string!
 LM.App.Wpf.ViewModels.Library.LibraryColumnOption.IsVisible.get -> bool
@@ -484,7 +418,7 @@ LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectedItems.get -> Syste
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectionChanged -> System.EventHandler?
 LM.App.Wpf.ViewModels.LibraryViewModel
 LM.App.Wpf.ViewModels.LibraryViewModel.Filters.get -> LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel!
-LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.Core.Abstractions.ITagVocabularyProvider! tagVocabularyProvider, LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel! filters, LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel! results, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.Configuration.IUserPreferencesStore! preferencesStore, LM.App.Wpf.Common.IClipboardService! clipboard, LM.App.Wpf.Common.IFileExplorerService! fileExplorer, LM.App.Wpf.Library.ILibraryDocumentService! documentService) -> void
+LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel! filters, LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel! results, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.Configuration.IUserPreferencesStore! preferencesStore, LM.App.Wpf.Common.IClipboardService! clipboard, LM.App.Wpf.Common.IFileExplorerService! fileExplorer, LM.App.Wpf.Library.ILibraryDocumentService! documentService) -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.Results.get -> LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel!
 LM.App.Wpf.ViewModels.LibraryViewModel.ColumnOptions.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.Library.LibraryColumnOption!>!
 LM.App.Wpf.ViewModels.LibraryViewModel.ColumnVisibility.get -> LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility!

--- a/src/LM.App.Wpf/ViewModels/Library/LibraryNavigationNodeViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LibraryNavigationNodeViewModel.cs
@@ -1,0 +1,41 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using LM.App.Wpf.Common;
+
+namespace LM.App.Wpf.ViewModels.Library
+{
+    public enum LibraryNavigationNodeKind
+    {
+        Category,
+        SavedSearch,
+        LitSearchEntry,
+        LitSearchRun
+    }
+
+    public sealed partial class LibraryNavigationNodeViewModel : ObservableObject
+    {
+        public LibraryNavigationNodeViewModel(string name, LibraryNavigationNodeKind kind)
+        {
+            Name = name;
+            Kind = kind;
+        }
+
+        public string Name { get; }
+        public LibraryNavigationNodeKind Kind { get; }
+
+        [ObservableProperty]
+        private string? subtitle;
+
+        public ObservableCollection<LibraryNavigationNodeViewModel> Children { get; } = new();
+
+        public object? Payload { get; init; }
+
+        public bool HasChildren => Children.Count > 0;
+    }
+
+    internal sealed record LibrarySavedSearchPayload(LibraryPresetSummary Summary);
+
+    internal sealed record LibraryLitSearchEntryPayload(string EntryId, string HookPath, string Title, string? Query);
+
+    internal sealed record LibraryLitSearchRunPayload(string EntryId, string RunId, string? CheckedEntriesPath, string? Label);
+}

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -4,9 +4,9 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviors="clr-namespace:LM.App.Wpf.Views.Behaviors"
-             xmlns:libraryViews="clr-namespace:LM.App.Wpf.Views.Library"
-             xmlns:filters="clr-namespace:LM.Core.Models.Filters;assembly=LM.Core"
              xmlns:converters="clr-namespace:LM.App.Wpf.Views.Converters"
+             xmlns:viewModels="clr-namespace:LM.App.Wpf.ViewModels.Library"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 
              mc:Ignorable="d"
@@ -18,11 +18,14 @@
         <ResourceDictionary Source="Library/LibraryEntryDetailTemplate.xaml" />
         <ResourceDictionary Source="Templates/LibraryResultsColumns.xaml" />
       </ResourceDictionary.MergedDictionaries>
-      <converters:EnumEqualsConverter x:Key="EnumEqualsConverter" />
     </ResourceDictionary>
 
   </UserControl.Resources>
   <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="*"/>
+    </Grid.RowDefinitions>
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="310"/>
       <ColumnDefinition Width="5"/>
@@ -31,152 +34,109 @@
       <ColumnDefinition Width="360"/>
     </Grid.ColumnDefinitions>
 
-    <!-- Filters Panel -->
-    <ScrollViewer Grid.Column="0" VerticalScrollBarVisibility="Auto" DataContext="{Binding Filters}">
-      <StackPanel Margin="12">
-        <TextBlock Text="Library Filters" FontWeight="Bold" Margin="0,0,0,8"/>
-        <CheckBox Content="Use full-text search"
-                  IsChecked="{Binding UseFullTextSearch}"
-                  Margin="0,0,0,8"/>
-        <StackPanel Margin="0,0,0,12"
-                    Visibility="{Binding UseFullTextSearch, Converter={StaticResource BoolToVisibilityConverter}}">
-          <TextBlock Text="Full-text query"/>
-          <TextBox Text="{Binding FullTextQuery, UpdateSourceTrigger=PropertyChanged}"/>
-          <TextBlock Text="Search within" Margin="0,6,0,0"/>
-          <UniformGrid Columns="3" Margin="0,4,0,0">
-            <CheckBox Content="Title" IsChecked="{Binding FullTextInTitle}"/>
-            <CheckBox Content="Abstract" IsChecked="{Binding FullTextInAbstract}"/>
-            <CheckBox Content="Content" IsChecked="{Binding FullTextInContent}"/>
-          </UniformGrid>
-        </StackPanel>
-        <TextBlock Text="Title contains"/>
-        <TextBox Text="{Binding TitleContains, UpdateSourceTrigger=PropertyChanged}"/>
+    <!-- Search header -->
+    <Border Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="5" Background="#FFF7F7F7" BorderBrush="#FFE0E0E0" BorderThickness="0,0,0,1">
+      <Grid DataContext="{Binding Filters}" Margin="12">
+        <Grid.RowDefinitions>
+          <RowDefinition Height="Auto"/>
+          <RowDefinition Height="Auto"/>
+          <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*"/>
+          <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
 
-        <TextBlock Text="Author contains"/>
-        <TextBox Text="{Binding AuthorContains, UpdateSourceTrigger=PropertyChanged}"/>
-
-        <TextBlock Text="Tags"/>
-        <libraryViews:TagTokenSelector SelectedTags="{Binding SelectedTags}"
-                                       TagVocabulary="{Binding TagVocabulary}"/>
-        <StackPanel Orientation="Horizontal" Margin="0,6,0,6">
-          <TextBlock Text="Match mode:" VerticalAlignment="Center" Margin="0,0,8,0"/>
-          <RadioButton Content="Any"
-                       GroupName="TagMatchMode"
-                       Margin="0,0,6,0"
-                       IsChecked="{Binding TagMatchMode, Mode=TwoWay, Converter={StaticResource EnumEqualsConverter}, ConverterParameter={x:Static filters:TagMatchMode.Any}}"/>
-          <RadioButton Content="All"
-                       GroupName="TagMatchMode"
-                       Margin="0,0,6,0"
-                       IsChecked="{Binding TagMatchMode, Mode=TwoWay, Converter={StaticResource EnumEqualsConverter}, ConverterParameter={x:Static filters:TagMatchMode.All}}"/>
-          <RadioButton Content="Not"
-                       GroupName="TagMatchMode"
-                       IsChecked="{Binding TagMatchMode, Mode=TwoWay, Converter={StaticResource EnumEqualsConverter}, ConverterParameter={x:Static filters:TagMatchMode.Not}}"/>
+        <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">
+          <TextBlock Text="Library search" FontWeight="SemiBold"/>
+          <TextBox Margin="0,6,0,0"
+                   Text="{Binding UnifiedQuery, UpdateSourceTrigger=PropertyChanged}"
+                   ToolTip="Use field qualifiers like title:heart OR author:&quot;Doe&quot; to refine results."/>
+          <TextBlock Text="Examples: title:heart AND tags:aortic, author:nicolas, NOT internal:true"
+                     FontSize="11"
+                     Foreground="DimGray"
+                     Margin="0,4,0,0"/>
         </StackPanel>
 
-        <TextBlock Text="Source contains"/>
-        <TextBox Text="{Binding SourceContains, UpdateSourceTrigger=PropertyChanged}"/>
-
-        <TextBlock Text="Internal ID contains"/>
-        <TextBox Text="{Binding InternalIdContains, UpdateSourceTrigger=PropertyChanged}"/>
-
-        <TextBlock Text="DOI contains"/>
-        <TextBox Text="{Binding DoiContains, UpdateSourceTrigger=PropertyChanged}"/>
-
-        <TextBlock Text="PMID contains"/>
-        <TextBox Text="{Binding PmidContains, UpdateSourceTrigger=PropertyChanged}"/>
-
-        <TextBlock Text="NCT contains"/>
-        <TextBox Text="{Binding NctContains, UpdateSourceTrigger=PropertyChanged}"/>
-
-        <TextBlock Text="Added by contains"/>
-        <TextBox Text="{Binding AddedByContains, UpdateSourceTrigger=PropertyChanged}"/>
-
-        <TextBlock Text="Type"/>
-        <UniformGrid Columns="2" Margin="0,6,0,0">
-          <CheckBox Content="Publication" IsChecked="{Binding TypePublication}"/>
-          <CheckBox Content="Presentation" IsChecked="{Binding TypePresentation}"/>
-          <CheckBox Content="White paper" IsChecked="{Binding TypeWhitePaper}"/>
-          <CheckBox Content="Slide deck" IsChecked="{Binding TypeSlideDeck}"/>
-          <CheckBox Content="Report" IsChecked="{Binding TypeReport}"/>
-          <CheckBox Content="Other" IsChecked="{Binding TypeOther}"/>
-        </UniformGrid>
-
-        <TextBlock Text="Year range"/>
-        <DockPanel>
-          <TextBox Width="60" Text="{Binding YearFrom, UpdateSourceTrigger=PropertyChanged}"/>
-          <TextBlock Text=" to " VerticalAlignment="Center" Margin="6,0,6,0"/>
-          <TextBox Width="60" Text="{Binding YearTo, UpdateSourceTrigger=PropertyChanged}"/>
-        </DockPanel>
-
-        <TextBlock Text="Added on range"/>
-        <DockPanel>
-          <DatePicker Width="120" SelectedDate="{Binding AddedOnFrom, UpdateSourceTrigger=PropertyChanged}"/>
-          <TextBlock Text=" to " VerticalAlignment="Center" Margin="6,0,6,0"/>
-          <DatePicker Width="120" SelectedDate="{Binding AddedOnTo, UpdateSourceTrigger=PropertyChanged}"/>
-        </DockPanel>
-
-        <TextBlock Text="Visibility"/>
-        <ComboBox SelectedValue="{Binding IsInternal}">
-          <ComboBoxItem Content="Either" Tag="{x:Null}" IsSelected="True"/>
-          <ComboBoxItem Content="External" Tag="False"/>
-          <ComboBoxItem Content="Internal" Tag="True"/>
-        </ComboBox>
-
-        <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
+        <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Margin="0,8,0,0">
           <Button Content="Search"
                   Margin="0,0,8,0"
                   Command="{Binding DataContext.SearchCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
           <Button Content="Clear"
                   Margin="0,0,8,0"
                   Command="{Binding ClearCommand}"/>
-          <Button Content="Save preset"
+          <Button Content="Save search"
                   Margin="0,0,8,0"
                   Command="{Binding SavePresetCommand}"/>
-          <Button Content="Load preset"
+          <Button Content="Manage saved"
                   Margin="0,0,8,0"
-                  Command="{Binding LoadPresetCommand}"/>
-          <Button Content="Manage presets"
                   Command="{Binding ManagePresetsCommand}"/>
+          <Button Content="Load saved"
+                  Command="{Binding LoadPresetCommand}"/>
         </StackPanel>
-        <StackPanel Margin="0,16,0,0">
-          <TextBlock Text="Saved presets" FontWeight="SemiBold"/>
-          <TextBlock Text="No saved presets yet."
-                     Margin="0,4,0,0"
-                     Foreground="DimGray"
-                     FontStyle="Italic">
-            <TextBlock.Style>
-              <Style TargetType="TextBlock">
-                <Setter Property="Visibility" Value="Visible"/>
-                <Style.Triggers>
-                  <DataTrigger Binding="{Binding HasSavedPresets}" Value="True">
-                    <Setter Property="Visibility" Value="Collapsed"/>
-                  </DataTrigger>
-                </Style.Triggers>
-              </Style>
-            </TextBlock.Style>
-          </TextBlock>
-          <ItemsControl ItemsSource="{Binding SavedPresets}"
-                        Margin="0,8,0,0"
-                        Visibility="{Binding HasSavedPresets, Converter={StaticResource BoolToVisibilityConverter}}">
-            <ItemsControl.ItemTemplate>
-              <DataTemplate>
-                <Button Command="{Binding DataContext.ApplyPresetCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                        CommandParameter="{Binding}"
-                        Margin="0,0,0,6"
-                        HorizontalContentAlignment="Stretch">
-                  <StackPanel>
-                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
-                    <TextBlock Text="{Binding SavedUtc, StringFormat='Saved {0:yyyy-MM-dd HH:mm}'}" FontSize="12" Opacity="0.7"/>
-                  </StackPanel>
-                </Button>
-              </DataTemplate>
-            </ItemsControl.ItemTemplate>
-          </ItemsControl>
-        </StackPanel>
-      </StackPanel>
-    </ScrollViewer>
 
-    <GridSplitter Grid.Column="1"
+        <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="8,8,0,0">
+          <CheckBox Content="Full-text search" IsChecked="{Binding UseFullTextSearch}"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,8,0,0"
+                    Visibility="{Binding UseFullTextSearch, Converter={StaticResource BoolToVisibilityConverter}}">
+          <TextBox Text="{Binding FullTextQuery, UpdateSourceTrigger=PropertyChanged}"/>
+          <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+            <TextBlock Text="Search within:" VerticalAlignment="Center" Margin="0,0,8,0"/>
+            <CheckBox Content="Title" Margin="0,0,8,0" IsChecked="{Binding FullTextInTitle}"/>
+            <CheckBox Content="Abstract" Margin="0,0,8,0" IsChecked="{Binding FullTextInAbstract}"/>
+            <CheckBox Content="Content" IsChecked="{Binding FullTextInContent}"/>
+          </StackPanel>
+        </StackPanel>
+      </Grid>
+    </Border>
+
+    <!-- Navigation tree -->
+    <Border Grid.Row="1" Grid.Column="0" BorderBrush="#FFE0E0E0" BorderThickness="0,1,0,0">
+      <ScrollViewer VerticalScrollBarVisibility="Auto" DataContext="{Binding Filters}">
+        <StackPanel Margin="12">
+          <TextBlock Text="Saved searches" FontWeight="SemiBold" Margin="0,0,0,8"/>
+          <TreeView ItemsSource="{Binding NavigationRoots}" SelectedItemChanged="OnNavigationSelected">
+            <TreeView.ItemTemplate>
+              <HierarchicalDataTemplate ItemsSource="{Binding Children}">
+                <StackPanel>
+                  <TextBlock Text="{Binding Name}">
+                    <TextBlock.Style>
+                      <Style TargetType="TextBlock">
+                        <Setter Property="FontWeight" Value="Normal"/>
+                        <Style.Triggers>
+                          <DataTrigger Binding="{Binding Kind}" Value="{x:Static viewModels:LibraryNavigationNodeKind.Category}">
+                            <Setter Property="FontWeight" Value="SemiBold"/>
+                          </DataTrigger>
+                        </Style.Triggers>
+                      </Style>
+                    </TextBlock.Style>
+                  </TextBlock>
+                  <TextBlock Text="{Binding Subtitle}" FontSize="11" Foreground="DimGray">
+                    <TextBlock.Style>
+                      <Style TargetType="TextBlock">
+                        <Setter Property="Visibility" Value="Visible"/>
+                        <Style.Triggers>
+                          <DataTrigger Binding="{Binding Subtitle}" Value="{x:Null}">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                          </DataTrigger>
+                          <DataTrigger Binding="{Binding Subtitle}" Value="">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                          </DataTrigger>
+                        </Style.Triggers>
+                      </Style>
+                    </TextBlock.Style>
+                  </TextBlock>
+                </StackPanel>
+              </HierarchicalDataTemplate>
+            </TreeView.ItemTemplate>
+          </TreeView>
+        </StackPanel>
+      </ScrollViewer>
+    </Border>
+
+    <GridSplitter Grid.Row="1" Grid.Column="1"
                   HorizontalAlignment="Stretch"
                   VerticalAlignment="Stretch"
                   Background="#FFE0E0E0"
@@ -184,7 +144,7 @@
                   Width="5"/>
 
     <!-- Results -->
-    <Grid Grid.Column="2" DataContext="{Binding Results}">
+    <Grid Grid.Row="1" Grid.Column="2" DataContext="{Binding Results}">
       <Grid.RowDefinitions>
         <RowDefinition Height="Auto"/>
         <RowDefinition Height="*"/>
@@ -287,14 +247,14 @@
       </StackPanel>
     </Grid>
 
-    <GridSplitter Grid.Column="3"
+    <GridSplitter Grid.Row="1" Grid.Column="3"
                   HorizontalAlignment="Stretch"
                   VerticalAlignment="Stretch"
                   Background="#FFE0E0E0"
                   ShowsPreview="True"
                   Width="5"/>
 
-    <Border Grid.Column="4" BorderBrush="#FFE0E0E0" BorderThickness="1,0,0,0" Background="#FFFDFDFD">
+    <Border Grid.Row="1" Grid.Column="4" BorderBrush="#FFE0E0E0" BorderThickness="1,0,0,0" Background="#FFFDFDFD">
       <ScrollViewer VerticalScrollBarVisibility="Auto"
                     AllowDrop="True"
                     DataContext="{Binding Results}">

--- a/src/LM.App.Wpf/Views/LibraryView.xaml.cs
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml.cs
@@ -1,7 +1,24 @@
+using System.Threading.Tasks;
+using LM.App.Wpf.ViewModels;
+using LM.App.Wpf.ViewModels.Library;
+
 namespace LM.App.Wpf.Views
 {
     public partial class LibraryView : System.Windows.Controls.UserControl
     {
         public LibraryView() => InitializeComponent();
+
+        private async void OnNavigationSelected(object sender, System.Windows.RoutedPropertyChangedEventArgs<object> e)
+        {
+            if (DataContext is not LibraryViewModel vm)
+            {
+                return;
+            }
+
+            if (e.NewValue is LibraryNavigationNodeViewModel node)
+            {
+                await vm.HandleNavigationSelectionAsync(node).ConfigureAwait(false);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add lexer, parser, and evaluator for the new unified library metadata search experience
- rework library filters/navigation to expose the new tree structure with saved searches and LitSearch runs
- update the WPF layout and tests, including new parser coverage, to reflect the unified search flow

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: Microsoft.WindowsDesktop.App 9.0.0 runtime is unavailable on this Linux agent)*

------
https://chatgpt.com/codex/tasks/task_e_68d51997c638832b94c2888aa883266b