### PR TITLE
Add review domain models and consensus policy validation

### DIFF
--- a/CombinedPublicAPI.txt
+++ b/CombinedPublicAPI.txt
@@ -1,1 +1,1454 @@
 === Combined Public API for KnowledgeWorks_20250820_082416 ===
+---------- LM.Core ----------
+#nullable enable
+#nullable enable
+IPublicationLookup
+IPublicationLookup.TryGetByDoiAsync(string! doi, bool includeCitedBy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<LM.Core.Models.PublicationRecord?>!
+LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore
+LM.Core.Abstractions.IContentExtractor
+LM.Core.Abstractions.IContentExtractor.ExtractTextAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IEntryStore
+LM.Core.Abstractions.IEntryStore.EnumerateAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<LM.Core.Models.Entry!>!
+LM.Core.Abstractions.IEntryStore.FindByHashAsync(string! sha256, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.FindByIdsAsync(string? doi, string? pmid, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.FindSimilarByNameYearAsync(string! title, int? year, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Core.Abstractions.IEntryStore.GetByIdAsync(string! id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IEntryStore.SaveAsync(LM.Core.Models.Entry! entry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IEntryStore.SearchAsync(LM.Core.Models.Filters.EntryFilter! filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Core.Abstractions.IFullTextSearchService
+LM.Core.Abstractions.IFullTextSearchService.SearchAsync(LM.Core.Models.Search.FullTextSearchQuery! query, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Search.FullTextSearchHit!>!>!
+LM.Core.Abstractions.Search.ISearchExecutionService
+LM.Core.Abstractions.Search.ISearchExecutionService.ExecuteAsync(LM.Core.Models.Search.SearchExecutionRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Search.SearchExecutionResult!>!
+LM.Core.Abstractions.Search.ISearchProvider
+LM.Core.Abstractions.Search.ISearchProvider.Database.get -> LM.Core.Models.SearchDatabase
+LM.Core.Abstractions.Search.ISearchProvider.SearchAsync(string! query, System.DateTime? from, System.DateTime? to, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.SearchHit!>!>!
+LM.Core.Abstractions.IFileStorageRepository
+LM.Core.Abstractions.IFileStorageRepository.SaveNewAsync(string! sourcePath, string! relativeTargetDir, string? preferredFileName = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IHasher
+LM.Core.Abstractions.IHasher.ComputeSha256Async(string! filePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IMetadataDebugSlideExporter
+LM.Core.Abstractions.IMetadataDebugSlideExporter.ExportAsync(System.Collections.Generic.IEnumerable<LM.Core.Models.FileMetadata!>! items, string! outputPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IMetadataExtractor
+LM.Core.Abstractions.IMetadataExtractor.ExtractAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.FileMetadata!>!
+LM.Core.Abstractions.IPmidNormalizer
+LM.Core.Abstractions.IPmidNormalizer.Normalize(string? raw) -> string?
+LM.Core.Abstractions.ISimilarityService
+LM.Core.Abstractions.ISimilarityService.ComputeFileSimilarityAsync(string! filePathA, string! filePathB, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<double>!
+LM.Core.Abstractions.ITagVocabularyProvider
+LM.Core.Abstractions.ITagVocabularyProvider.GetAllTagsAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
+LM.Core.Abstractions.IWorkSpaceService
+LM.Core.Abstractions.IWorkSpaceService.EnsureWorkspaceAsync(string! absoluteWorkspacePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IWorkSpaceService.GetAbsolutePath(string! relativePath) -> string!
+LM.Core.Abstractions.IWorkSpaceService.GetLocalDbPath() -> string!
+LM.Core.Abstractions.IWorkSpaceService.GetWorkspaceRoot() -> string!
+LM.Core.Abstractions.IWorkSpaceService.WorkspacePath.get -> string?
+LM.Core.Abstractions.IDoiNormalizer
+LM.Core.Abstractions.IDoiNormalizer.Normalize(string? raw) -> string?
+LM.Core.Models.AbstractSection
+LM.Core.Models.AbstractSection.Label.get -> string?
+LM.Core.Models.AbstractSection.Label.init -> void
+LM.Core.Models.AbstractSection.Text.get -> string?
+LM.Core.Models.AbstractSection.Text.init -> void
+LM.Core.Models.Attachment
+LM.Core.Models.Attachment.Attachment() -> void
+LM.Core.Models.Attachment.Id.get -> string!
+LM.Core.Models.Attachment.Id.set -> void
+LM.Core.Models.Attachment.Notes.get -> string?
+LM.Core.Models.Attachment.Notes.set -> void
+LM.Core.Models.Attachment.RelativePath.get -> string!
+LM.Core.Models.Attachment.RelativePath.set -> void
+LM.Core.Models.Attachment.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Attachment.Tags.set -> void
+LM.Core.Models.Attachment.Title.get -> string!
+LM.Core.Models.Attachment.Title.set -> void
+LM.Core.Models.Attachment.Kind.get -> LM.Core.Models.AttachmentKind
+LM.Core.Models.Attachment.Kind.set -> void
+LM.Core.Models.Attachment.AddedBy.get -> string!
+LM.Core.Models.Attachment.AddedBy.set -> void
+LM.Core.Models.Attachment.AddedUtc.get -> System.DateTime
+LM.Core.Models.Attachment.AddedUtc.set -> void
+LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.Supplement = 0 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.Version = 1 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.Presentation = 2 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.ExternalNotes = 3 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AuthorName
+LM.Core.Models.AuthorName.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.AuthorName.Affiliations.init -> void
+LM.Core.Models.AuthorName.CollectiveName.get -> string?
+LM.Core.Models.AuthorName.CollectiveName.init -> void
+LM.Core.Models.AuthorName.Family.get -> string?
+LM.Core.Models.AuthorName.Family.init -> void
+LM.Core.Models.AuthorName.Given.get -> string?
+LM.Core.Models.AuthorName.Given.init -> void
+LM.Core.Models.AuthorName.LastFromLiteral() -> string?
+LM.Core.Models.AuthorName.Literal.get -> string?
+LM.Core.Models.AuthorName.Literal.init -> void
+LM.Core.Models.AuthorName.Orcid.get -> string?
+LM.Core.Models.AuthorName.Orcid.init -> void
+LM.Core.Models.AuthorName.ToCsvPart() -> string!
+LM.Core.Models.Entry
+LM.Core.Models.Entry.AddedBy.get -> string?
+LM.Core.Models.Entry.AddedBy.set -> void
+LM.Core.Models.Entry.AddedOnUtc.get -> System.DateTime
+LM.Core.Models.Entry.AddedOnUtc.set -> void
+LM.Core.Models.Entry.Attachments.get -> System.Collections.Generic.List<LM.Core.Models.Attachment!>!
+LM.Core.Models.Entry.Attachments.set -> void
+LM.Core.Models.Entry.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Authors.set -> void
+LM.Core.Models.Entry.DisplayName.get -> string?
+LM.Core.Models.Entry.DisplayName.set -> void
+LM.Core.Models.Entry.Doi.get -> string?
+LM.Core.Models.Entry.Doi.set -> void
+LM.Core.Models.Entry.Entry() -> void
+LM.Core.Models.Entry.Id.get -> string!
+LM.Core.Models.Entry.Id.set -> void
+LM.Core.Models.Entry.InternalId.get -> string?
+LM.Core.Models.Entry.InternalId.set -> void
+LM.Core.Models.Entry.IsInternal.get -> bool
+LM.Core.Models.Entry.IsInternal.set -> void
+LM.Core.Models.Entry.Links.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Links.set -> void
+LM.Core.Models.Entry.MainFileHashSha256.get -> string?
+LM.Core.Models.Entry.MainFileHashSha256.set -> void
+LM.Core.Models.Entry.MainFilePath.get -> string!
+LM.Core.Models.Entry.MainFilePath.set -> void
+LM.Core.Models.Entry.Nct.get -> string?
+LM.Core.Models.Entry.Nct.set -> void
+LM.Core.Models.Entry.Notes.get -> string?
+LM.Core.Models.Entry.Notes.set -> void
+LM.Core.Models.Entry.UserNotes.get -> string?
+LM.Core.Models.Entry.UserNotes.set -> void
+LM.Core.Models.Entry.OriginalFileName.get -> string?
+LM.Core.Models.Entry.OriginalFileName.set -> void
+LM.Core.Models.Entry.Pmid.get -> string?
+LM.Core.Models.Entry.Pmid.set -> void
+LM.Core.Models.Entry.Relations.get -> System.Collections.Generic.List<LM.Core.Models.Relation!>!
+LM.Core.Models.Entry.Relations.set -> void
+LM.Core.Models.Entry.ShortTitle.get -> string?
+LM.Core.Models.Entry.ShortTitle.set -> void
+LM.Core.Models.Entry.Source.get -> string?
+LM.Core.Models.Entry.Source.set -> void
+LM.Core.Models.Entry.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Tags.set -> void
+LM.Core.Models.Entry.Title.get -> string!
+LM.Core.Models.Entry.Title.set -> void
+LM.Core.Models.Entry.Type.get -> LM.Core.Models.EntryType
+LM.Core.Models.Entry.Type.set -> void
+LM.Core.Models.Entry.Version.get -> int
+LM.Core.Models.Entry.Version.set -> void
+LM.Core.Models.Entry.Year.get -> int?
+LM.Core.Models.Entry.Year.set -> void
+LM.Core.Models.EntryDocument
+LM.Core.Models.EntryDocument.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.EntryDocument.Authors.set -> void
+LM.Core.Models.EntryDocument.CreatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.EntryDocument.CreatedUtc.set -> void
+LM.Core.Models.EntryDocument.Doi.get -> string?
+LM.Core.Models.EntryDocument.Doi.set -> void
+LM.Core.Models.EntryDocument.EntryDocument() -> void
+LM.Core.Models.EntryDocument.Files.get -> System.Collections.Generic.List<LM.Core.Models.EntryFile!>!
+LM.Core.Models.EntryDocument.Files.set -> void
+LM.Core.Models.EntryDocument.Id.get -> string!
+LM.Core.Models.EntryDocument.Id.set -> void
+LM.Core.Models.EntryDocument.Internal.get -> bool
+LM.Core.Models.EntryDocument.Internal.set -> void
+LM.Core.Models.EntryDocument.Pmid.get -> string?
+LM.Core.Models.EntryDocument.Pmid.set -> void
+LM.Core.Models.EntryDocument.Source.get -> string?
+LM.Core.Models.EntryDocument.Source.set -> void
+LM.Core.Models.EntryDocument.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.EntryDocument.Tags.set -> void
+LM.Core.Models.EntryDocument.Title.get -> string?
+LM.Core.Models.EntryDocument.Title.set -> void
+LM.Core.Models.EntryDocument.UpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.EntryDocument.UpdatedUtc.set -> void
+LM.Core.Models.EntryDocument.Year.get -> int?
+LM.Core.Models.EntryDocument.Year.set -> void
+LM.Core.Models.EntryFile
+LM.Core.Models.EntryFile.EntryFile() -> void
+LM.Core.Models.EntryFile.Hash.get -> string!
+LM.Core.Models.EntryFile.Hash.set -> void
+LM.Core.Models.EntryFile.MimeType.get -> string!
+LM.Core.Models.EntryFile.MimeType.set -> void
+LM.Core.Models.EntryFile.OriginalFileName.get -> string!
+LM.Core.Models.EntryFile.OriginalFileName.set -> void
+LM.Core.Models.EntryFile.RelativePath.get -> string!
+LM.Core.Models.EntryFile.RelativePath.set -> void
+LM.Core.Models.EntryFile.SizeBytes.get -> long
+LM.Core.Models.EntryFile.SizeBytes.set -> void
+LM.Core.Models.EntryFile.StoredFileName.get -> string!
+LM.Core.Models.EntryFile.StoredFileName.set -> void
+LM.Core.Models.EntryType
+LM.Core.Models.EntryType.LitSearch = 6 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Other = 5 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Presentation = 1 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Publication = 0 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Report = 4 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.SlideDeck = 3 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.WhitePaper = 2 -> LM.Core.Models.EntryType
+LM.Core.Models.FileMetadata
+LM.Core.Models.FileMetadata.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.FileMetadata.Authors.set -> void
+LM.Core.Models.FileMetadata.Doi.get -> string?
+LM.Core.Models.FileMetadata.Doi.set -> void
+LM.Core.Models.FileMetadata.FileMetadata() -> void
+LM.Core.Models.FileMetadata.Pmid.get -> string?
+LM.Core.Models.FileMetadata.Pmid.set -> void
+LM.Core.Models.FileMetadata.Source.get -> string?
+LM.Core.Models.FileMetadata.Source.set -> void
+LM.Core.Models.FileMetadata.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.FileMetadata.Tags.set -> void
+LM.Core.Models.FileMetadata.Title.get -> string?
+LM.Core.Models.FileMetadata.Title.set -> void
+LM.Core.Models.FileMetadata.Year.get -> int?
+LM.Core.Models.FileMetadata.Year.set -> void
+LM.Core.Models.Filters.EntryFilter
+LM.Core.Models.Filters.EntryFilter.AuthorContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.AuthorContains.set -> void
+LM.Core.Models.Filters.EntryFilter.EntryFilter() -> void
+LM.Core.Models.Filters.EntryFilter.IsInternal.get -> bool?
+LM.Core.Models.Filters.EntryFilter.IsInternal.set -> void
+LM.Core.Models.Filters.EntryFilter.TagMatchMode.get -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.EntryFilter.TagMatchMode.set -> void
+LM.Core.Models.Filters.EntryFilter.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Filters.EntryFilter.Tags.set -> void
+LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.TagMatchMode.Any = 0 -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.TagMatchMode.All = 1 -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.TagMatchMode.Not = 2 -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.EntryFilter.TitleContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.TitleContains.set -> void
+LM.Core.Models.Filters.EntryFilter.TypesAny.get -> LM.Core.Models.EntryType[]?
+LM.Core.Models.Filters.EntryFilter.TypesAny.set -> void
+LM.Core.Models.Filters.EntryFilter.YearFrom.get -> int?
+LM.Core.Models.Filters.EntryFilter.YearFrom.set -> void
+LM.Core.Models.Filters.EntryFilter.YearTo.get -> int?
+LM.Core.Models.Filters.EntryFilter.YearTo.set -> void
+LM.Core.Models.Filters.EntryFilter.SourceContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.SourceContains.set -> void
+LM.Core.Models.Filters.EntryFilter.InternalIdContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.InternalIdContains.set -> void
+LM.Core.Models.Filters.EntryFilter.DoiContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.DoiContains.set -> void
+LM.Core.Models.Filters.EntryFilter.PmidContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.PmidContains.set -> void
+LM.Core.Models.Filters.EntryFilter.NctContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.NctContains.set -> void
+LM.Core.Models.Filters.EntryFilter.AddedByContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.AddedByContains.set -> void
+LM.Core.Models.Filters.EntryFilter.AddedOnFromUtc.get -> System.DateTime?
+LM.Core.Models.Filters.EntryFilter.AddedOnFromUtc.set -> void
+LM.Core.Models.Filters.EntryFilter.AddedOnToUtc.get -> System.DateTime?
+LM.Core.Models.Filters.EntryFilter.AddedOnToUtc.set -> void
+LM.Core.Models.GrantInfo
+LM.Core.Models.GrantInfo.Agency.get -> string?
+LM.Core.Models.GrantInfo.Agency.init -> void
+LM.Core.Models.GrantInfo.Country.get -> string?
+LM.Core.Models.GrantInfo.Country.init -> void
+LM.Core.Models.GrantInfo.GrantId.get -> string?
+LM.Core.Models.GrantInfo.GrantId.init -> void
+LM.Core.Models.PublicationRecord
+LM.Core.Models.PublicationRecord.AbstractPlain.get -> string?
+LM.Core.Models.PublicationRecord.AbstractPlain.init -> void
+LM.Core.Models.PublicationRecord.AbstractSections.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AbstractSection!>!
+LM.Core.Models.PublicationRecord.AbstractSections.init -> void
+LM.Core.Models.PublicationRecord.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.Affiliations.init -> void
+LM.Core.Models.PublicationRecord.Authors.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AuthorName!>!
+LM.Core.Models.PublicationRecord.Authors.init -> void
+LM.Core.Models.PublicationRecord.AuthorsCsv.get -> string!
+LM.Core.Models.PublicationRecord.CitedByCount.get -> int?
+LM.Core.Models.PublicationRecord.CitedByCount.init -> void
+LM.Core.Models.PublicationRecord.CitedByPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.CitedByPmids.init -> void
+LM.Core.Models.PublicationRecord.CommentsCorrections.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.CommentsCorrections.init -> void
+LM.Core.Models.PublicationRecord.Country.get -> string?
+LM.Core.Models.PublicationRecord.Country.init -> void
+LM.Core.Models.PublicationRecord.Doi.get -> string?
+LM.Core.Models.PublicationRecord.Doi.init -> void
+LM.Core.Models.PublicationRecord.FirstAuthorLast.get -> string!
+LM.Core.Models.PublicationRecord.Grants.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.GrantInfo!>!
+LM.Core.Models.PublicationRecord.Grants.init -> void
+LM.Core.Models.PublicationRecord.Issue.get -> string?
+LM.Core.Models.PublicationRecord.Issue.init -> void
+LM.Core.Models.PublicationRecord.JournalIsoAbbrev.get -> string?
+LM.Core.Models.PublicationRecord.JournalIsoAbbrev.init -> void
+LM.Core.Models.PublicationRecord.JournalTitle.get -> string?
+LM.Core.Models.PublicationRecord.JournalTitle.init -> void
+LM.Core.Models.PublicationRecord.Keywords.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.Keywords.init -> void
+LM.Core.Models.PublicationRecord.Language.get -> string?
+LM.Core.Models.PublicationRecord.Language.init -> void
+LM.Core.Models.PublicationRecord.MeshHeadings.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.MeshHeadings.init -> void
+LM.Core.Models.PublicationRecord.Pages.get -> string?
+LM.Core.Models.PublicationRecord.Pages.init -> void
+LM.Core.Models.PublicationRecord.Pmcid.get -> string?
+LM.Core.Models.PublicationRecord.Pmcid.init -> void
+LM.Core.Models.PublicationRecord.Pmid.get -> string?
+LM.Core.Models.PublicationRecord.Pmid.init -> void
+LM.Core.Models.PublicationRecord.PublicationTypes.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.PublicationTypes.init -> void
+LM.Core.Models.PublicationRecord.PublishedEpub.get -> System.DateOnly?
+LM.Core.Models.PublicationRecord.PublishedEpub.init -> void
+LM.Core.Models.PublicationRecord.PublishedPrint.get -> System.DateOnly?
+LM.Core.Models.PublicationRecord.PublishedPrint.init -> void
+LM.Core.Models.PublicationRecord.ReferencedPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.ReferencedPmids.init -> void
+LM.Core.Models.PublicationRecord.Title.get -> string?
+LM.Core.Models.PublicationRecord.Title.init -> void
+LM.Core.Models.PublicationRecord.UrlPubMed.get -> string?
+LM.Core.Models.PublicationRecord.UrlPubMed.init -> void
+LM.Core.Models.PublicationRecord.Volume.get -> string?
+LM.Core.Models.PublicationRecord.Volume.init -> void
+LM.Core.Models.PublicationRecord.Year.get -> int?
+LM.Core.Models.PublicationRecord.Year.init -> void
+LM.Core.Models.Relation
+LM.Core.Models.Relation.Relation() -> void
+LM.Core.Models.Relation.TargetEntryId.get -> string!
+LM.Core.Models.Relation.TargetEntryId.set -> void
+LM.Core.Models.Relation.Type.get -> string!
+LM.Core.Models.Relation.Type.set -> void
+LM.Core.Models.Search.FullTextSearchHit.EntryId.init -> void
+LM.Core.Models.Search.FullTextSearchHit.Highlight.init -> void
+LM.Core.Models.Search.FullTextSearchHit.Score.init -> void
+LM.Core.Models.Search.FullTextSearchQuery.TypesAny.get -> LM.Core.Models.EntryType[]?
+LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchDatabase.ClinicalTrialsGov = 1 -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchDatabase.PubMed = 0 -> LM.Core.Models.SearchDatabase
+LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchField.Abstract = 2 -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchField.Content = 4 -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchField.None = 0 -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchField.Title = 1 -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchHit
+LM.Core.Models.Search.FullTextSearchHit.EntryId.get -> string!
+LM.Core.Models.Search.FullTextSearchHit.FullTextSearchHit(string! EntryId, double Score, string? Highlight) -> void
+LM.Core.Models.Search.FullTextSearchHit.Highlight.get -> string?
+LM.Core.Models.Search.FullTextSearchHit.Score.get -> double
+LM.Core.Models.Search.FullTextSearchQuery
+LM.Core.Models.Search.FullTextSearchQuery.Fields.get -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchQuery.Fields.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.FullTextSearchQuery() -> void
+LM.Core.Models.Search.FullTextSearchQuery.IsInternal.get -> bool?
+LM.Core.Models.Search.FullTextSearchQuery.IsInternal.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.Limit.get -> int
+LM.Core.Models.Search.FullTextSearchQuery.Limit.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.Text.get -> string?
+LM.Core.Models.Search.FullTextSearchQuery.Text.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.TypesAny.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.YearFrom.get -> int?
+LM.Core.Models.Search.FullTextSearchQuery.YearFrom.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.YearTo.get -> int?
+LM.Core.Models.Search.FullTextSearchQuery.YearTo.set -> void
+LM.Core.Models.SearchHit
+LM.Core.Models.SearchHit.AlreadyInDb.get -> bool
+LM.Core.Models.SearchHit.AlreadyInDb.set -> void
+LM.Core.Models.SearchHit.Authors.get -> string!
+LM.Core.Models.SearchHit.Authors.init -> void
+LM.Core.Models.SearchHit.Doi.get -> string?
+LM.Core.Models.SearchHit.Doi.init -> void
+LM.Core.Models.SearchHit.ExternalId.get -> string!
+LM.Core.Models.SearchHit.ExternalId.init -> void
+LM.Core.Models.SearchHit.ExistingEntryId.get -> string?
+LM.Core.Models.SearchHit.ExistingEntryId.set -> void
+LM.Core.Models.SearchHit.JournalOrSource.get -> string?
+LM.Core.Models.SearchHit.JournalOrSource.init -> void
+LM.Core.Models.SearchHit.SearchHit() -> void
+LM.Core.Models.SearchHit.Selected.get -> bool
+LM.Core.Models.SearchHit.Selected.set -> void
+LM.Core.Models.SearchHit.Source.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchHit.Source.init -> void
+LM.Core.Models.SearchHit.Title.get -> string!
+LM.Core.Models.SearchHit.Title.init -> void
+LM.Core.Models.SearchHit.Url.get -> string?
+LM.Core.Models.SearchHit.Url.init -> void
+LM.Core.Models.SearchHit.Year.get -> int?
+LM.Core.Models.SearchHit.Year.init -> void
+LM.Core.Models.SearchHit.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.Core.Models.WatchedFolderState.WatchedFolderState(string! Path, System.DateTimeOffset? LastScanUtc, string? AggregatedHash, bool LastScanWasUnchanged) -> void
+LM.Core.Utils.Hashes
+LM.Core.Utils.IdGen
+LM.Core.Utils.JsonEx
+static LM.Core.Utils.Hashes.Sha1(string! input) -> string!
+static LM.Core.Utils.Hashes.Sha256File(string! path) -> string!
+static LM.Core.Utils.IdGen.NewId() -> string!
+static LM.Core.Utils.JsonEx.Deserialize<T>(string! s) -> T?
+static LM.Core.Utils.JsonEx.Serialize<T>(T v) -> string!
+LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.WatchedFolderSettings!>!
+LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore.SaveAsync(LM.Core.Models.WatchedFolderSettings! settings, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.Configuration.ISearchHistoryStore
+LM.Core.Abstractions.Configuration.ISearchHistoryStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Search.SearchHistoryDocument!>!
+LM.Core.Abstractions.Configuration.ISearchHistoryStore.SaveAsync(LM.Core.Models.Search.SearchHistoryDocument! document, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.Configuration.IUserPreferencesStore
+LM.Core.Abstractions.Configuration.IUserPreferencesStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.UserPreferences!>!
+LM.Core.Abstractions.Configuration.IUserPreferencesStore.SaveAsync(LM.Core.Models.UserPreferences! preferences, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Models.Search.SearchHistoryDocument
+LM.Core.Models.Search.SearchHistoryDocument.Entries.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.Search.SearchHistoryEntry!>!
+LM.Core.Models.Search.SearchHistoryDocument.Entries.init -> void
+LM.Core.Models.Search.SearchHistoryEntry
+LM.Core.Models.Search.SearchHistoryEntry.Database.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.Search.SearchHistoryEntry.Database.init -> void
+LM.Core.Models.Search.SearchHistoryEntry.ExecutedUtc.get -> System.DateTimeOffset
+LM.Core.Models.Search.SearchHistoryEntry.ExecutedUtc.init -> void
+LM.Core.Models.Search.SearchHistoryEntry.From.get -> System.DateTime?
+LM.Core.Models.Search.SearchHistoryEntry.From.init -> void
+LM.Core.Models.Search.SearchHistoryEntry.Query.get -> string!
+LM.Core.Models.Search.SearchHistoryEntry.Query.init -> void
+LM.Core.Models.Search.SearchHistoryEntry.To.get -> System.DateTime?
+LM.Core.Models.Search.SearchHistoryEntry.To.init -> void
+LM.Core.Models.Search.SearchExecutionRequest
+LM.Core.Models.Search.SearchExecutionRequest.Database.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.Search.SearchExecutionRequest.Database.init -> void
+LM.Core.Models.Search.SearchExecutionRequest.From.get -> System.DateTime?
+LM.Core.Models.Search.SearchExecutionRequest.From.init -> void
+LM.Core.Models.Search.SearchExecutionRequest.Query.get -> string!
+LM.Core.Models.Search.SearchExecutionRequest.Query.init -> void
+LM.Core.Models.Search.SearchExecutionRequest.To.get -> System.DateTime?
+LM.Core.Models.Search.SearchExecutionRequest.To.init -> void
+LM.Core.Models.Search.SearchExecutionResult
+LM.Core.Models.Search.SearchExecutionResult.ExecutedUtc.get -> System.DateTimeOffset
+LM.Core.Models.Search.SearchExecutionResult.ExecutedUtc.init -> void
+LM.Core.Models.Search.SearchExecutionResult.Hits.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.SearchHit!>!
+LM.Core.Models.Search.SearchExecutionResult.Hits.init -> void
+LM.Core.Models.Search.SearchExecutionResult.Request.get -> LM.Core.Models.Search.SearchExecutionRequest!
+LM.Core.Models.Search.SearchExecutionResult.Request.init -> void
+LM.Core.Models.UserPreferences
+LM.Core.Models.UserPreferences.Search.get -> LM.Core.Models.SearchPreferences!
+LM.Core.Models.UserPreferences.Search.init -> void
+LM.Core.Models.UserPreferences.Library.get -> LM.Core.Models.LibraryPreferences!
+LM.Core.Models.UserPreferences.Library.init -> void
+LM.Core.Models.SearchPreferences
+LM.Core.Models.SearchPreferences.LastSelectedDatabase.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchPreferences.LastSelectedDatabase.init -> void
+LM.Core.Models.SearchPreferences.LastUpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.SearchPreferences.LastUpdatedUtc.init -> void
+LM.Core.Models.LibraryPreferences
+LM.Core.Models.LibraryPreferences.VisibleColumns.get -> string![]!
+LM.Core.Models.LibraryPreferences.VisibleColumns.init -> void
+LM.Core.Models.LibraryPreferences.LastUpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.LibraryPreferences.LastUpdatedUtc.init -> void
+LM.Core.Models.WatchedFolderSettings
+LM.Core.Models.WatchedFolderSettings.Folders.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.WatchedFolderSettingsFolder!>!
+LM.Core.Models.WatchedFolderSettings.Folders.init -> void
+LM.Core.Models.WatchedFolderSettings.States.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.WatchedFolderState!>!
+LM.Core.Models.WatchedFolderSettings.States.init -> void
+LM.Core.Models.WatchedFolderSettingsFolder
+LM.Core.Models.WatchedFolderSettingsFolder.IsEnabled.get -> bool
+LM.Core.Models.WatchedFolderSettingsFolder.IsEnabled.init -> void
+LM.Core.Models.WatchedFolderSettingsFolder.Path.get -> string!
+LM.Core.Models.WatchedFolderSettingsFolder.Path.init -> void
+LM.Core.Models.WatchedFolderState
+LM.Core.Models.WatchedFolderState.AggregatedHash.get -> string?
+LM.Core.Models.WatchedFolderState.AggregatedHash.init -> void
+LM.Core.Models.WatchedFolderState.LastScanUtc.get -> System.DateTimeOffset?
+LM.Core.Models.WatchedFolderState.LastScanUtc.init -> void
+LM.Core.Models.WatchedFolderState.LastScanWasUnchanged.get -> bool
+LM.Core.Models.WatchedFolderState.LastScanWasUnchanged.init -> void
+LM.Core.Models.WatchedFolderState.Path.get -> string!
+LM.Core.Models.WatchedFolderState.Path.init -> void
+static readonly LM.Core.Utils.JsonEx.Options -> System.Text.Json.JsonSerializerOptions!
+---------- LM.Core ----------
+#nullable enable
+#nullable enable
+IPublicationLookup
+IPublicationLookup.TryGetByDoiAsync(string! doi, bool includeCitedBy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<LM.Core.Models.PublicationRecord?>!
+LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore
+LM.Core.Abstractions.IContentExtractor
+LM.Core.Abstractions.IContentExtractor.ExtractTextAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IEntryStore
+LM.Core.Abstractions.IEntryStore.EnumerateAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<LM.Core.Models.Entry!>!
+LM.Core.Abstractions.IEntryStore.FindByHashAsync(string! sha256, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.FindByIdsAsync(string? doi, string? pmid, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.FindSimilarByNameYearAsync(string! title, int? year, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Core.Abstractions.IEntryStore.GetByIdAsync(string! id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IEntryStore.SaveAsync(LM.Core.Models.Entry! entry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IEntryStore.SearchAsync(LM.Core.Models.Filters.EntryFilter! filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Core.Abstractions.IFullTextSearchService
+LM.Core.Abstractions.IFullTextSearchService.SearchAsync(LM.Core.Models.Search.FullTextSearchQuery! query, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Search.FullTextSearchHit!>!>!
+LM.Core.Abstractions.Search.ISearchExecutionService
+LM.Core.Abstractions.Search.ISearchExecutionService.ExecuteAsync(LM.Core.Models.Search.SearchExecutionRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Search.SearchExecutionResult!>!
+LM.Core.Abstractions.Search.ISearchProvider
+LM.Core.Abstractions.Search.ISearchProvider.Database.get -> LM.Core.Models.SearchDatabase
+LM.Core.Abstractions.Search.ISearchProvider.SearchAsync(string! query, System.DateTime? from, System.DateTime? to, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.SearchHit!>!>!
+LM.Core.Abstractions.IFileStorageRepository
+LM.Core.Abstractions.IFileStorageRepository.SaveNewAsync(string! sourcePath, string! relativeTargetDir, string? preferredFileName = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IHasher
+LM.Core.Abstractions.IHasher.ComputeSha256Async(string! filePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IMetadataDebugSlideExporter
+LM.Core.Abstractions.IMetadataDebugSlideExporter.ExportAsync(System.Collections.Generic.IEnumerable<LM.Core.Models.FileMetadata!>! items, string! outputPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IMetadataExtractor
+LM.Core.Abstractions.IMetadataExtractor.ExtractAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.FileMetadata!>!
+LM.Core.Abstractions.IPmidNormalizer
+LM.Core.Abstractions.IPmidNormalizer.Normalize(string? raw) -> string?
+LM.Core.Abstractions.ISimilarityService
+LM.Core.Abstractions.ISimilarityService.ComputeFileSimilarityAsync(string! filePathA, string! filePathB, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<double>!
+LM.Core.Abstractions.ITagVocabularyProvider
+LM.Core.Abstractions.ITagVocabularyProvider.GetAllTagsAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
+LM.Core.Abstractions.IWorkSpaceService
+LM.Core.Abstractions.IWorkSpaceService.EnsureWorkspaceAsync(string! absoluteWorkspacePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IWorkSpaceService.GetAbsolutePath(string! relativePath) -> string!
+LM.Core.Abstractions.IWorkSpaceService.GetLocalDbPath() -> string!
+LM.Core.Abstractions.IWorkSpaceService.GetWorkspaceRoot() -> string!
+LM.Core.Abstractions.IWorkSpaceService.WorkspacePath.get -> string?
+LM.Core.Abstractions.IDoiNormalizer
+LM.Core.Abstractions.IDoiNormalizer.Normalize(string? raw) -> string?
+LM.Core.Models.AbstractSection
+LM.Core.Models.AbstractSection.Label.get -> string?
+LM.Core.Models.AbstractSection.Label.init -> void
+LM.Core.Models.AbstractSection.Text.get -> string?
+LM.Core.Models.AbstractSection.Text.init -> void
+LM.Core.Models.Attachment
+LM.Core.Models.Attachment.Attachment() -> void
+LM.Core.Models.Attachment.Id.get -> string!
+LM.Core.Models.Attachment.Id.set -> void
+LM.Core.Models.Attachment.Notes.get -> string?
+LM.Core.Models.Attachment.Notes.set -> void
+LM.Core.Models.Attachment.RelativePath.get -> string!
+LM.Core.Models.Attachment.RelativePath.set -> void
+LM.Core.Models.Attachment.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Attachment.Tags.set -> void
+LM.Core.Models.Attachment.Title.get -> string!
+LM.Core.Models.Attachment.Title.set -> void
+LM.Core.Models.Attachment.Kind.get -> LM.Core.Models.AttachmentKind
+LM.Core.Models.Attachment.Kind.set -> void
+LM.Core.Models.Attachment.AddedBy.get -> string!
+LM.Core.Models.Attachment.AddedBy.set -> void
+LM.Core.Models.Attachment.AddedUtc.get -> System.DateTime
+LM.Core.Models.Attachment.AddedUtc.set -> void
+LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.Supplement = 0 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.Version = 1 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.Presentation = 2 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.ExternalNotes = 3 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AuthorName
+LM.Core.Models.AuthorName.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.AuthorName.Affiliations.init -> void
+LM.Core.Models.AuthorName.CollectiveName.get -> string?
+LM.Core.Models.AuthorName.CollectiveName.init -> void
+LM.Core.Models.AuthorName.Family.get -> string?
+LM.Core.Models.AuthorName.Family.init -> void
+LM.Core.Models.AuthorName.Given.get -> string?
+LM.Core.Models.AuthorName.Given.init -> void
+LM.Core.Models.AuthorName.LastFromLiteral() -> string?
+LM.Core.Models.AuthorName.Literal.get -> string?
+LM.Core.Models.AuthorName.Literal.init -> void
+LM.Core.Models.AuthorName.Orcid.get -> string?
+LM.Core.Models.AuthorName.Orcid.init -> void
+LM.Core.Models.AuthorName.ToCsvPart() -> string!
+LM.Core.Models.Entry
+LM.Core.Models.Entry.AddedBy.get -> string?
+LM.Core.Models.Entry.AddedBy.set -> void
+LM.Core.Models.Entry.AddedOnUtc.get -> System.DateTime
+LM.Core.Models.Entry.AddedOnUtc.set -> void
+LM.Core.Models.Entry.Attachments.get -> System.Collections.Generic.List<LM.Core.Models.Attachment!>!
+LM.Core.Models.Entry.Attachments.set -> void
+LM.Core.Models.Entry.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Authors.set -> void
+LM.Core.Models.Entry.DisplayName.get -> string?
+LM.Core.Models.Entry.DisplayName.set -> void
+LM.Core.Models.Entry.Doi.get -> string?
+LM.Core.Models.Entry.Doi.set -> void
+LM.Core.Models.Entry.Entry() -> void
+LM.Core.Models.Entry.Id.get -> string!
+LM.Core.Models.Entry.Id.set -> void
+LM.Core.Models.Entry.InternalId.get -> string?
+LM.Core.Models.Entry.InternalId.set -> void
+LM.Core.Models.Entry.IsInternal.get -> bool
+LM.Core.Models.Entry.IsInternal.set -> void
+LM.Core.Models.Entry.Links.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Links.set -> void
+LM.Core.Models.Entry.MainFileHashSha256.get -> string?
+LM.Core.Models.Entry.MainFileHashSha256.set -> void
+LM.Core.Models.Entry.MainFilePath.get -> string!
+LM.Core.Models.Entry.MainFilePath.set -> void
+LM.Core.Models.Entry.Nct.get -> string?
+LM.Core.Models.Entry.Nct.set -> void
+LM.Core.Models.Entry.Notes.get -> string?
+LM.Core.Models.Entry.Notes.set -> void
+LM.Core.Models.Entry.UserNotes.get -> string?
+LM.Core.Models.Entry.UserNotes.set -> void
+LM.Core.Models.Entry.OriginalFileName.get -> string?
+LM.Core.Models.Entry.OriginalFileName.set -> void
+LM.Core.Models.Entry.Pmid.get -> string?
+LM.Core.Models.Entry.Pmid.set -> void
+LM.Core.Models.Entry.Relations.get -> System.Collections.Generic.List<LM.Core.Models.Relation!>!
+LM.Core.Models.Entry.Relations.set -> void
+LM.Core.Models.Entry.ShortTitle.get -> string?
+LM.Core.Models.Entry.ShortTitle.set -> void
+LM.Core.Models.Entry.Source.get -> string?
+LM.Core.Models.Entry.Source.set -> void
+LM.Core.Models.Entry.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Tags.set -> void
+LM.Core.Models.Entry.Title.get -> string!
+LM.Core.Models.Entry.Title.set -> void
+LM.Core.Models.Entry.Type.get -> LM.Core.Models.EntryType
+LM.Core.Models.Entry.Type.set -> void
+LM.Core.Models.Entry.Version.get -> int
+LM.Core.Models.Entry.Version.set -> void
+LM.Core.Models.Entry.Year.get -> int?
+LM.Core.Models.Entry.Year.set -> void
+LM.Core.Models.EntryDocument
+LM.Core.Models.EntryDocument.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.EntryDocument.Authors.set -> void
+LM.Core.Models.EntryDocument.CreatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.EntryDocument.CreatedUtc.set -> void
+LM.Core.Models.EntryDocument.Doi.get -> string?
+LM.Core.Models.EntryDocument.Doi.set -> void
+LM.Core.Models.EntryDocument.EntryDocument() -> void
+LM.Core.Models.EntryDocument.Files.get -> System.Collections.Generic.List<LM.Core.Models.EntryFile!>!
+LM.Core.Models.EntryDocument.Files.set -> void
+LM.Core.Models.EntryDocument.Id.get -> string!
+LM.Core.Models.EntryDocument.Id.set -> void
+LM.Core.Models.EntryDocument.Internal.get -> bool
+LM.Core.Models.EntryDocument.Internal.set -> void
+LM.Core.Models.EntryDocument.Pmid.get -> string?
+LM.Core.Models.EntryDocument.Pmid.set -> void
+LM.Core.Models.EntryDocument.Source.get -> string?
+LM.Core.Models.EntryDocument.Source.set -> void
+LM.Core.Models.EntryDocument.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.EntryDocument.Tags.set -> void
+LM.Core.Models.EntryDocument.Title.get -> string?
+LM.Core.Models.EntryDocument.Title.set -> void
+LM.Core.Models.EntryDocument.UpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.EntryDocument.UpdatedUtc.set -> void
+LM.Core.Models.EntryDocument.Year.get -> int?
+LM.Core.Models.EntryDocument.Year.set -> void
+LM.Core.Models.EntryFile
+LM.Core.Models.EntryFile.EntryFile() -> void
+LM.Core.Models.EntryFile.Hash.get -> string!
+LM.Core.Models.EntryFile.Hash.set -> void
+LM.Core.Models.EntryFile.MimeType.get -> string!
+LM.Core.Models.EntryFile.MimeType.set -> void
+LM.Core.Models.EntryFile.OriginalFileName.get -> string!
+LM.Core.Models.EntryFile.OriginalFileName.set -> void
+LM.Core.Models.EntryFile.RelativePath.get -> string!
+LM.Core.Models.EntryFile.RelativePath.set -> void
+LM.Core.Models.EntryFile.SizeBytes.get -> long
+LM.Core.Models.EntryFile.SizeBytes.set -> void
+LM.Core.Models.EntryFile.StoredFileName.get -> string!
+LM.Core.Models.EntryFile.StoredFileName.set -> void
+LM.Core.Models.EntryType
+LM.Core.Models.EntryType.LitSearch = 6 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Other = 5 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Presentation = 1 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Publication = 0 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Report = 4 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.SlideDeck = 3 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.WhitePaper = 2 -> LM.Core.Models.EntryType
+LM.Core.Models.FileMetadata
+LM.Core.Models.FileMetadata.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.FileMetadata.Authors.set -> void
+LM.Core.Models.FileMetadata.Doi.get -> string?
+LM.Core.Models.FileMetadata.Doi.set -> void
+LM.Core.Models.FileMetadata.FileMetadata() -> void
+LM.Core.Models.FileMetadata.Pmid.get -> string?
+LM.Core.Models.FileMetadata.Pmid.set -> void
+LM.Core.Models.FileMetadata.Source.get -> string?
+LM.Core.Models.FileMetadata.Source.set -> void
+LM.Core.Models.FileMetadata.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.FileMetadata.Tags.set -> void
+LM.Core.Models.FileMetadata.Title.get -> string?
+LM.Core.Models.FileMetadata.Title.set -> void
+LM.Core.Models.FileMetadata.Year.get -> int?
+LM.Core.Models.FileMetadata.Year.set -> void
+LM.Core.Models.Filters.EntryFilter
+LM.Core.Models.Filters.EntryFilter.AuthorContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.AuthorContains.set -> void
+LM.Core.Models.Filters.EntryFilter.EntryFilter() -> void
+LM.Core.Models.Filters.EntryFilter.IsInternal.get -> bool?
+LM.Core.Models.Filters.EntryFilter.IsInternal.set -> void
+LM.Core.Models.Filters.EntryFilter.TagMatchMode.get -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.EntryFilter.TagMatchMode.set -> void
+LM.Core.Models.Filters.EntryFilter.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Filters.EntryFilter.Tags.set -> void
+LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.TagMatchMode.Any = 0 -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.TagMatchMode.All = 1 -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.TagMatchMode.Not = 2 -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.EntryFilter.TitleContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.TitleContains.set -> void
+LM.Core.Models.Filters.EntryFilter.TypesAny.get -> LM.Core.Models.EntryType[]?
+LM.Core.Models.Filters.EntryFilter.TypesAny.set -> void
+LM.Core.Models.Filters.EntryFilter.YearFrom.get -> int?
+LM.Core.Models.Filters.EntryFilter.YearFrom.set -> void
+LM.Core.Models.Filters.EntryFilter.YearTo.get -> int?
+LM.Core.Models.Filters.EntryFilter.YearTo.set -> void
+LM.Core.Models.Filters.EntryFilter.SourceContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.SourceContains.set -> void
+LM.Core.Models.Filters.EntryFilter.InternalIdContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.InternalIdContains.set -> void
+LM.Core.Models.Filters.EntryFilter.DoiContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.DoiContains.set -> void
+LM.Core.Models.Filters.EntryFilter.PmidContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.PmidContains.set -> void
+LM.Core.Models.Filters.EntryFilter.NctContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.NctContains.set -> void
+LM.Core.Models.Filters.EntryFilter.AddedByContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.AddedByContains.set -> void
+LM.Core.Models.Filters.EntryFilter.AddedOnFromUtc.get -> System.DateTime?
+LM.Core.Models.Filters.EntryFilter.AddedOnFromUtc.set -> void
+LM.Core.Models.Filters.EntryFilter.AddedOnToUtc.get -> System.DateTime?
+LM.Core.Models.Filters.EntryFilter.AddedOnToUtc.set -> void
+LM.Core.Models.GrantInfo
+LM.Core.Models.GrantInfo.Agency.get -> string?
+LM.Core.Models.GrantInfo.Agency.init -> void
+LM.Core.Models.GrantInfo.Country.get -> string?
+LM.Core.Models.GrantInfo.Country.init -> void
+LM.Core.Models.GrantInfo.GrantId.get -> string?
+LM.Core.Models.GrantInfo.GrantId.init -> void
+LM.Core.Models.PublicationRecord
+LM.Core.Models.PublicationRecord.AbstractPlain.get -> string?
+LM.Core.Models.PublicationRecord.AbstractPlain.init -> void
+LM.Core.Models.PublicationRecord.AbstractSections.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AbstractSection!>!
+LM.Core.Models.PublicationRecord.AbstractSections.init -> void
+LM.Core.Models.PublicationRecord.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.Affiliations.init -> void
+LM.Core.Models.PublicationRecord.Authors.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AuthorName!>!
+LM.Core.Models.PublicationRecord.Authors.init -> void
+LM.Core.Models.PublicationRecord.AuthorsCsv.get -> string!
+LM.Core.Models.PublicationRecord.CitedByCount.get -> int?
+LM.Core.Models.PublicationRecord.CitedByCount.init -> void
+LM.Core.Models.PublicationRecord.CitedByPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.CitedByPmids.init -> void
+LM.Core.Models.PublicationRecord.CommentsCorrections.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.CommentsCorrections.init -> void
+LM.Core.Models.PublicationRecord.Country.get -> string?
+LM.Core.Models.PublicationRecord.Country.init -> void
+LM.Core.Models.PublicationRecord.Doi.get -> string?
+LM.Core.Models.PublicationRecord.Doi.init -> void
+LM.Core.Models.PublicationRecord.FirstAuthorLast.get -> string!
+LM.Core.Models.PublicationRecord.Grants.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.GrantInfo!>!
+LM.Core.Models.PublicationRecord.Grants.init -> void
+LM.Core.Models.PublicationRecord.Issue.get -> string?
+LM.Core.Models.PublicationRecord.Issue.init -> void
+LM.Core.Models.PublicationRecord.JournalIsoAbbrev.get -> string?
+LM.Core.Models.PublicationRecord.JournalIsoAbbrev.init -> void
+LM.Core.Models.PublicationRecord.JournalTitle.get -> string?
+LM.Core.Models.PublicationRecord.JournalTitle.init -> void
+LM.Core.Models.PublicationRecord.Keywords.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.Keywords.init -> void
+LM.Core.Models.PublicationRecord.Language.get -> string?
+LM.Core.Models.PublicationRecord.Language.init -> void
+LM.Core.Models.PublicationRecord.MeshHeadings.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.MeshHeadings.init -> void
+LM.Core.Models.PublicationRecord.Pages.get -> string?
+LM.Core.Models.PublicationRecord.Pages.init -> void
+LM.Core.Models.PublicationRecord.Pmcid.get -> string?
+LM.Core.Models.PublicationRecord.Pmcid.init -> void
+LM.Core.Models.PublicationRecord.Pmid.get -> string?
+LM.Core.Models.PublicationRecord.Pmid.init -> void
+LM.Core.Models.PublicationRecord.PublicationTypes.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.PublicationTypes.init -> void
+LM.Core.Models.PublicationRecord.PublishedEpub.get -> System.DateOnly?
+LM.Core.Models.PublicationRecord.PublishedEpub.init -> void
+LM.Core.Models.PublicationRecord.PublishedPrint.get -> System.DateOnly?
+LM.Core.Models.PublicationRecord.PublishedPrint.init -> void
+LM.Core.Models.PublicationRecord.ReferencedPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.ReferencedPmids.init -> void
+LM.Core.Models.PublicationRecord.Title.get -> string?
+LM.Core.Models.PublicationRecord.Title.init -> void
+LM.Core.Models.PublicationRecord.UrlPubMed.get -> string?
+LM.Core.Models.PublicationRecord.UrlPubMed.init -> void
+LM.Core.Models.PublicationRecord.Volume.get -> string?
+LM.Core.Models.PublicationRecord.Volume.init -> void
+LM.Core.Models.PublicationRecord.Year.get -> int?
+LM.Core.Models.PublicationRecord.Year.init -> void
+LM.Core.Models.Relation
+LM.Core.Models.Relation.Relation() -> void
+LM.Core.Models.Relation.TargetEntryId.get -> string!
+LM.Core.Models.Relation.TargetEntryId.set -> void
+LM.Core.Models.Relation.Type.get -> string!
+LM.Core.Models.Relation.Type.set -> void
+LM.Core.Models.Search.FullTextSearchHit.EntryId.init -> void
+LM.Core.Models.Search.FullTextSearchHit.Highlight.init -> void
+LM.Core.Models.Search.FullTextSearchHit.Score.init -> void
+LM.Core.Models.Search.FullTextSearchQuery.TypesAny.get -> LM.Core.Models.EntryType[]?
+LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchDatabase.ClinicalTrialsGov = 1 -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchDatabase.PubMed = 0 -> LM.Core.Models.SearchDatabase
+LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchField.Abstract = 2 -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchField.Content = 4 -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchField.None = 0 -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchField.Title = 1 -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchHit
+LM.Core.Models.Search.FullTextSearchHit.EntryId.get -> string!
+LM.Core.Models.Search.FullTextSearchHit.FullTextSearchHit(string! EntryId, double Score, string? Highlight) -> void
+LM.Core.Models.Search.FullTextSearchHit.Highlight.get -> string?
+LM.Core.Models.Search.FullTextSearchHit.Score.get -> double
+LM.Core.Models.Search.FullTextSearchQuery
+LM.Core.Models.Search.FullTextSearchQuery.Fields.get -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchQuery.Fields.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.FullTextSearchQuery() -> void
+LM.Core.Models.Search.FullTextSearchQuery.IsInternal.get -> bool?
+LM.Core.Models.Search.FullTextSearchQuery.IsInternal.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.Limit.get -> int
+LM.Core.Models.Search.FullTextSearchQuery.Limit.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.Text.get -> string?
+LM.Core.Models.Search.FullTextSearchQuery.Text.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.TypesAny.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.YearFrom.get -> int?
+LM.Core.Models.Search.FullTextSearchQuery.YearFrom.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.YearTo.get -> int?
+LM.Core.Models.Search.FullTextSearchQuery.YearTo.set -> void
+LM.Core.Models.SearchHit
+LM.Core.Models.SearchHit.AlreadyInDb.get -> bool
+LM.Core.Models.SearchHit.AlreadyInDb.set -> void
+LM.Core.Models.SearchHit.Authors.get -> string!
+LM.Core.Models.SearchHit.Authors.init -> void
+LM.Core.Models.SearchHit.Doi.get -> string?
+LM.Core.Models.SearchHit.Doi.init -> void
+LM.Core.Models.SearchHit.ExternalId.get -> string!
+LM.Core.Models.SearchHit.ExternalId.init -> void
+LM.Core.Models.SearchHit.ExistingEntryId.get -> string?
+LM.Core.Models.SearchHit.ExistingEntryId.set -> void
+LM.Core.Models.SearchHit.JournalOrSource.get -> string?
+LM.Core.Models.SearchHit.JournalOrSource.init -> void
+LM.Core.Models.SearchHit.SearchHit() -> void
+LM.Core.Models.SearchHit.Selected.get -> bool
+LM.Core.Models.SearchHit.Selected.set -> void
+LM.Core.Models.SearchHit.Source.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchHit.Source.init -> void
+LM.Core.Models.SearchHit.Title.get -> string!
+LM.Core.Models.SearchHit.Title.init -> void
+LM.Core.Models.SearchHit.Url.get -> string?
+LM.Core.Models.SearchHit.Url.init -> void
+LM.Core.Models.SearchHit.Year.get -> int?
+LM.Core.Models.SearchHit.Year.init -> void
+LM.Core.Models.SearchHit.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.Core.Models.WatchedFolderState.WatchedFolderState(string! Path, System.DateTimeOffset? LastScanUtc, string? AggregatedHash, bool LastScanWasUnchanged) -> void
+LM.Core.Utils.Hashes
+LM.Core.Utils.IdGen
+LM.Core.Utils.JsonEx
+static LM.Core.Utils.Hashes.Sha1(string! input) -> string!
+static LM.Core.Utils.Hashes.Sha256File(string! path) -> string!
+static LM.Core.Utils.IdGen.NewId() -> string!
+static LM.Core.Utils.JsonEx.Deserialize<T>(string! s) -> T?
+static LM.Core.Utils.JsonEx.Serialize<T>(T v) -> string!
+LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.WatchedFolderSettings!>!
+LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore.SaveAsync(LM.Core.Models.WatchedFolderSettings! settings, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.Configuration.ISearchHistoryStore
+LM.Core.Abstractions.Configuration.ISearchHistoryStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Search.SearchHistoryDocument!>!
+LM.Core.Abstractions.Configuration.ISearchHistoryStore.SaveAsync(LM.Core.Models.Search.SearchHistoryDocument! document, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.Configuration.IUserPreferencesStore
+LM.Core.Abstractions.Configuration.IUserPreferencesStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.UserPreferences!>!
+LM.Core.Abstractions.Configuration.IUserPreferencesStore.SaveAsync(LM.Core.Models.UserPreferences! preferences, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Models.Search.SearchHistoryDocument
+LM.Core.Models.Search.SearchHistoryDocument.Entries.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.Search.SearchHistoryEntry!>!
+LM.Core.Models.Search.SearchHistoryDocument.Entries.init -> void
+LM.Core.Models.Search.SearchHistoryEntry
+LM.Core.Models.Search.SearchHistoryEntry.Database.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.Search.SearchHistoryEntry.Database.init -> void
+LM.Core.Models.Search.SearchHistoryEntry.ExecutedUtc.get -> System.DateTimeOffset
+LM.Core.Models.Search.SearchHistoryEntry.ExecutedUtc.init -> void
+LM.Core.Models.Search.SearchHistoryEntry.From.get -> System.DateTime?
+LM.Core.Models.Search.SearchHistoryEntry.From.init -> void
+LM.Core.Models.Search.SearchHistoryEntry.Query.get -> string!
+LM.Core.Models.Search.SearchHistoryEntry.Query.init -> void
+LM.Core.Models.Search.SearchHistoryEntry.To.get -> System.DateTime?
+LM.Core.Models.Search.SearchHistoryEntry.To.init -> void
+LM.Core.Models.Search.SearchExecutionRequest
+LM.Core.Models.Search.SearchExecutionRequest.Database.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.Search.SearchExecutionRequest.Database.init -> void
+LM.Core.Models.Search.SearchExecutionRequest.From.get -> System.DateTime?
+LM.Core.Models.Search.SearchExecutionRequest.From.init -> void
+LM.Core.Models.Search.SearchExecutionRequest.Query.get -> string!
+LM.Core.Models.Search.SearchExecutionRequest.Query.init -> void
+LM.Core.Models.Search.SearchExecutionRequest.To.get -> System.DateTime?
+LM.Core.Models.Search.SearchExecutionRequest.To.init -> void
+LM.Core.Models.Search.SearchExecutionResult
+LM.Core.Models.Search.SearchExecutionResult.ExecutedUtc.get -> System.DateTimeOffset
+LM.Core.Models.Search.SearchExecutionResult.ExecutedUtc.init -> void
+LM.Core.Models.Search.SearchExecutionResult.Hits.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.SearchHit!>!
+LM.Core.Models.Search.SearchExecutionResult.Hits.init -> void
+LM.Core.Models.Search.SearchExecutionResult.Request.get -> LM.Core.Models.Search.SearchExecutionRequest!
+LM.Core.Models.Search.SearchExecutionResult.Request.init -> void
+LM.Core.Models.UserPreferences
+LM.Core.Models.UserPreferences.Search.get -> LM.Core.Models.SearchPreferences!
+LM.Core.Models.UserPreferences.Search.init -> void
+LM.Core.Models.UserPreferences.Library.get -> LM.Core.Models.LibraryPreferences!
+LM.Core.Models.UserPreferences.Library.init -> void
+LM.Core.Models.SearchPreferences
+LM.Core.Models.SearchPreferences.LastSelectedDatabase.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchPreferences.LastSelectedDatabase.init -> void
+LM.Core.Models.SearchPreferences.LastUpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.SearchPreferences.LastUpdatedUtc.init -> void
+LM.Core.Models.LibraryPreferences
+LM.Core.Models.LibraryPreferences.VisibleColumns.get -> string![]!
+LM.Core.Models.LibraryPreferences.VisibleColumns.init -> void
+LM.Core.Models.LibraryPreferences.LastUpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.LibraryPreferences.LastUpdatedUtc.init -> void
+LM.Core.Models.WatchedFolderSettings
+LM.Core.Models.WatchedFolderSettings.Folders.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.WatchedFolderSettingsFolder!>!
+LM.Core.Models.WatchedFolderSettings.Folders.init -> void
+LM.Core.Models.WatchedFolderSettings.States.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.WatchedFolderState!>!
+LM.Core.Models.WatchedFolderSettings.States.init -> void
+LM.Core.Models.WatchedFolderSettingsFolder
+LM.Core.Models.WatchedFolderSettingsFolder.IsEnabled.get -> bool
+LM.Core.Models.WatchedFolderSettingsFolder.IsEnabled.init -> void
+LM.Core.Models.WatchedFolderSettingsFolder.Path.get -> string!
+LM.Core.Models.WatchedFolderSettingsFolder.Path.init -> void
+LM.Core.Models.WatchedFolderState
+LM.Core.Models.WatchedFolderState.AggregatedHash.get -> string?
+LM.Core.Models.WatchedFolderState.AggregatedHash.init -> void
+LM.Core.Models.WatchedFolderState.LastScanUtc.get -> System.DateTimeOffset?
+LM.Core.Models.WatchedFolderState.LastScanUtc.init -> void
+LM.Core.Models.WatchedFolderState.LastScanWasUnchanged.get -> bool
+LM.Core.Models.WatchedFolderState.LastScanWasUnchanged.init -> void
+LM.Core.Models.WatchedFolderState.Path.get -> string!
+LM.Core.Models.WatchedFolderState.Path.init -> void
+static readonly LM.Core.Utils.JsonEx.Options -> System.Text.Json.JsonSerializerOptions!
+---------- LM.Core ----------
+#nullable enable
+#nullable enable
+IPublicationLookup
+IPublicationLookup.TryGetByDoiAsync(string! doi, bool includeCitedBy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<LM.Core.Models.PublicationRecord?>!
+LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore
+LM.Core.Abstractions.IContentExtractor
+LM.Core.Abstractions.IContentExtractor.ExtractTextAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IEntryStore
+LM.Core.Abstractions.IEntryStore.EnumerateAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<LM.Core.Models.Entry!>!
+LM.Core.Abstractions.IEntryStore.FindByHashAsync(string! sha256, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.FindByIdsAsync(string? doi, string? pmid, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.FindSimilarByNameYearAsync(string! title, int? year, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Core.Abstractions.IEntryStore.GetByIdAsync(string! id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
+LM.Core.Abstractions.IEntryStore.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IEntryStore.SaveAsync(LM.Core.Models.Entry! entry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IEntryStore.SearchAsync(LM.Core.Models.Filters.EntryFilter! filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
+LM.Core.Abstractions.IFullTextSearchService
+LM.Core.Abstractions.IFullTextSearchService.SearchAsync(LM.Core.Models.Search.FullTextSearchQuery! query, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Search.FullTextSearchHit!>!>!
+LM.Core.Abstractions.Search.ISearchExecutionService
+LM.Core.Abstractions.Search.ISearchExecutionService.ExecuteAsync(LM.Core.Models.Search.SearchExecutionRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Search.SearchExecutionResult!>!
+LM.Core.Abstractions.Search.ISearchProvider
+LM.Core.Abstractions.Search.ISearchProvider.Database.get -> LM.Core.Models.SearchDatabase
+LM.Core.Abstractions.Search.ISearchProvider.SearchAsync(string! query, System.DateTime? from, System.DateTime? to, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.SearchHit!>!>!
+LM.Core.Abstractions.IFileStorageRepository
+LM.Core.Abstractions.IFileStorageRepository.SaveNewAsync(string! sourcePath, string! relativeTargetDir, string? preferredFileName = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IHasher
+LM.Core.Abstractions.IHasher.ComputeSha256Async(string! filePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IMetadataDebugSlideExporter
+LM.Core.Abstractions.IMetadataDebugSlideExporter.ExportAsync(System.Collections.Generic.IEnumerable<LM.Core.Models.FileMetadata!>! items, string! outputPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IMetadataExtractor
+LM.Core.Abstractions.IMetadataExtractor.ExtractAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.FileMetadata!>!
+LM.Core.Abstractions.IPmidNormalizer
+LM.Core.Abstractions.IPmidNormalizer.Normalize(string? raw) -> string?
+LM.Core.Abstractions.ISimilarityService
+LM.Core.Abstractions.ISimilarityService.ComputeFileSimilarityAsync(string! filePathA, string! filePathB, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<double>!
+LM.Core.Abstractions.ITagVocabularyProvider
+LM.Core.Abstractions.ITagVocabularyProvider.GetAllTagsAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
+LM.Core.Abstractions.IWorkSpaceService
+LM.Core.Abstractions.IWorkSpaceService.EnsureWorkspaceAsync(string! absoluteWorkspacePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IWorkSpaceService.GetAbsolutePath(string! relativePath) -> string!
+LM.Core.Abstractions.IWorkSpaceService.GetLocalDbPath() -> string!
+LM.Core.Abstractions.IWorkSpaceService.GetWorkspaceRoot() -> string!
+LM.Core.Abstractions.IWorkSpaceService.WorkspacePath.get -> string?
+LM.Core.Abstractions.IDoiNormalizer
+LM.Core.Abstractions.IDoiNormalizer.Normalize(string? raw) -> string?
+LM.Core.Models.AbstractSection
+LM.Core.Models.AbstractSection.Label.get -> string?
+LM.Core.Models.AbstractSection.Label.init -> void
+LM.Core.Models.AbstractSection.Text.get -> string?
+LM.Core.Models.AbstractSection.Text.init -> void
+LM.Core.Models.Attachment
+LM.Core.Models.Attachment.Attachment() -> void
+LM.Core.Models.Attachment.Id.get -> string!
+LM.Core.Models.Attachment.Id.set -> void
+LM.Core.Models.Attachment.Notes.get -> string?
+LM.Core.Models.Attachment.Notes.set -> void
+LM.Core.Models.Attachment.RelativePath.get -> string!
+LM.Core.Models.Attachment.RelativePath.set -> void
+LM.Core.Models.Attachment.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Attachment.Tags.set -> void
+LM.Core.Models.Attachment.Title.get -> string!
+LM.Core.Models.Attachment.Title.set -> void
+LM.Core.Models.Attachment.Kind.get -> LM.Core.Models.AttachmentKind
+LM.Core.Models.Attachment.Kind.set -> void
+LM.Core.Models.Attachment.AddedBy.get -> string!
+LM.Core.Models.Attachment.AddedBy.set -> void
+LM.Core.Models.Attachment.AddedUtc.get -> System.DateTime
+LM.Core.Models.Attachment.AddedUtc.set -> void
+LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.Supplement = 0 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.Version = 1 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.Presentation = 2 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AttachmentKind.ExternalNotes = 3 -> LM.Core.Models.AttachmentKind
+LM.Core.Models.AuthorName
+LM.Core.Models.AuthorName.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.AuthorName.Affiliations.init -> void
+LM.Core.Models.AuthorName.CollectiveName.get -> string?
+LM.Core.Models.AuthorName.CollectiveName.init -> void
+LM.Core.Models.AuthorName.Family.get -> string?
+LM.Core.Models.AuthorName.Family.init -> void
+LM.Core.Models.AuthorName.Given.get -> string?
+LM.Core.Models.AuthorName.Given.init -> void
+LM.Core.Models.AuthorName.LastFromLiteral() -> string?
+LM.Core.Models.AuthorName.Literal.get -> string?
+LM.Core.Models.AuthorName.Literal.init -> void
+LM.Core.Models.AuthorName.Orcid.get -> string?
+LM.Core.Models.AuthorName.Orcid.init -> void
+LM.Core.Models.AuthorName.ToCsvPart() -> string!
+LM.Core.Models.Entry
+LM.Core.Models.Entry.AddedBy.get -> string?
+LM.Core.Models.Entry.AddedBy.set -> void
+LM.Core.Models.Entry.AddedOnUtc.get -> System.DateTime
+LM.Core.Models.Entry.AddedOnUtc.set -> void
+LM.Core.Models.Entry.Attachments.get -> System.Collections.Generic.List<LM.Core.Models.Attachment!>!
+LM.Core.Models.Entry.Attachments.set -> void
+LM.Core.Models.Entry.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Authors.set -> void
+LM.Core.Models.Entry.DisplayName.get -> string?
+LM.Core.Models.Entry.DisplayName.set -> void
+LM.Core.Models.Entry.Doi.get -> string?
+LM.Core.Models.Entry.Doi.set -> void
+LM.Core.Models.Entry.Entry() -> void
+LM.Core.Models.Entry.Id.get -> string!
+LM.Core.Models.Entry.Id.set -> void
+LM.Core.Models.Entry.InternalId.get -> string?
+LM.Core.Models.Entry.InternalId.set -> void
+LM.Core.Models.Entry.IsInternal.get -> bool
+LM.Core.Models.Entry.IsInternal.set -> void
+LM.Core.Models.Entry.Links.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Links.set -> void
+LM.Core.Models.Entry.MainFileHashSha256.get -> string?
+LM.Core.Models.Entry.MainFileHashSha256.set -> void
+LM.Core.Models.Entry.MainFilePath.get -> string!
+LM.Core.Models.Entry.MainFilePath.set -> void
+LM.Core.Models.Entry.Nct.get -> string?
+LM.Core.Models.Entry.Nct.set -> void
+LM.Core.Models.Entry.Notes.get -> string?
+LM.Core.Models.Entry.Notes.set -> void
+LM.Core.Models.Entry.UserNotes.get -> string?
+LM.Core.Models.Entry.UserNotes.set -> void
+LM.Core.Models.Entry.OriginalFileName.get -> string?
+LM.Core.Models.Entry.OriginalFileName.set -> void
+LM.Core.Models.Entry.Pmid.get -> string?
+LM.Core.Models.Entry.Pmid.set -> void
+LM.Core.Models.Entry.Relations.get -> System.Collections.Generic.List<LM.Core.Models.Relation!>!
+LM.Core.Models.Entry.Relations.set -> void
+LM.Core.Models.Entry.ShortTitle.get -> string?
+LM.Core.Models.Entry.ShortTitle.set -> void
+LM.Core.Models.Entry.Source.get -> string?
+LM.Core.Models.Entry.Source.set -> void
+LM.Core.Models.Entry.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Entry.Tags.set -> void
+LM.Core.Models.Entry.Title.get -> string!
+LM.Core.Models.Entry.Title.set -> void
+LM.Core.Models.Entry.Type.get -> LM.Core.Models.EntryType
+LM.Core.Models.Entry.Type.set -> void
+LM.Core.Models.Entry.Version.get -> int
+LM.Core.Models.Entry.Version.set -> void
+LM.Core.Models.Entry.Year.get -> int?
+LM.Core.Models.Entry.Year.set -> void
+LM.Core.Models.EntryDocument
+LM.Core.Models.EntryDocument.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.EntryDocument.Authors.set -> void
+LM.Core.Models.EntryDocument.CreatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.EntryDocument.CreatedUtc.set -> void
+LM.Core.Models.EntryDocument.Doi.get -> string?
+LM.Core.Models.EntryDocument.Doi.set -> void
+LM.Core.Models.EntryDocument.EntryDocument() -> void
+LM.Core.Models.EntryDocument.Files.get -> System.Collections.Generic.List<LM.Core.Models.EntryFile!>!
+LM.Core.Models.EntryDocument.Files.set -> void
+LM.Core.Models.EntryDocument.Id.get -> string!
+LM.Core.Models.EntryDocument.Id.set -> void
+LM.Core.Models.EntryDocument.Internal.get -> bool
+LM.Core.Models.EntryDocument.Internal.set -> void
+LM.Core.Models.EntryDocument.Pmid.get -> string?
+LM.Core.Models.EntryDocument.Pmid.set -> void
+LM.Core.Models.EntryDocument.Source.get -> string?
+LM.Core.Models.EntryDocument.Source.set -> void
+LM.Core.Models.EntryDocument.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.EntryDocument.Tags.set -> void
+LM.Core.Models.EntryDocument.Title.get -> string?
+LM.Core.Models.EntryDocument.Title.set -> void
+LM.Core.Models.EntryDocument.UpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.EntryDocument.UpdatedUtc.set -> void
+LM.Core.Models.EntryDocument.Year.get -> int?
+LM.Core.Models.EntryDocument.Year.set -> void
+LM.Core.Models.EntryFile
+LM.Core.Models.EntryFile.EntryFile() -> void
+LM.Core.Models.EntryFile.Hash.get -> string!
+LM.Core.Models.EntryFile.Hash.set -> void
+LM.Core.Models.EntryFile.MimeType.get -> string!
+LM.Core.Models.EntryFile.MimeType.set -> void
+LM.Core.Models.EntryFile.OriginalFileName.get -> string!
+LM.Core.Models.EntryFile.OriginalFileName.set -> void
+LM.Core.Models.EntryFile.RelativePath.get -> string!
+LM.Core.Models.EntryFile.RelativePath.set -> void
+LM.Core.Models.EntryFile.SizeBytes.get -> long
+LM.Core.Models.EntryFile.SizeBytes.set -> void
+LM.Core.Models.EntryFile.StoredFileName.get -> string!
+LM.Core.Models.EntryFile.StoredFileName.set -> void
+LM.Core.Models.EntryType
+LM.Core.Models.EntryType.LitSearch = 6 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Other = 5 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Presentation = 1 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Publication = 0 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.Report = 4 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.SlideDeck = 3 -> LM.Core.Models.EntryType
+LM.Core.Models.EntryType.WhitePaper = 2 -> LM.Core.Models.EntryType
+LM.Core.Models.FileMetadata
+LM.Core.Models.FileMetadata.Authors.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.FileMetadata.Authors.set -> void
+LM.Core.Models.FileMetadata.Doi.get -> string?
+LM.Core.Models.FileMetadata.Doi.set -> void
+LM.Core.Models.FileMetadata.FileMetadata() -> void
+LM.Core.Models.FileMetadata.Pmid.get -> string?
+LM.Core.Models.FileMetadata.Pmid.set -> void
+LM.Core.Models.FileMetadata.Source.get -> string?
+LM.Core.Models.FileMetadata.Source.set -> void
+LM.Core.Models.FileMetadata.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.FileMetadata.Tags.set -> void
+LM.Core.Models.FileMetadata.Title.get -> string?
+LM.Core.Models.FileMetadata.Title.set -> void
+LM.Core.Models.FileMetadata.Year.get -> int?
+LM.Core.Models.FileMetadata.Year.set -> void
+LM.Core.Models.Filters.EntryFilter
+LM.Core.Models.Filters.EntryFilter.AuthorContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.AuthorContains.set -> void
+LM.Core.Models.Filters.EntryFilter.EntryFilter() -> void
+LM.Core.Models.Filters.EntryFilter.IsInternal.get -> bool?
+LM.Core.Models.Filters.EntryFilter.IsInternal.set -> void
+LM.Core.Models.Filters.EntryFilter.TagMatchMode.get -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.EntryFilter.TagMatchMode.set -> void
+LM.Core.Models.Filters.EntryFilter.Tags.get -> System.Collections.Generic.List<string!>!
+LM.Core.Models.Filters.EntryFilter.Tags.set -> void
+LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.TagMatchMode.Any = 0 -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.TagMatchMode.All = 1 -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.TagMatchMode.Not = 2 -> LM.Core.Models.Filters.TagMatchMode
+LM.Core.Models.Filters.EntryFilter.TitleContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.TitleContains.set -> void
+LM.Core.Models.Filters.EntryFilter.TypesAny.get -> LM.Core.Models.EntryType[]?
+LM.Core.Models.Filters.EntryFilter.TypesAny.set -> void
+LM.Core.Models.Filters.EntryFilter.YearFrom.get -> int?
+LM.Core.Models.Filters.EntryFilter.YearFrom.set -> void
+LM.Core.Models.Filters.EntryFilter.YearTo.get -> int?
+LM.Core.Models.Filters.EntryFilter.YearTo.set -> void
+LM.Core.Models.Filters.EntryFilter.SourceContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.SourceContains.set -> void
+LM.Core.Models.Filters.EntryFilter.InternalIdContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.InternalIdContains.set -> void
+LM.Core.Models.Filters.EntryFilter.DoiContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.DoiContains.set -> void
+LM.Core.Models.Filters.EntryFilter.PmidContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.PmidContains.set -> void
+LM.Core.Models.Filters.EntryFilter.NctContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.NctContains.set -> void
+LM.Core.Models.Filters.EntryFilter.AddedByContains.get -> string?
+LM.Core.Models.Filters.EntryFilter.AddedByContains.set -> void
+LM.Core.Models.Filters.EntryFilter.AddedOnFromUtc.get -> System.DateTime?
+LM.Core.Models.Filters.EntryFilter.AddedOnFromUtc.set -> void
+LM.Core.Models.Filters.EntryFilter.AddedOnToUtc.get -> System.DateTime?
+LM.Core.Models.Filters.EntryFilter.AddedOnToUtc.set -> void
+LM.Core.Models.GrantInfo
+LM.Core.Models.GrantInfo.Agency.get -> string?
+LM.Core.Models.GrantInfo.Agency.init -> void
+LM.Core.Models.GrantInfo.Country.get -> string?
+LM.Core.Models.GrantInfo.Country.init -> void
+LM.Core.Models.GrantInfo.GrantId.get -> string?
+LM.Core.Models.GrantInfo.GrantId.init -> void
+LM.Core.Models.PublicationRecord
+LM.Core.Models.PublicationRecord.AbstractPlain.get -> string?
+LM.Core.Models.PublicationRecord.AbstractPlain.init -> void
+LM.Core.Models.PublicationRecord.AbstractSections.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AbstractSection!>!
+LM.Core.Models.PublicationRecord.AbstractSections.init -> void
+LM.Core.Models.PublicationRecord.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.Affiliations.init -> void
+LM.Core.Models.PublicationRecord.Authors.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AuthorName!>!
+LM.Core.Models.PublicationRecord.Authors.init -> void
+LM.Core.Models.PublicationRecord.AuthorsCsv.get -> string!
+LM.Core.Models.PublicationRecord.CitedByCount.get -> int?
+LM.Core.Models.PublicationRecord.CitedByCount.init -> void
+LM.Core.Models.PublicationRecord.CitedByPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.CitedByPmids.init -> void
+LM.Core.Models.PublicationRecord.CommentsCorrections.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.CommentsCorrections.init -> void
+LM.Core.Models.PublicationRecord.Country.get -> string?
+LM.Core.Models.PublicationRecord.Country.init -> void
+LM.Core.Models.PublicationRecord.Doi.get -> string?
+LM.Core.Models.PublicationRecord.Doi.init -> void
+LM.Core.Models.PublicationRecord.FirstAuthorLast.get -> string!
+LM.Core.Models.PublicationRecord.Grants.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.GrantInfo!>!
+LM.Core.Models.PublicationRecord.Grants.init -> void
+LM.Core.Models.PublicationRecord.Issue.get -> string?
+LM.Core.Models.PublicationRecord.Issue.init -> void
+LM.Core.Models.PublicationRecord.JournalIsoAbbrev.get -> string?
+LM.Core.Models.PublicationRecord.JournalIsoAbbrev.init -> void
+LM.Core.Models.PublicationRecord.JournalTitle.get -> string?
+LM.Core.Models.PublicationRecord.JournalTitle.init -> void
+LM.Core.Models.PublicationRecord.Keywords.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.Keywords.init -> void
+LM.Core.Models.PublicationRecord.Language.get -> string?
+LM.Core.Models.PublicationRecord.Language.init -> void
+LM.Core.Models.PublicationRecord.MeshHeadings.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.MeshHeadings.init -> void
+LM.Core.Models.PublicationRecord.Pages.get -> string?
+LM.Core.Models.PublicationRecord.Pages.init -> void
+LM.Core.Models.PublicationRecord.Pmcid.get -> string?
+LM.Core.Models.PublicationRecord.Pmcid.init -> void
+LM.Core.Models.PublicationRecord.Pmid.get -> string?
+LM.Core.Models.PublicationRecord.Pmid.init -> void
+LM.Core.Models.PublicationRecord.PublicationTypes.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.PublicationTypes.init -> void
+LM.Core.Models.PublicationRecord.PublishedEpub.get -> System.DateOnly?
+LM.Core.Models.PublicationRecord.PublishedEpub.init -> void
+LM.Core.Models.PublicationRecord.PublishedPrint.get -> System.DateOnly?
+LM.Core.Models.PublicationRecord.PublishedPrint.init -> void
+LM.Core.Models.PublicationRecord.ReferencedPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.Core.Models.PublicationRecord.ReferencedPmids.init -> void
+LM.Core.Models.PublicationRecord.Title.get -> string?
+LM.Core.Models.PublicationRecord.Title.init -> void
+LM.Core.Models.PublicationRecord.UrlPubMed.get -> string?
+LM.Core.Models.PublicationRecord.UrlPubMed.init -> void
+LM.Core.Models.PublicationRecord.Volume.get -> string?
+LM.Core.Models.PublicationRecord.Volume.init -> void
+LM.Core.Models.PublicationRecord.Year.get -> int?
+LM.Core.Models.PublicationRecord.Year.init -> void
+LM.Core.Models.Relation
+LM.Core.Models.Relation.Relation() -> void
+LM.Core.Models.Relation.TargetEntryId.get -> string!
+LM.Core.Models.Relation.TargetEntryId.set -> void
+LM.Core.Models.Relation.Type.get -> string!
+LM.Core.Models.Relation.Type.set -> void
+LM.Core.Models.Search.FullTextSearchHit.EntryId.init -> void
+LM.Core.Models.Search.FullTextSearchHit.Highlight.init -> void
+LM.Core.Models.Search.FullTextSearchHit.Score.init -> void
+LM.Core.Models.Search.FullTextSearchQuery.TypesAny.get -> LM.Core.Models.EntryType[]?
+LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchDatabase.ClinicalTrialsGov = 1 -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchDatabase.PubMed = 0 -> LM.Core.Models.SearchDatabase
+LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchField.Abstract = 2 -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchField.Content = 4 -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchField.None = 0 -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchField.Title = 1 -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchHit
+LM.Core.Models.Search.FullTextSearchHit.EntryId.get -> string!
+LM.Core.Models.Search.FullTextSearchHit.FullTextSearchHit(string! EntryId, double Score, string? Highlight) -> void
+LM.Core.Models.Search.FullTextSearchHit.Highlight.get -> string?
+LM.Core.Models.Search.FullTextSearchHit.Score.get -> double
+LM.Core.Models.Search.FullTextSearchQuery
+LM.Core.Models.Search.FullTextSearchQuery.Fields.get -> LM.Core.Models.Search.FullTextSearchField
+LM.Core.Models.Search.FullTextSearchQuery.Fields.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.FullTextSearchQuery() -> void
+LM.Core.Models.Search.FullTextSearchQuery.IsInternal.get -> bool?
+LM.Core.Models.Search.FullTextSearchQuery.IsInternal.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.Limit.get -> int
+LM.Core.Models.Search.FullTextSearchQuery.Limit.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.Text.get -> string?
+LM.Core.Models.Search.FullTextSearchQuery.Text.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.TypesAny.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.YearFrom.get -> int?
+LM.Core.Models.Search.FullTextSearchQuery.YearFrom.set -> void
+LM.Core.Models.Search.FullTextSearchQuery.YearTo.get -> int?
+LM.Core.Models.Search.FullTextSearchQuery.YearTo.set -> void
+LM.Core.Models.SearchHit
+LM.Core.Models.SearchHit.AlreadyInDb.get -> bool
+LM.Core.Models.SearchHit.AlreadyInDb.set -> void
+LM.Core.Models.SearchHit.Authors.get -> string!
+LM.Core.Models.SearchHit.Authors.init -> void
+LM.Core.Models.SearchHit.Doi.get -> string?
+LM.Core.Models.SearchHit.Doi.init -> void
+LM.Core.Models.SearchHit.ExternalId.get -> string!
+LM.Core.Models.SearchHit.ExternalId.init -> void
+LM.Core.Models.SearchHit.ExistingEntryId.get -> string?
+LM.Core.Models.SearchHit.ExistingEntryId.set -> void
+LM.Core.Models.SearchHit.JournalOrSource.get -> string?
+LM.Core.Models.SearchHit.JournalOrSource.init -> void
+LM.Core.Models.SearchHit.SearchHit() -> void
+LM.Core.Models.SearchHit.Selected.get -> bool
+LM.Core.Models.SearchHit.Selected.set -> void
+LM.Core.Models.SearchHit.Source.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchHit.Source.init -> void
+LM.Core.Models.SearchHit.Title.get -> string!
+LM.Core.Models.SearchHit.Title.init -> void
+LM.Core.Models.SearchHit.Url.get -> string?
+LM.Core.Models.SearchHit.Url.init -> void
+LM.Core.Models.SearchHit.Year.get -> int?
+LM.Core.Models.SearchHit.Year.init -> void
+LM.Core.Models.SearchHit.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.Core.Models.WatchedFolderState.WatchedFolderState(string! Path, System.DateTimeOffset? LastScanUtc, string? AggregatedHash, bool LastScanWasUnchanged) -> void
+LM.Core.Utils.Hashes
+LM.Core.Utils.IdGen
+LM.Core.Utils.JsonEx
+static LM.Core.Utils.Hashes.Sha1(string! input) -> string!
+static LM.Core.Utils.Hashes.Sha256File(string! path) -> string!
+static LM.Core.Utils.IdGen.NewId() -> string!
+static LM.Core.Utils.JsonEx.Deserialize<T>(string! s) -> T?
+static LM.Core.Utils.JsonEx.Serialize<T>(T v) -> string!
+LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.WatchedFolderSettings!>!
+LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore.SaveAsync(LM.Core.Models.WatchedFolderSettings! settings, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.Configuration.ISearchHistoryStore
+LM.Core.Abstractions.Configuration.ISearchHistoryStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Search.SearchHistoryDocument!>!
+LM.Core.Abstractions.Configuration.ISearchHistoryStore.SaveAsync(LM.Core.Models.Search.SearchHistoryDocument! document, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.Configuration.IUserPreferencesStore
+LM.Core.Abstractions.Configuration.IUserPreferencesStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.UserPreferences!>!
+LM.Core.Abstractions.Configuration.IUserPreferencesStore.SaveAsync(LM.Core.Models.UserPreferences! preferences, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Models.Search.SearchHistoryDocument
+LM.Core.Models.Search.SearchHistoryDocument.Entries.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.Search.SearchHistoryEntry!>!
+LM.Core.Models.Search.SearchHistoryDocument.Entries.init -> void
+LM.Core.Models.Search.SearchHistoryEntry
+LM.Core.Models.Search.SearchHistoryEntry.Database.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.Search.SearchHistoryEntry.Database.init -> void
+LM.Core.Models.Search.SearchHistoryEntry.ExecutedUtc.get -> System.DateTimeOffset
+LM.Core.Models.Search.SearchHistoryEntry.ExecutedUtc.init -> void
+LM.Core.Models.Search.SearchHistoryEntry.From.get -> System.DateTime?
+LM.Core.Models.Search.SearchHistoryEntry.From.init -> void
+LM.Core.Models.Search.SearchHistoryEntry.Query.get -> string!
+LM.Core.Models.Search.SearchHistoryEntry.Query.init -> void
+LM.Core.Models.Search.SearchHistoryEntry.To.get -> System.DateTime?
+LM.Core.Models.Search.SearchHistoryEntry.To.init -> void
+LM.Core.Models.Search.SearchExecutionRequest
+LM.Core.Models.Search.SearchExecutionRequest.Database.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.Search.SearchExecutionRequest.Database.init -> void
+LM.Core.Models.Search.SearchExecutionRequest.From.get -> System.DateTime?
+LM.Core.Models.Search.SearchExecutionRequest.From.init -> void
+LM.Core.Models.Search.SearchExecutionRequest.Query.get -> string!
+LM.Core.Models.Search.SearchExecutionRequest.Query.init -> void
+LM.Core.Models.Search.SearchExecutionRequest.To.get -> System.DateTime?
+LM.Core.Models.Search.SearchExecutionRequest.To.init -> void
+LM.Core.Models.Search.SearchExecutionResult
+LM.Core.Models.Search.SearchExecutionResult.ExecutedUtc.get -> System.DateTimeOffset
+LM.Core.Models.Search.SearchExecutionResult.ExecutedUtc.init -> void
+LM.Core.Models.Search.SearchExecutionResult.Hits.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.SearchHit!>!
+LM.Core.Models.Search.SearchExecutionResult.Hits.init -> void
+LM.Core.Models.Search.SearchExecutionResult.Request.get -> LM.Core.Models.Search.SearchExecutionRequest!
+LM.Core.Models.Search.SearchExecutionResult.Request.init -> void
+LM.Core.Models.UserPreferences
+LM.Core.Models.UserPreferences.Search.get -> LM.Core.Models.SearchPreferences!
+LM.Core.Models.UserPreferences.Search.init -> void
+LM.Core.Models.UserPreferences.Library.get -> LM.Core.Models.LibraryPreferences!
+LM.Core.Models.UserPreferences.Library.init -> void
+LM.Core.Models.SearchPreferences
+LM.Core.Models.SearchPreferences.LastSelectedDatabase.get -> LM.Core.Models.SearchDatabase
+LM.Core.Models.SearchPreferences.LastSelectedDatabase.init -> void
+LM.Core.Models.SearchPreferences.LastUpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.SearchPreferences.LastUpdatedUtc.init -> void
+LM.Core.Models.LibraryPreferences
+LM.Core.Models.LibraryPreferences.VisibleColumns.get -> string![]!
+LM.Core.Models.LibraryPreferences.VisibleColumns.init -> void
+LM.Core.Models.LibraryPreferences.LastUpdatedUtc.get -> System.DateTimeOffset
+LM.Core.Models.LibraryPreferences.LastUpdatedUtc.init -> void
+LM.Core.Models.WatchedFolderSettings
+LM.Core.Models.WatchedFolderSettings.Folders.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.WatchedFolderSettingsFolder!>!
+LM.Core.Models.WatchedFolderSettings.Folders.init -> void
+LM.Core.Models.WatchedFolderSettings.States.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.WatchedFolderState!>!
+LM.Core.Models.WatchedFolderSettings.States.init -> void
+LM.Core.Models.WatchedFolderSettingsFolder
+LM.Core.Models.WatchedFolderSettingsFolder.IsEnabled.get -> bool
+LM.Core.Models.WatchedFolderSettingsFolder.IsEnabled.init -> void
+LM.Core.Models.WatchedFolderSettingsFolder.Path.get -> string!
+LM.Core.Models.WatchedFolderSettingsFolder.Path.init -> void
+LM.Core.Models.WatchedFolderState
+LM.Core.Models.WatchedFolderState.AggregatedHash.get -> string?
+LM.Core.Models.WatchedFolderState.AggregatedHash.init -> void
+LM.Core.Models.WatchedFolderState.LastScanUtc.get -> System.DateTimeOffset?
+LM.Core.Models.WatchedFolderState.LastScanUtc.init -> void
+LM.Core.Models.WatchedFolderState.LastScanWasUnchanged.get -> bool
+LM.Core.Models.WatchedFolderState.LastScanWasUnchanged.init -> void
+LM.Core.Models.WatchedFolderState.Path.get -> string!
+LM.Core.Models.WatchedFolderState.Path.init -> void
+static readonly LM.Core.Utils.JsonEx.Options -> System.Text.Json.JsonSerializerOptions!
+---------- LM.Review.Core ----------
+#nullable enable
+#nullable enable
+LM.Review.Core.Models.ConflictState
+LM.Review.Core.Models.ConflictState.None = 0 -> LM.Review.Core.Models.ConflictState
+LM.Review.Core.Models.ConflictState.Conflict = 1 -> LM.Review.Core.Models.ConflictState
+LM.Review.Core.Models.ConflictState.Escalated = 2 -> LM.Review.Core.Models.ConflictState
+LM.Review.Core.Models.ConflictState.Resolved = 3 -> LM.Review.Core.Models.ConflictState
+LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ScreeningStatus.Pending = 0 -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ScreeningStatus.InProgress = 1 -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ScreeningStatus.Included = 2 -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ScreeningStatus.Excluded = 3 -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ScreeningStatus.Escalated = 4 -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ReviewerRole
+LM.Review.Core.Models.ReviewerRole.Primary = 0 -> LM.Review.Core.Models.ReviewerRole
+LM.Review.Core.Models.ReviewerRole.Secondary = 1 -> LM.Review.Core.Models.ReviewerRole
+LM.Review.Core.Models.ReviewerRole.TieBreaker = 2 -> LM.Review.Core.Models.ReviewerRole
+LM.Review.Core.Models.ReviewerRole.Arbitrator = 3 -> LM.Review.Core.Models.ReviewerRole
+LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.ReviewStageType.TitleScreening = 0 -> LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.ReviewStageType.FullTextReview = 1 -> LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.ReviewStageType.ConsensusMeeting = 2 -> LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.ReviewStageType.QualityAssurance = 3 -> LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.ReviewerDecision
+LM.Review.Core.Models.ReviewerDecision.AssignmentId.get -> string!
+static LM.Review.Core.Models.ReviewerDecision.Create(string! assignmentId, string! reviewerId, LM.Review.Core.Models.ScreeningStatus decision, System.DateTimeOffset decidedAtUtc, string? notes = null) -> LM.Review.Core.Models.ReviewerDecision!
+LM.Review.Core.Models.ReviewerDecision.DecidedAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.ReviewerDecision.Decision.get -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ReviewerDecision.Notes.get -> string?
+LM.Review.Core.Models.ReviewerDecision.ReviewerId.get -> string!
+LM.Review.Core.Models.ConsensusOutcome
+LM.Review.Core.Models.ConsensusOutcome.Approved.get -> bool
+static LM.Review.Core.Models.ConsensusOutcome.Create(string! stageId, bool approved, LM.Review.Core.Models.ConflictState resultingState, System.DateTimeOffset resolvedAtUtc, string? notes = null, string? resolvedBy = null) -> LM.Review.Core.Models.ConsensusOutcome!
+LM.Review.Core.Models.ConsensusOutcome.Notes.get -> string?
+LM.Review.Core.Models.ConsensusOutcome.ResolvedAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.ConsensusOutcome.ResolvedBy.get -> string?
+LM.Review.Core.Models.ConsensusOutcome.ResultingState.get -> LM.Review.Core.Models.ConflictState
+LM.Review.Core.Models.ConsensusOutcome.StageId.get -> string!
+LM.Review.Core.Models.ReviewAuditTrail
+LM.Review.Core.Models.ReviewAuditTrail.Append(LM.Review.Core.Models.ReviewAuditTrail.AuditEntry! entry) -> LM.Review.Core.Models.ReviewAuditTrail!
+static LM.Review.Core.Models.ReviewAuditTrail.Create(System.Collections.Generic.IEnumerable<LM.Review.Core.Models.ReviewAuditTrail.AuditEntry!>? entries = null) -> LM.Review.Core.Models.ReviewAuditTrail!
+LM.Review.Core.Models.ReviewAuditTrail.Entries.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.ReviewAuditTrail.AuditEntry!>!
+LM.Review.Core.Models.ReviewAuditTrail.AuditEntry
+LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Action.get -> string!
+LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Actor.get -> string!
+static LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Create(string! id, string! actor, string! action, System.DateTimeOffset occurredAtUtc, string? details = null) -> LM.Review.Core.Models.ReviewAuditTrail.AuditEntry!
+LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Details.get -> string?
+LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Id.get -> string!
+LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.OccurredAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.ReviewProject
+LM.Review.Core.Models.ReviewProject.AuditTrail.get -> LM.Review.Core.Models.ReviewAuditTrail!
+static LM.Review.Core.Models.ReviewProject.Create(string! id, string! name, System.DateTimeOffset createdAtUtc, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.StageDefinition!>! stageDefinitions, LM.Review.Core.Models.ReviewAuditTrail? auditTrail = null) -> LM.Review.Core.Models.ReviewProject!
+LM.Review.Core.Models.ReviewProject.CreatedAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.ReviewProject.Id.get -> string!
+LM.Review.Core.Models.ReviewProject.Name.get -> string!
+LM.Review.Core.Models.ReviewProject.StageDefinitions.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.StageDefinition!>!
+LM.Review.Core.Models.ReviewStage
+LM.Review.Core.Models.ReviewStage.ActivatedAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.ReviewStage.Assignments.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.ScreeningAssignment!>!
+LM.Review.Core.Models.ReviewStage.CompletedAt.get -> System.DateTimeOffset?
+LM.Review.Core.Models.ReviewStage.Consensus.get -> LM.Review.Core.Models.ConsensusOutcome?
+LM.Review.Core.Models.ReviewStage.ConflictState.get -> LM.Review.Core.Models.ConflictState
+static LM.Review.Core.Models.ReviewStage.Create(string! id, string! projectId, LM.Review.Core.Models.StageDefinition! definition, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.ScreeningAssignment!>! assignments, LM.Review.Core.Models.ConflictState conflictState, System.DateTimeOffset activatedAtUtc, System.DateTimeOffset? completedAtUtc = null, LM.Review.Core.Models.ConsensusOutcome? consensus = null) -> LM.Review.Core.Models.ReviewStage!
+LM.Review.Core.Models.ReviewStage.Definition.get -> LM.Review.Core.Models.StageDefinition!
+LM.Review.Core.Models.ReviewStage.Id.get -> string!
+LM.Review.Core.Models.ReviewStage.IsComplete.get -> bool
+LM.Review.Core.Models.ReviewStage.ProjectId.get -> string!
+LM.Review.Core.Models.StageDefinition
+LM.Review.Core.Models.StageDefinition.ConsensusPolicy.get -> LM.Review.Core.Models.StageConsensusPolicy!
+static LM.Review.Core.Models.StageDefinition.Create(string! id, string! name, LM.Review.Core.Models.ReviewStageType stageType, LM.Review.Core.Models.ReviewerRequirement! reviewerRequirement, LM.Review.Core.Models.StageConsensusPolicy! consensusPolicy) -> LM.Review.Core.Models.StageDefinition!
+LM.Review.Core.Models.StageDefinition.Id.get -> string!
+LM.Review.Core.Models.StageDefinition.Name.get -> string!
+LM.Review.Core.Models.StageDefinition.ReviewerRequirement.get -> LM.Review.Core.Models.ReviewerRequirement!
+LM.Review.Core.Models.StageDefinition.StageType.get -> LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.StageConsensusPolicy
+LM.Review.Core.Models.StageConsensusPolicy.ArbitrationRole.get -> LM.Review.Core.Models.ReviewerRole?
+static LM.Review.Core.Models.StageConsensusPolicy.Disabled() -> LM.Review.Core.Models.StageConsensusPolicy!
+LM.Review.Core.Models.StageConsensusPolicy.EscalateOnDisagreement.get -> bool
+LM.Review.Core.Models.StageConsensusPolicy.MinimumAgreements.get -> int
+static LM.Review.Core.Models.StageConsensusPolicy.RequireAgreement(int minimumAgreements, bool escalateOnDisagreement, LM.Review.Core.Models.ReviewerRole? arbitrationRole) -> LM.Review.Core.Models.StageConsensusPolicy!
+LM.Review.Core.Models.StageConsensusPolicy.RequiresConsensus.get -> bool
+LM.Review.Core.Models.ReviewerRequirement
+static LM.Review.Core.Models.ReviewerRequirement.Create(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<LM.Review.Core.Models.ReviewerRole, int>>! requirements) -> LM.Review.Core.Models.ReviewerRequirement!
+LM.Review.Core.Models.ReviewerRequirement.GetRequirement(LM.Review.Core.Models.ReviewerRole role) -> int
+LM.Review.Core.Models.ReviewerRequirement.Requirements.get -> System.Collections.Generic.IReadOnlyDictionary<LM.Review.Core.Models.ReviewerRole, int>!
+LM.Review.Core.Models.ReviewerRequirement.TotalRequired.get -> int
+LM.Review.Core.Models.ScreeningAssignment
+LM.Review.Core.Models.ScreeningAssignment.AssignedAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.ScreeningAssignment.CompletedAt.get -> System.DateTimeOffset?
+static LM.Review.Core.Models.ScreeningAssignment.Create(string! id, string! stageId, string! reviewerId, LM.Review.Core.Models.ReviewerRole role, LM.Review.Core.Models.ScreeningStatus status, System.DateTimeOffset assignedAtUtc, System.DateTimeOffset? completedAtUtc = null, LM.Review.Core.Models.ReviewerDecision? decision = null) -> LM.Review.Core.Models.ScreeningAssignment!
+LM.Review.Core.Models.ScreeningAssignment.Decision.get -> LM.Review.Core.Models.ReviewerDecision?
+LM.Review.Core.Models.ScreeningAssignment.Id.get -> string!
+LM.Review.Core.Models.ScreeningAssignment.ReviewerId.get -> string!
+LM.Review.Core.Models.ScreeningAssignment.Role.get -> LM.Review.Core.Models.ReviewerRole
+LM.Review.Core.Models.ScreeningAssignment.StageId.get -> string!
+LM.Review.Core.Models.ScreeningAssignment.Status.get -> LM.Review.Core.Models.ScreeningStatus

--- a/src/LM.Review.Core/LM.Review.Core.csproj
+++ b/src/LM.Review.Core/LM.Review.Core.csproj
@@ -5,4 +5,22 @@
   <ItemGroup>
     <ProjectReference Include="..\LM.Core\LM.Core.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Track public API changes -->
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+  <Target Name="EnsurePublicApiFiles" BeforeTargets="Build">
+    <WriteLinesToFile File="PublicAPI.Shipped.txt"
+                      Lines=""
+                      Overwrite="false"
+                      Condition="!Exists('PublicAPI.Shipped.txt')" />
+    <WriteLinesToFile File="PublicAPI.Unshipped.txt"
+                      Lines=""
+                      Overwrite="false"
+                      Condition="!Exists('PublicAPI.Unshipped.txt')" />
+  </Target>
 </Project>

--- a/src/LM.Review.Core/Models/ConflictState.cs
+++ b/src/LM.Review.Core/Models/ConflictState.cs
@@ -1,0 +1,9 @@
+namespace LM.Review.Core.Models;
+
+public enum ConflictState
+{
+    None = 0,
+    Conflict = 1,
+    Escalated = 2,
+    Resolved = 3
+}

--- a/src/LM.Review.Core/Models/ConsensusOutcome.cs
+++ b/src/LM.Review.Core/Models/ConsensusOutcome.cs
@@ -1,0 +1,64 @@
+namespace LM.Review.Core.Models;
+
+public sealed record ConsensusOutcome
+{
+    private ConsensusOutcome(
+        string stageId,
+        bool approved,
+        ConflictState resultingState,
+        DateTimeOffset resolvedAt,
+        string? notes,
+        string? resolvedBy)
+    {
+        StageId = stageId;
+        Approved = approved;
+        ResultingState = resultingState;
+        ResolvedAt = resolvedAt;
+        Notes = notes;
+        ResolvedBy = resolvedBy;
+    }
+
+    public string StageId { get; }
+
+    public bool Approved { get; }
+
+    public ConflictState ResultingState { get; }
+
+    public DateTimeOffset ResolvedAt { get; }
+
+    public string? Notes { get; }
+
+    public string? ResolvedBy { get; }
+
+    public static ConsensusOutcome Create(
+        string stageId,
+        bool approved,
+        ConflictState resultingState,
+        DateTimeOffset resolvedAtUtc,
+        string? notes = null,
+        string? resolvedBy = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stageId);
+        EnsureUtc(resolvedAtUtc, nameof(resolvedAtUtc));
+
+        if (approved && resultingState is not ConflictState.None and not ConflictState.Resolved)
+        {
+            throw new ArgumentException("An approved consensus must result in a resolved or neutral conflict state.", nameof(resultingState));
+        }
+
+        if (!approved && resultingState is ConflictState.None)
+        {
+            throw new ArgumentException("A rejected consensus cannot result in a neutral conflict state.", nameof(resultingState));
+        }
+
+        return new ConsensusOutcome(stageId.Trim(), approved, resultingState, resolvedAtUtc, notes?.Trim(), resolvedBy?.Trim());
+    }
+
+    private static void EnsureUtc(DateTimeOffset timestamp, string parameterName)
+    {
+        if (timestamp.Offset != TimeSpan.Zero)
+        {
+            throw new ArgumentException("Timestamp must be provided in UTC.", parameterName);
+        }
+    }
+}

--- a/src/LM.Review.Core/Models/ReviewAuditTrail.cs
+++ b/src/LM.Review.Core/Models/ReviewAuditTrail.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace LM.Review.Core.Models;
+
+public sealed class ReviewAuditTrail
+{
+    private ReviewAuditTrail(IReadOnlyList<AuditEntry> entries)
+    {
+        Entries = entries;
+    }
+
+    public IReadOnlyList<AuditEntry> Entries { get; }
+
+    public static ReviewAuditTrail Create(IEnumerable<AuditEntry>? entries = null)
+    {
+        var entryList = new List<AuditEntry>();
+        if (entries is not null)
+        {
+            foreach (var entry in entries)
+            {
+                ArgumentNullException.ThrowIfNull(entry);
+                entryList.Add(entry);
+            }
+        }
+
+        var ordered = entryList
+            .OrderBy(entry => entry.OccurredAt)
+            .ToList();
+
+        return new ReviewAuditTrail(new ReadOnlyCollection<AuditEntry>(ordered));
+    }
+
+    public ReviewAuditTrail Append(AuditEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var combined = Entries
+            .Concat(new[] { entry })
+            .OrderBy(e => e.OccurredAt)
+            .ToList();
+
+        return new ReviewAuditTrail(new ReadOnlyCollection<AuditEntry>(combined));
+    }
+
+    public sealed record AuditEntry
+    {
+        private AuditEntry(string id, string actor, string action, DateTimeOffset occurredAt, string? details)
+        {
+            Id = id;
+            Actor = actor;
+            Action = action;
+            OccurredAt = occurredAt;
+            Details = details;
+        }
+
+        public string Id { get; }
+
+        public string Actor { get; }
+
+        public string Action { get; }
+
+        public DateTimeOffset OccurredAt { get; }
+
+        public string? Details { get; }
+
+        public static AuditEntry Create(string id, string actor, string action, DateTimeOffset occurredAtUtc, string? details = null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(id);
+            ArgumentException.ThrowIfNullOrWhiteSpace(actor);
+            ArgumentException.ThrowIfNullOrWhiteSpace(action);
+            EnsureUtc(occurredAtUtc, nameof(occurredAtUtc));
+
+            return new AuditEntry(id.Trim(), actor.Trim(), action.Trim(), occurredAtUtc, details?.Trim());
+        }
+    }
+
+    private static void EnsureUtc(DateTimeOffset timestamp, string parameterName)
+    {
+        if (timestamp.Offset != TimeSpan.Zero)
+        {
+            throw new ArgumentException("Timestamp must be provided in UTC.", parameterName);
+        }
+    }
+}

--- a/src/LM.Review.Core/Models/ReviewModels.cs
+++ b/src/LM.Review.Core/Models/ReviewModels.cs
@@ -1,1 +1,0 @@
-namespace LM.Review.Core.Models { public record Review(string Id, string Title); }

--- a/src/LM.Review.Core/Models/ReviewProject.cs
+++ b/src/LM.Review.Core/Models/ReviewProject.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace LM.Review.Core.Models;
+
+public sealed class ReviewProject
+{
+    private ReviewProject(
+        string id,
+        string name,
+        DateTimeOffset createdAt,
+        IReadOnlyList<StageDefinition> stageDefinitions,
+        ReviewAuditTrail auditTrail)
+    {
+        Id = id;
+        Name = name;
+        CreatedAt = createdAt;
+        StageDefinitions = stageDefinitions;
+        AuditTrail = auditTrail;
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public DateTimeOffset CreatedAt { get; }
+
+    public IReadOnlyList<StageDefinition> StageDefinitions { get; }
+
+    public ReviewAuditTrail AuditTrail { get; }
+
+    public static ReviewProject Create(
+        string id,
+        string name,
+        DateTimeOffset createdAtUtc,
+        IEnumerable<StageDefinition> stageDefinitions,
+        ReviewAuditTrail? auditTrail = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(stageDefinitions);
+        EnsureUtc(createdAtUtc, nameof(createdAtUtc));
+
+        var trimmedId = id.Trim();
+        var trimmedName = name.Trim();
+
+        var definitionList = new List<StageDefinition>();
+        foreach (var definition in stageDefinitions)
+        {
+            ArgumentNullException.ThrowIfNull(definition);
+            definitionList.Add(definition);
+        }
+
+        if (definitionList.Count == 0)
+        {
+            throw new InvalidOperationException("A review project must declare at least one stage definition.");
+        }
+
+        var duplicateStageIds = definitionList
+            .GroupBy(definition => definition.Id, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
+
+        if (duplicateStageIds.Count > 0)
+        {
+            throw new InvalidOperationException($"Stage definition identifiers must be unique. Duplicates: {string.Join(", ", duplicateStageIds)}");
+        }
+
+        var readOnlyDefinitions = new ReadOnlyCollection<StageDefinition>(definitionList);
+        var resolvedAuditTrail = auditTrail ?? ReviewAuditTrail.Create();
+
+        return new ReviewProject(trimmedId, trimmedName, createdAtUtc, readOnlyDefinitions, resolvedAuditTrail);
+    }
+
+    private static void EnsureUtc(DateTimeOffset timestamp, string parameterName)
+    {
+        if (timestamp.Offset != TimeSpan.Zero)
+        {
+            throw new ArgumentException("Timestamp must be provided in UTC.", parameterName);
+        }
+    }
+}

--- a/src/LM.Review.Core/Models/ReviewStage.cs
+++ b/src/LM.Review.Core/Models/ReviewStage.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace LM.Review.Core.Models;
+
+public sealed class ReviewStage
+{
+    private ReviewStage(
+        string id,
+        string projectId,
+        StageDefinition definition,
+        IReadOnlyList<ScreeningAssignment> assignments,
+        ConflictState conflictState,
+        DateTimeOffset activatedAt,
+        DateTimeOffset? completedAt,
+        ConsensusOutcome? consensus)
+    {
+        Id = id;
+        ProjectId = projectId;
+        Definition = definition;
+        Assignments = assignments;
+        ConflictState = conflictState;
+        ActivatedAt = activatedAt;
+        CompletedAt = completedAt;
+        Consensus = consensus;
+    }
+
+    public string Id { get; }
+
+    public string ProjectId { get; }
+
+    public StageDefinition Definition { get; }
+
+    public IReadOnlyList<ScreeningAssignment> Assignments { get; }
+
+    public ConflictState ConflictState { get; }
+
+    public DateTimeOffset ActivatedAt { get; }
+
+    public DateTimeOffset? CompletedAt { get; }
+
+    public ConsensusOutcome? Consensus { get; }
+
+    public bool IsComplete => CompletedAt.HasValue;
+
+    public static ReviewStage Create(
+        string id,
+        string projectId,
+        StageDefinition definition,
+        IEnumerable<ScreeningAssignment> assignments,
+        ConflictState conflictState,
+        DateTimeOffset activatedAtUtc,
+        DateTimeOffset? completedAtUtc = null,
+        ConsensusOutcome? consensus = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(assignments);
+        EnsureUtc(activatedAtUtc, nameof(activatedAtUtc));
+
+        if (completedAtUtc.HasValue)
+        {
+            EnsureUtc(completedAtUtc.Value, nameof(completedAtUtc));
+            if (completedAtUtc < activatedAtUtc)
+            {
+                throw new ArgumentException("Completion timestamp cannot be earlier than activation timestamp.", nameof(completedAtUtc));
+            }
+        }
+
+        var trimmedId = id.Trim();
+        var trimmedProjectId = projectId.Trim();
+
+        var assignmentList = new List<ScreeningAssignment>();
+        foreach (var assignment in assignments)
+        {
+            ArgumentNullException.ThrowIfNull(assignment);
+            if (!string.Equals(assignment.StageId, trimmedId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Assignment stage identifier must match the review stage identifier.");
+            }
+
+            assignmentList.Add(assignment);
+        }
+
+        ValidateAssignmentCardinality(definition, assignmentList);
+
+        if (consensus is not null && !string.Equals(consensus.StageId, trimmedId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Consensus outcome must reference the stage it belongs to.");
+        }
+
+        if (definition.ConsensusPolicy.RequiresConsensus && consensus is null && conflictState == ConflictState.Resolved)
+        {
+            throw new InvalidOperationException("A resolved conflict state requires a consensus outcome.");
+        }
+
+        if (!definition.ConsensusPolicy.RequiresConsensus && consensus is not null)
+        {
+            throw new InvalidOperationException("Consensus outcome provided for a stage that does not require consensus.");
+        }
+
+        var readOnlyAssignments = new ReadOnlyCollection<ScreeningAssignment>(assignmentList);
+
+        return new ReviewStage(trimmedId, trimmedProjectId, definition, readOnlyAssignments, conflictState, activatedAtUtc, completedAtUtc, consensus);
+    }
+
+    private static void ValidateAssignmentCardinality(StageDefinition definition, IReadOnlyCollection<ScreeningAssignment> assignments)
+    {
+        var allowedRoles = new HashSet<ReviewerRole>(definition.ReviewerRequirement.Requirements.Keys);
+
+        foreach (var (role, requiredCount) in definition.ReviewerRequirement.Requirements)
+        {
+            var actualCount = assignments.Count(assignment => assignment.Role == role);
+            if (actualCount != requiredCount)
+            {
+                throw new InvalidOperationException($"Stage '{definition.Name}' expected {requiredCount} {role} reviewer(s) but found {actualCount}.");
+            }
+        }
+
+        var unexpectedAssignment = assignments.FirstOrDefault(assignment => !allowedRoles.Contains(assignment.Role));
+        if (unexpectedAssignment is not null)
+        {
+            throw new InvalidOperationException($"Assignment for role '{unexpectedAssignment.Role}' is not permitted by the stage definition.");
+        }
+    }
+
+    private static void EnsureUtc(DateTimeOffset timestamp, string parameterName)
+    {
+        if (timestamp.Offset != TimeSpan.Zero)
+        {
+            throw new ArgumentException("Timestamp must be provided in UTC.", parameterName);
+        }
+    }
+}

--- a/src/LM.Review.Core/Models/ReviewStageType.cs
+++ b/src/LM.Review.Core/Models/ReviewStageType.cs
@@ -1,0 +1,9 @@
+namespace LM.Review.Core.Models;
+
+public enum ReviewStageType
+{
+    TitleScreening = 0,
+    FullTextReview = 1,
+    ConsensusMeeting = 2,
+    QualityAssurance = 3
+}

--- a/src/LM.Review.Core/Models/ReviewerDecision.cs
+++ b/src/LM.Review.Core/Models/ReviewerDecision.cs
@@ -1,0 +1,55 @@
+namespace LM.Review.Core.Models;
+
+public sealed record ReviewerDecision
+{
+    private ReviewerDecision(
+        string assignmentId,
+        string reviewerId,
+        ScreeningStatus decision,
+        DateTimeOffset decidedAt,
+        string? notes)
+    {
+        AssignmentId = assignmentId;
+        ReviewerId = reviewerId;
+        Decision = decision;
+        DecidedAt = decidedAt;
+        Notes = notes;
+    }
+
+    public string AssignmentId { get; }
+
+    public string ReviewerId { get; }
+
+    public ScreeningStatus Decision { get; }
+
+    public DateTimeOffset DecidedAt { get; }
+
+    public string? Notes { get; }
+
+    public static ReviewerDecision Create(
+        string assignmentId,
+        string reviewerId,
+        ScreeningStatus decision,
+        DateTimeOffset decidedAtUtc,
+        string? notes = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assignmentId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reviewerId);
+        EnsureUtc(decidedAtUtc, nameof(decidedAtUtc));
+
+        if (decision is not ScreeningStatus.Included and not ScreeningStatus.Excluded)
+        {
+            throw new ArgumentException($"Reviewer decisions must resolve to an inclusion or exclusion, not '{decision}'.", nameof(decision));
+        }
+
+        return new ReviewerDecision(assignmentId.Trim(), reviewerId.Trim(), decision, decidedAtUtc, notes?.Trim());
+    }
+
+    private static void EnsureUtc(DateTimeOffset timestamp, string parameterName)
+    {
+        if (timestamp.Offset != TimeSpan.Zero)
+        {
+            throw new ArgumentException("Timestamp must be provided in UTC.", parameterName);
+        }
+    }
+}

--- a/src/LM.Review.Core/Models/ReviewerRole.cs
+++ b/src/LM.Review.Core/Models/ReviewerRole.cs
@@ -1,0 +1,9 @@
+namespace LM.Review.Core.Models;
+
+public enum ReviewerRole
+{
+    Primary = 0,
+    Secondary = 1,
+    TieBreaker = 2,
+    Arbitrator = 3
+}

--- a/src/LM.Review.Core/Models/ScreeningAssignment.cs
+++ b/src/LM.Review.Core/Models/ScreeningAssignment.cs
@@ -1,0 +1,125 @@
+namespace LM.Review.Core.Models;
+
+public sealed record ScreeningAssignment
+{
+    private ScreeningAssignment(
+        string id,
+        string stageId,
+        string reviewerId,
+        ReviewerRole role,
+        ScreeningStatus status,
+        DateTimeOffset assignedAt,
+        DateTimeOffset? completedAt,
+        ReviewerDecision? decision)
+    {
+        Id = id;
+        StageId = stageId;
+        ReviewerId = reviewerId;
+        Role = role;
+        Status = status;
+        AssignedAt = assignedAt;
+        CompletedAt = completedAt;
+        Decision = decision;
+    }
+
+    public string Id { get; }
+
+    public string StageId { get; }
+
+    public string ReviewerId { get; }
+
+    public ReviewerRole Role { get; }
+
+    public ScreeningStatus Status { get; }
+
+    public DateTimeOffset AssignedAt { get; }
+
+    public DateTimeOffset? CompletedAt { get; }
+
+    public ReviewerDecision? Decision { get; }
+
+    public static ScreeningAssignment Create(
+        string id,
+        string stageId,
+        string reviewerId,
+        ReviewerRole role,
+        ScreeningStatus status,
+        DateTimeOffset assignedAtUtc,
+        DateTimeOffset? completedAtUtc = null,
+        ReviewerDecision? decision = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(stageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reviewerId);
+        EnsureUtc(assignedAtUtc, nameof(assignedAtUtc));
+
+        if (completedAtUtc.HasValue)
+        {
+            EnsureUtc(completedAtUtc.Value, nameof(completedAtUtc));
+            if (completedAtUtc < assignedAtUtc)
+            {
+                throw new ArgumentException("Completion timestamp cannot precede assignment timestamp.", nameof(completedAtUtc));
+            }
+        }
+
+        if (RequiresCompletion(status) && completedAtUtc is null)
+        {
+            throw new InvalidOperationException($"Status '{status}' requires a completion timestamp.");
+        }
+
+        if (!RequiresCompletion(status) && completedAtUtc is not null)
+        {
+            throw new InvalidOperationException($"Status '{status}' must not define a completion timestamp.");
+        }
+
+        if (decision is not null)
+        {
+            if (!IsDecisionStatus(decision.Decision))
+            {
+                throw new InvalidOperationException($"Decision status '{decision.Decision}' is not a terminal screening decision.");
+            }
+
+            if (!string.Equals(decision.AssignmentId, id.Trim(), StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Decision assignment identifier does not match the assignment.");
+            }
+
+            if (!string.Equals(decision.ReviewerId, reviewerId.Trim(), StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Decision reviewer identifier does not match the assignment.");
+            }
+
+            if (!IsDecisionStatus(status))
+            {
+                throw new InvalidOperationException("Assignment status must reflect the recorded reviewer decision.");
+            }
+        }
+
+        if (IsDecisionStatus(status) && decision is null)
+        {
+            throw new InvalidOperationException("A reviewer decision must accompany a completed assignment.");
+        }
+
+        return new ScreeningAssignment(
+            id.Trim(),
+            stageId.Trim(),
+            reviewerId.Trim(),
+            role,
+            status,
+            assignedAtUtc,
+            completedAtUtc,
+            decision);
+    }
+
+    private static bool RequiresCompletion(ScreeningStatus status) => status is ScreeningStatus.Included or ScreeningStatus.Excluded or ScreeningStatus.Escalated;
+
+    private static bool IsDecisionStatus(ScreeningStatus status) => status is ScreeningStatus.Included or ScreeningStatus.Excluded;
+
+    private static void EnsureUtc(DateTimeOffset timestamp, string parameterName)
+    {
+        if (timestamp.Offset != TimeSpan.Zero)
+        {
+            throw new ArgumentException("Timestamp must be provided in UTC.", parameterName);
+        }
+    }
+}

--- a/src/LM.Review.Core/Models/ScreeningStatus.cs
+++ b/src/LM.Review.Core/Models/ScreeningStatus.cs
@@ -1,0 +1,10 @@
+namespace LM.Review.Core.Models;
+
+public enum ScreeningStatus
+{
+    Pending = 0,
+    InProgress = 1,
+    Included = 2,
+    Excluded = 3,
+    Escalated = 4
+}

--- a/src/LM.Review.Core/Models/StageDefinition.cs
+++ b/src/LM.Review.Core/Models/StageDefinition.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+
+namespace LM.Review.Core.Models;
+
+public sealed record StageDefinition
+{
+    private StageDefinition(
+        string id,
+        string name,
+        ReviewStageType stageType,
+        ReviewerRequirement reviewerRequirement,
+        StageConsensusPolicy consensusPolicy)
+    {
+        Id = id;
+        Name = name;
+        StageType = stageType;
+        ReviewerRequirement = reviewerRequirement;
+        ConsensusPolicy = consensusPolicy;
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public ReviewStageType StageType { get; }
+
+    public ReviewerRequirement ReviewerRequirement { get; }
+
+    public StageConsensusPolicy ConsensusPolicy { get; }
+
+    public static StageDefinition Create(
+        string id,
+        string name,
+        ReviewStageType stageType,
+        ReviewerRequirement reviewerRequirement,
+        StageConsensusPolicy consensusPolicy)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(reviewerRequirement);
+        ArgumentNullException.ThrowIfNull(consensusPolicy);
+
+        var trimmedId = id.Trim();
+        var trimmedName = name.Trim();
+
+        reviewerRequirement.EnsureHasReviewers();
+        consensusPolicy.EnsureCompatibility(reviewerRequirement);
+
+        return new StageDefinition(trimmedId, trimmedName, stageType, reviewerRequirement, consensusPolicy);
+    }
+}
+
+public sealed record ReviewerRequirement
+{
+    private readonly ReadOnlyDictionary<ReviewerRole, int> _requirements;
+
+    private ReviewerRequirement(ReadOnlyDictionary<ReviewerRole, int> requirements)
+    {
+        _requirements = requirements;
+    }
+
+    public IReadOnlyDictionary<ReviewerRole, int> Requirements => _requirements;
+
+    public int TotalRequired => _requirements.Values.Sum();
+
+    public int GetRequirement(ReviewerRole role) => _requirements.TryGetValue(role, out var count) ? count : 0;
+
+    public static ReviewerRequirement Create(IEnumerable<KeyValuePair<ReviewerRole, int>> requirements)
+    {
+        ArgumentNullException.ThrowIfNull(requirements);
+
+        var requirementDictionary = new Dictionary<ReviewerRole, int>();
+        foreach (var requirement in requirements)
+        {
+            if (requirement.Value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(requirements),
+                    string.Format(CultureInfo.InvariantCulture, "Reviewer requirement for role {0} must be greater than zero.", requirement.Key));
+            }
+
+            if (requirementDictionary.ContainsKey(requirement.Key))
+            {
+                throw new ArgumentException(
+                    string.Format(CultureInfo.InvariantCulture, "Duplicate reviewer requirement defined for role {0}.", requirement.Key),
+                    nameof(requirements));
+            }
+
+            requirementDictionary[requirement.Key] = requirement.Value;
+        }
+
+        return new ReviewerRequirement(new ReadOnlyDictionary<ReviewerRole, int>(requirementDictionary));
+    }
+
+    internal void EnsureHasReviewers()
+    {
+        if (_requirements.Count == 0)
+        {
+            throw new InvalidOperationException("At least one reviewer requirement must be defined for a stage.");
+        }
+    }
+}
+
+public sealed record StageConsensusPolicy
+{
+    private StageConsensusPolicy(bool requiresConsensus, int minimumAgreements, bool escalateOnDisagreement, ReviewerRole? arbitrationRole)
+    {
+        RequiresConsensus = requiresConsensus;
+        MinimumAgreements = minimumAgreements;
+        EscalateOnDisagreement = escalateOnDisagreement;
+        ArbitrationRole = arbitrationRole;
+    }
+
+    public bool RequiresConsensus { get; }
+
+    public int MinimumAgreements { get; }
+
+    public bool EscalateOnDisagreement { get; }
+
+    public ReviewerRole? ArbitrationRole { get; }
+
+    public static StageConsensusPolicy Disabled() => new(false, 0, false, null);
+
+    public static StageConsensusPolicy RequireAgreement(int minimumAgreements, bool escalateOnDisagreement, ReviewerRole? arbitrationRole)
+    {
+        if (minimumAgreements <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minimumAgreements), "Minimum agreements must be greater than zero when consensus is required.");
+        }
+
+        return new StageConsensusPolicy(true, minimumAgreements, escalateOnDisagreement, arbitrationRole);
+    }
+
+    internal void EnsureCompatibility(ReviewerRequirement requirement)
+    {
+        if (!RequiresConsensus)
+        {
+            return;
+        }
+
+        if (MinimumAgreements > requirement.TotalRequired)
+        {
+            throw new InvalidOperationException("Minimum agreements cannot exceed the total number of required reviewers for the stage.");
+        }
+
+        if (ArbitrationRole.HasValue && requirement.GetRequirement(ArbitrationRole.Value) == 0)
+        {
+            throw new InvalidOperationException("An arbitration role was provided but is not part of the reviewer requirements.");
+        }
+    }
+}

--- a/src/LM.Review.Core/PublicAPI.Shipped.txt
+++ b/src/LM.Review.Core/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/LM.Review.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Review.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,95 @@
+#nullable enable
+LM.Review.Core.Models.ConflictState
+LM.Review.Core.Models.ConflictState.None = 0 -> LM.Review.Core.Models.ConflictState
+LM.Review.Core.Models.ConflictState.Conflict = 1 -> LM.Review.Core.Models.ConflictState
+LM.Review.Core.Models.ConflictState.Escalated = 2 -> LM.Review.Core.Models.ConflictState
+LM.Review.Core.Models.ConflictState.Resolved = 3 -> LM.Review.Core.Models.ConflictState
+LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ScreeningStatus.Pending = 0 -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ScreeningStatus.InProgress = 1 -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ScreeningStatus.Included = 2 -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ScreeningStatus.Excluded = 3 -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ScreeningStatus.Escalated = 4 -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ReviewerRole
+LM.Review.Core.Models.ReviewerRole.Primary = 0 -> LM.Review.Core.Models.ReviewerRole
+LM.Review.Core.Models.ReviewerRole.Secondary = 1 -> LM.Review.Core.Models.ReviewerRole
+LM.Review.Core.Models.ReviewerRole.TieBreaker = 2 -> LM.Review.Core.Models.ReviewerRole
+LM.Review.Core.Models.ReviewerRole.Arbitrator = 3 -> LM.Review.Core.Models.ReviewerRole
+LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.ReviewStageType.TitleScreening = 0 -> LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.ReviewStageType.FullTextReview = 1 -> LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.ReviewStageType.ConsensusMeeting = 2 -> LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.ReviewStageType.QualityAssurance = 3 -> LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.ReviewerDecision
+LM.Review.Core.Models.ReviewerDecision.AssignmentId.get -> string!
+static LM.Review.Core.Models.ReviewerDecision.Create(string! assignmentId, string! reviewerId, LM.Review.Core.Models.ScreeningStatus decision, System.DateTimeOffset decidedAtUtc, string? notes = null) -> LM.Review.Core.Models.ReviewerDecision!
+LM.Review.Core.Models.ReviewerDecision.DecidedAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.ReviewerDecision.Decision.get -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.ReviewerDecision.Notes.get -> string?
+LM.Review.Core.Models.ReviewerDecision.ReviewerId.get -> string!
+LM.Review.Core.Models.ConsensusOutcome
+LM.Review.Core.Models.ConsensusOutcome.Approved.get -> bool
+static LM.Review.Core.Models.ConsensusOutcome.Create(string! stageId, bool approved, LM.Review.Core.Models.ConflictState resultingState, System.DateTimeOffset resolvedAtUtc, string? notes = null, string? resolvedBy = null) -> LM.Review.Core.Models.ConsensusOutcome!
+LM.Review.Core.Models.ConsensusOutcome.Notes.get -> string?
+LM.Review.Core.Models.ConsensusOutcome.ResolvedAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.ConsensusOutcome.ResolvedBy.get -> string?
+LM.Review.Core.Models.ConsensusOutcome.ResultingState.get -> LM.Review.Core.Models.ConflictState
+LM.Review.Core.Models.ConsensusOutcome.StageId.get -> string!
+LM.Review.Core.Models.ReviewAuditTrail
+LM.Review.Core.Models.ReviewAuditTrail.Append(LM.Review.Core.Models.ReviewAuditTrail.AuditEntry! entry) -> LM.Review.Core.Models.ReviewAuditTrail!
+static LM.Review.Core.Models.ReviewAuditTrail.Create(System.Collections.Generic.IEnumerable<LM.Review.Core.Models.ReviewAuditTrail.AuditEntry!>? entries = null) -> LM.Review.Core.Models.ReviewAuditTrail!
+LM.Review.Core.Models.ReviewAuditTrail.Entries.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.ReviewAuditTrail.AuditEntry!>!
+LM.Review.Core.Models.ReviewAuditTrail.AuditEntry
+LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Action.get -> string!
+LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Actor.get -> string!
+static LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Create(string! id, string! actor, string! action, System.DateTimeOffset occurredAtUtc, string? details = null) -> LM.Review.Core.Models.ReviewAuditTrail.AuditEntry!
+LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Details.get -> string?
+LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Id.get -> string!
+LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.OccurredAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.ReviewProject
+LM.Review.Core.Models.ReviewProject.AuditTrail.get -> LM.Review.Core.Models.ReviewAuditTrail!
+static LM.Review.Core.Models.ReviewProject.Create(string! id, string! name, System.DateTimeOffset createdAtUtc, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.StageDefinition!>! stageDefinitions, LM.Review.Core.Models.ReviewAuditTrail? auditTrail = null) -> LM.Review.Core.Models.ReviewProject!
+LM.Review.Core.Models.ReviewProject.CreatedAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.ReviewProject.Id.get -> string!
+LM.Review.Core.Models.ReviewProject.Name.get -> string!
+LM.Review.Core.Models.ReviewProject.StageDefinitions.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.StageDefinition!>!
+LM.Review.Core.Models.ReviewStage
+LM.Review.Core.Models.ReviewStage.ActivatedAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.ReviewStage.Assignments.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.ScreeningAssignment!>!
+LM.Review.Core.Models.ReviewStage.CompletedAt.get -> System.DateTimeOffset?
+LM.Review.Core.Models.ReviewStage.Consensus.get -> LM.Review.Core.Models.ConsensusOutcome?
+LM.Review.Core.Models.ReviewStage.ConflictState.get -> LM.Review.Core.Models.ConflictState
+static LM.Review.Core.Models.ReviewStage.Create(string! id, string! projectId, LM.Review.Core.Models.StageDefinition! definition, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.ScreeningAssignment!>! assignments, LM.Review.Core.Models.ConflictState conflictState, System.DateTimeOffset activatedAtUtc, System.DateTimeOffset? completedAtUtc = null, LM.Review.Core.Models.ConsensusOutcome? consensus = null) -> LM.Review.Core.Models.ReviewStage!
+LM.Review.Core.Models.ReviewStage.Definition.get -> LM.Review.Core.Models.StageDefinition!
+LM.Review.Core.Models.ReviewStage.Id.get -> string!
+LM.Review.Core.Models.ReviewStage.IsComplete.get -> bool
+LM.Review.Core.Models.ReviewStage.ProjectId.get -> string!
+LM.Review.Core.Models.StageDefinition
+LM.Review.Core.Models.StageDefinition.ConsensusPolicy.get -> LM.Review.Core.Models.StageConsensusPolicy!
+static LM.Review.Core.Models.StageDefinition.Create(string! id, string! name, LM.Review.Core.Models.ReviewStageType stageType, LM.Review.Core.Models.ReviewerRequirement! reviewerRequirement, LM.Review.Core.Models.StageConsensusPolicy! consensusPolicy) -> LM.Review.Core.Models.StageDefinition!
+LM.Review.Core.Models.StageDefinition.Id.get -> string!
+LM.Review.Core.Models.StageDefinition.Name.get -> string!
+LM.Review.Core.Models.StageDefinition.ReviewerRequirement.get -> LM.Review.Core.Models.ReviewerRequirement!
+LM.Review.Core.Models.StageDefinition.StageType.get -> LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.StageConsensusPolicy
+LM.Review.Core.Models.StageConsensusPolicy.ArbitrationRole.get -> LM.Review.Core.Models.ReviewerRole?
+static LM.Review.Core.Models.StageConsensusPolicy.Disabled() -> LM.Review.Core.Models.StageConsensusPolicy!
+LM.Review.Core.Models.StageConsensusPolicy.EscalateOnDisagreement.get -> bool
+LM.Review.Core.Models.StageConsensusPolicy.MinimumAgreements.get -> int
+static LM.Review.Core.Models.StageConsensusPolicy.RequireAgreement(int minimumAgreements, bool escalateOnDisagreement, LM.Review.Core.Models.ReviewerRole? arbitrationRole) -> LM.Review.Core.Models.StageConsensusPolicy!
+LM.Review.Core.Models.StageConsensusPolicy.RequiresConsensus.get -> bool
+LM.Review.Core.Models.ReviewerRequirement
+static LM.Review.Core.Models.ReviewerRequirement.Create(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<LM.Review.Core.Models.ReviewerRole, int>>! requirements) -> LM.Review.Core.Models.ReviewerRequirement!
+LM.Review.Core.Models.ReviewerRequirement.GetRequirement(LM.Review.Core.Models.ReviewerRole role) -> int
+LM.Review.Core.Models.ReviewerRequirement.Requirements.get -> System.Collections.Generic.IReadOnlyDictionary<LM.Review.Core.Models.ReviewerRole, int>!
+LM.Review.Core.Models.ReviewerRequirement.TotalRequired.get -> int
+LM.Review.Core.Models.ScreeningAssignment
+LM.Review.Core.Models.ScreeningAssignment.AssignedAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.ScreeningAssignment.CompletedAt.get -> System.DateTimeOffset?
+static LM.Review.Core.Models.ScreeningAssignment.Create(string! id, string! stageId, string! reviewerId, LM.Review.Core.Models.ReviewerRole role, LM.Review.Core.Models.ScreeningStatus status, System.DateTimeOffset assignedAtUtc, System.DateTimeOffset? completedAtUtc = null, LM.Review.Core.Models.ReviewerDecision? decision = null) -> LM.Review.Core.Models.ScreeningAssignment!
+LM.Review.Core.Models.ScreeningAssignment.Decision.get -> LM.Review.Core.Models.ReviewerDecision?
+LM.Review.Core.Models.ScreeningAssignment.Id.get -> string!
+LM.Review.Core.Models.ScreeningAssignment.ReviewerId.get -> string!
+LM.Review.Core.Models.ScreeningAssignment.Role.get -> LM.Review.Core.Models.ReviewerRole
+LM.Review.Core.Models.ScreeningAssignment.StageId.get -> string!
+LM.Review.Core.Models.ScreeningAssignment.Status.get -> LM.Review.Core.Models.ScreeningStatus


### PR DESCRIPTION
## Summary
- replace the stub review model with dedicated types for projects, stages, assignments, decisions, consensus outcomes, and audit trail bookkeeping
- add reviewer stage definitions with explicit reviewer-count requirements and consensus policies plus supporting enums
- enable PublicAPI tracking for LM.Review.Core and update the combined surface description

## Testing
- `dotnet build src/LM.Review.Core/LM.Review.Core.csproj -c Debug`
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: existing CS0136 in LibrarySearchQueryBox.cs)*

------
https://chatgpt.com/codex/tasks/task_e_68d66e79130c832b94e9d7aa7128ab05