### PR TITLE
Add extraction form models and schema validators

### DIFF
--- a/src/LM.Review.Core/Models/Forms/ExtractionForm.cs
+++ b/src/LM.Review.Core/Models/Forms/ExtractionForm.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace LM.Review.Core.Models.Forms;
+
+public sealed class ExtractionForm
+{
+    private ExtractionForm(
+        string id,
+        string name,
+        IReadOnlyList<FormSection> sections,
+        string? description,
+        string? category)
+    {
+        Id = id;
+        Name = name;
+        Sections = sections;
+        Description = description;
+        Category = category;
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public string? Description { get; }
+
+    public string? Category { get; }
+
+    public IReadOnlyList<FormSection> Sections { get; }
+
+    public static ExtractionForm Create(
+        string id,
+        string name,
+        IEnumerable<FormSection> sections,
+        string? description = null,
+        string? category = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(sections);
+
+        var normalizedId = FormIdentifier.Normalize(id);
+        if (string.IsNullOrWhiteSpace(normalizedId))
+        {
+            throw new InvalidOperationException("Extraction form identifiers cannot be empty after normalization.");
+        }
+
+        var resolvedName = name.Trim();
+        if (resolvedName.Length == 0)
+        {
+            throw new InvalidOperationException("Extraction form names cannot be empty.");
+        }
+
+        var resolvedDescription = string.IsNullOrWhiteSpace(description) ? null : description.Trim();
+        var resolvedCategory = string.IsNullOrWhiteSpace(category) ? null : category.Trim();
+
+        var materializedSections = new List<FormSection>();
+        foreach (var section in sections)
+        {
+            ArgumentNullException.ThrowIfNull(section);
+            materializedSections.Add(section);
+        }
+
+        if (materializedSections.Count == 0)
+        {
+            throw new InvalidOperationException("Extraction forms must declare at least one section.");
+        }
+
+        var duplicateSectionIds = materializedSections
+            .GroupBy(section => section.Id, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
+
+        if (duplicateSectionIds.Count > 0)
+        {
+            throw new InvalidOperationException($"Section identifiers must be unique. Duplicates: {string.Join(", ", duplicateSectionIds)}");
+        }
+
+        return new ExtractionForm(
+            normalizedId,
+            resolvedName,
+            new ReadOnlyCollection<FormSection>(materializedSections),
+            resolvedDescription,
+            resolvedCategory);
+    }
+}
+
+public static class FormIdentifier
+{
+    private static readonly Regex s_invalidCharacters = new("[^A-Za-z0-9_-]+", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex s_repeatedSeparators = new("[-_]{2,}", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static string Normalize(string identifier)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(identifier);
+
+        var trimmed = identifier.Trim();
+        if (trimmed.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var collapsed = s_invalidCharacters.Replace(trimmed, "-");
+        collapsed = s_repeatedSeparators.Replace(collapsed, "-");
+        collapsed = collapsed.Trim('-');
+
+        return collapsed.ToLowerInvariant();
+    }
+
+    public static bool IsNormalized(string identifier)
+    {
+        if (string.IsNullOrWhiteSpace(identifier))
+        {
+            return false;
+        }
+
+        return string.Equals(identifier, Normalize(identifier), StringComparison.Ordinal);
+    }
+}

--- a/src/LM.Review.Core/Models/Forms/ExtractionFormSnapshot.cs
+++ b/src/LM.Review.Core/Models/Forms/ExtractionFormSnapshot.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace LM.Review.Core.Models.Forms;
+
+public sealed class ExtractionFormSnapshot
+{
+    private ExtractionFormSnapshot(
+        string formId,
+        string versionId,
+        string capturedBy,
+        DateTime capturedUtc,
+        IReadOnlyDictionary<string, object?> values)
+    {
+        FormId = formId;
+        VersionId = versionId;
+        CapturedBy = capturedBy;
+        CapturedUtc = capturedUtc;
+        Values = values;
+    }
+
+    public string FormId { get; }
+
+    public string VersionId { get; }
+
+    public string CapturedBy { get; }
+
+    public DateTime CapturedUtc { get; }
+
+    public IReadOnlyDictionary<string, object?> Values { get; }
+
+    public static ExtractionFormSnapshot Create(
+        string formId,
+        string versionId,
+        IDictionary<string, object?> values,
+        string? capturedBy = null,
+        DateTime? capturedUtc = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(formId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(versionId);
+        ArgumentNullException.ThrowIfNull(values);
+
+        var normalizedFormId = FormIdentifier.Normalize(formId);
+        if (string.IsNullOrWhiteSpace(normalizedFormId))
+        {
+            throw new InvalidOperationException("Form identifiers cannot be empty after normalization.");
+        }
+
+        var normalizedVersionId = FormIdentifier.Normalize(versionId);
+        if (string.IsNullOrWhiteSpace(normalizedVersionId))
+        {
+            throw new InvalidOperationException("Version identifiers cannot be empty after normalization.");
+        }
+
+        var resolvedCapturedBy = FormUserContext.ResolveUserName(capturedBy);
+
+        DateTime resolvedCapturedUtc;
+        if (capturedUtc is null)
+        {
+            resolvedCapturedUtc = DateTime.UtcNow;
+        }
+        else if (capturedUtc.Value.Kind == DateTimeKind.Utc)
+        {
+            resolvedCapturedUtc = capturedUtc.Value;
+        }
+        else
+        {
+            resolvedCapturedUtc = capturedUtc.Value.ToUniversalTime();
+        }
+
+        var normalizedValues = new Dictionary<string, object?>(values.Count, StringComparer.Ordinal);
+        foreach (var kvp in values)
+        {
+            if (string.IsNullOrWhiteSpace(kvp.Key))
+            {
+                throw new InvalidOperationException("Snapshot values require non-empty field identifiers.");
+            }
+
+            var normalizedKey = FormIdentifier.Normalize(kvp.Key);
+            if (string.IsNullOrWhiteSpace(normalizedKey))
+            {
+                throw new InvalidOperationException("Snapshot values require identifiers that remain non-empty after normalization.");
+            }
+
+            normalizedValues[normalizedKey] = kvp.Value;
+        }
+
+        return new ExtractionFormSnapshot(
+            normalizedFormId,
+            normalizedVersionId,
+            resolvedCapturedBy,
+            resolvedCapturedUtc,
+            new ReadOnlyDictionary<string, object?>(normalizedValues));
+    }
+}

--- a/src/LM.Review.Core/Models/Forms/ExtractionFormVersion.cs
+++ b/src/LM.Review.Core/Models/Forms/ExtractionFormVersion.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace LM.Review.Core.Models.Forms;
+
+public sealed class ExtractionFormVersion
+{
+    private ExtractionFormVersion(
+        string versionId,
+        ExtractionForm form,
+        string createdBy,
+        DateTime createdUtc,
+        IReadOnlyDictionary<string, string> metadata)
+    {
+        VersionId = versionId;
+        Form = form;
+        CreatedBy = createdBy;
+        CreatedUtc = createdUtc;
+        Metadata = metadata;
+    }
+
+    public string VersionId { get; }
+
+    public ExtractionForm Form { get; }
+
+    public string CreatedBy { get; }
+
+    public DateTime CreatedUtc { get; }
+
+    public IReadOnlyDictionary<string, string> Metadata { get; }
+
+    public static ExtractionFormVersion Create(
+        string versionId,
+        ExtractionForm form,
+        IDictionary<string, string>? metadata = null,
+        string? createdBy = null,
+        DateTime? createdUtc = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(versionId);
+        ArgumentNullException.ThrowIfNull(form);
+
+        var normalizedVersionId = FormIdentifier.Normalize(versionId);
+        if (string.IsNullOrWhiteSpace(normalizedVersionId))
+        {
+            throw new InvalidOperationException("Version identifiers cannot be empty after normalization.");
+        }
+
+        var resolvedCreatedBy = FormUserContext.ResolveUserName(createdBy);
+
+        DateTime resolvedCreatedUtc;
+        if (createdUtc is null)
+        {
+            resolvedCreatedUtc = DateTime.UtcNow;
+        }
+        else if (createdUtc.Value.Kind == DateTimeKind.Utc)
+        {
+            resolvedCreatedUtc = createdUtc.Value;
+        }
+        else
+        {
+            resolvedCreatedUtc = createdUtc.Value.ToUniversalTime();
+        }
+
+        var materializedMetadata = metadata is null
+            ? new Dictionary<string, string>(StringComparer.Ordinal)
+            : new Dictionary<string, string>(metadata, StringComparer.Ordinal);
+
+        return new ExtractionFormVersion(
+            normalizedVersionId,
+            form,
+            resolvedCreatedBy,
+            resolvedCreatedUtc,
+            new ReadOnlyDictionary<string, string>(materializedMetadata));
+    }
+}

--- a/src/LM.Review.Core/Models/Forms/FormField.cs
+++ b/src/LM.Review.Core/Models/Forms/FormField.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace LM.Review.Core.Models.Forms;
+
+public sealed class FormField
+{
+    private FormField(
+        string id,
+        string title,
+        string? description,
+        FormFieldType fieldType,
+        IReadOnlyList<FormFieldOption> options,
+        FormFieldValidation? validation,
+        FormVisibilityRule? visibility,
+        bool allowFreeTextFallback)
+    {
+        Id = id;
+        Title = title;
+        Description = description;
+        FieldType = fieldType;
+        Options = options;
+        Validation = validation;
+        Visibility = visibility;
+        AllowFreeTextFallback = allowFreeTextFallback;
+    }
+
+    public string Id { get; }
+
+    public string Title { get; }
+
+    public string? Description { get; }
+
+    public FormFieldType FieldType { get; }
+
+    public bool AllowFreeTextFallback { get; }
+
+    public FormFieldValidation? Validation { get; }
+
+    public FormVisibilityRule? Visibility { get; }
+
+    public IReadOnlyList<FormFieldOption> Options { get; }
+
+    public static FormField Create(
+        string id,
+        string title,
+        FormFieldType fieldType,
+        IEnumerable<FormFieldOption>? options = null,
+        string? description = null,
+        FormFieldValidation? validation = null,
+        FormVisibilityRule? visibility = null,
+        bool allowFreeTextFallback = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+
+        var normalizedId = FormIdentifier.Normalize(id);
+        if (string.IsNullOrWhiteSpace(normalizedId))
+        {
+            throw new InvalidOperationException("Field identifiers cannot be empty after normalization.");
+        }
+
+        var resolvedTitle = title.Trim();
+        if (resolvedTitle.Length == 0)
+        {
+            throw new InvalidOperationException("Field titles cannot be empty.");
+        }
+
+        var resolvedDescription = string.IsNullOrWhiteSpace(description) ? null : description.Trim();
+
+        var materializedOptions = new List<FormFieldOption>();
+        if (options is not null)
+        {
+            foreach (var option in options)
+            {
+                ArgumentNullException.ThrowIfNull(option);
+                materializedOptions.Add(option);
+            }
+
+            var duplicateOptionIds = materializedOptions
+                .GroupBy(option => option.Id, StringComparer.Ordinal)
+                .Where(group => group.Count() > 1)
+                .Select(group => group.Key)
+                .ToList();
+
+            if (duplicateOptionIds.Count > 0)
+            {
+                throw new InvalidOperationException($"Field option identifiers must be unique. Duplicates: {string.Join(", ", duplicateOptionIds)}");
+            }
+        }
+
+        if (fieldType is FormFieldType.SingleSelect or FormFieldType.MultiSelect)
+        {
+            if (materializedOptions.Count == 0)
+            {
+                throw new InvalidOperationException($"Field '{resolvedTitle}' must declare at least one option.");
+            }
+        }
+        else if (materializedOptions.Count > 0)
+        {
+            throw new InvalidOperationException($"Field '{resolvedTitle}' does not support options for field type '{fieldType}'.");
+        }
+
+        if (allowFreeTextFallback && fieldType is not (FormFieldType.SingleSelect or FormFieldType.MultiSelect))
+        {
+            throw new InvalidOperationException("Free-text fallbacks are only supported for selection fields.");
+        }
+
+        return new FormField(
+            normalizedId,
+            resolvedTitle,
+            resolvedDescription,
+            fieldType,
+            new ReadOnlyCollection<FormFieldOption>(materializedOptions),
+            validation,
+            visibility,
+            allowFreeTextFallback);
+    }
+}
+
+public sealed class FormFieldValidation
+{
+    private FormFieldValidation(
+        FormValidationMode mode,
+        decimal? minimum,
+        decimal? maximum,
+        DateTime? minimumDateUtc,
+        DateTime? maximumDateUtc,
+        string? expression)
+    {
+        Mode = mode;
+        Minimum = minimum;
+        Maximum = maximum;
+        MinimumDateUtc = minimumDateUtc;
+        MaximumDateUtc = maximumDateUtc;
+        Expression = expression;
+    }
+
+    public FormValidationMode Mode { get; }
+
+    public decimal? Minimum { get; }
+
+    public decimal? Maximum { get; }
+
+    public DateTime? MinimumDateUtc { get; }
+
+    public DateTime? MaximumDateUtc { get; }
+
+    public string? Expression { get; }
+
+    public static FormFieldValidation CreateRequired() => new(FormValidationMode.Required, null, null, null, null, null);
+
+    public static FormFieldValidation CreateNumericRange(decimal? minimum, decimal? maximum)
+    {
+        if (minimum is null && maximum is null)
+        {
+            throw new InvalidOperationException("Numeric range validation requires at least one bound.");
+        }
+
+        if (minimum is not null && maximum is not null && minimum > maximum)
+        {
+            throw new InvalidOperationException("Numeric range validation requires minimum to be less than or equal to maximum.");
+        }
+
+        return new FormFieldValidation(FormValidationMode.Range, minimum, maximum, null, null, null);
+    }
+
+    public static FormFieldValidation CreateDateRange(DateTime? minimumUtc, DateTime? maximumUtc)
+    {
+        if (minimumUtc is null && maximumUtc is null)
+        {
+            throw new InvalidOperationException("Date range validation requires at least one bound.");
+        }
+
+        DateTime? normalizedMin = null;
+        DateTime? normalizedMax = null;
+
+        if (minimumUtc is not null)
+        {
+            normalizedMin = EnsureUtc(minimumUtc.Value);
+        }
+
+        if (maximumUtc is not null)
+        {
+            normalizedMax = EnsureUtc(maximumUtc.Value);
+        }
+
+        if (normalizedMin is not null && normalizedMax is not null && normalizedMin > normalizedMax)
+        {
+            throw new InvalidOperationException("Date range validation requires minimum to be earlier than or equal to maximum.");
+        }
+
+        return new FormFieldValidation(FormValidationMode.Range, null, null, normalizedMin, normalizedMax, null);
+    }
+
+    public static FormFieldValidation CreateRegex(string pattern)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pattern);
+        return new FormFieldValidation(FormValidationMode.Regex, null, null, null, null, pattern);
+    }
+
+    private static DateTime EnsureUtc(DateTime value)
+    {
+        return value.Kind switch
+        {
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+            DateTimeKind.Utc => value,
+            _ => value.ToUniversalTime()
+        };
+    }
+}

--- a/src/LM.Review.Core/Models/Forms/FormFieldOption.cs
+++ b/src/LM.Review.Core/Models/Forms/FormFieldOption.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace LM.Review.Core.Models.Forms;
+
+public sealed class FormFieldOption
+{
+    private FormFieldOption(string id, string label, string? description, bool isDefault)
+    {
+        Id = id;
+        Label = label;
+        Description = description;
+        IsDefault = isDefault;
+    }
+
+    public string Id { get; }
+
+    public string Label { get; }
+
+    public string? Description { get; }
+
+    public bool IsDefault { get; }
+
+    public static FormFieldOption Create(string id, string label, string? description = null, bool isDefault = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(label);
+
+        var normalizedId = FormIdentifier.Normalize(id);
+        if (string.IsNullOrWhiteSpace(normalizedId))
+        {
+            throw new InvalidOperationException("Field option identifiers cannot be empty after normalization.");
+        }
+
+        var resolvedLabel = label.Trim();
+        if (resolvedLabel.Length == 0)
+        {
+            throw new InvalidOperationException("Field option labels cannot be empty.");
+        }
+
+        var resolvedDescription = string.IsNullOrWhiteSpace(description) ? null : description.Trim();
+
+        return new FormFieldOption(normalizedId, resolvedLabel, resolvedDescription, isDefault);
+    }
+}

--- a/src/LM.Review.Core/Models/Forms/FormFieldType.cs
+++ b/src/LM.Review.Core/Models/Forms/FormFieldType.cs
@@ -1,0 +1,11 @@
+namespace LM.Review.Core.Models.Forms;
+
+public enum FormFieldType
+{
+    SingleSelect = 0,
+    MultiSelect = 1,
+    Text = 2,
+    Numeric = 3,
+    Date = 4,
+    Reference = 5
+}

--- a/src/LM.Review.Core/Models/Forms/FormSection.cs
+++ b/src/LM.Review.Core/Models/Forms/FormSection.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace LM.Review.Core.Models.Forms;
+
+public sealed class FormSection
+{
+    private FormSection(
+        string id,
+        string title,
+        IReadOnlyList<FormField> fields,
+        IReadOnlyList<FormSection> children,
+        bool isRepeatable,
+        string? description,
+        FormVisibilityRule? visibility)
+    {
+        Id = id;
+        Title = title;
+        Fields = fields;
+        Children = children;
+        IsRepeatable = isRepeatable;
+        Description = description;
+        Visibility = visibility;
+    }
+
+    public string Id { get; }
+
+    public string Title { get; }
+
+    public string? Description { get; }
+
+    public bool IsRepeatable { get; }
+
+    public FormVisibilityRule? Visibility { get; }
+
+    public IReadOnlyList<FormField> Fields { get; }
+
+    public IReadOnlyList<FormSection> Children { get; }
+
+    public static FormSection Create(
+        string id,
+        string title,
+        IEnumerable<FormField> fields,
+        IEnumerable<FormSection>? children = null,
+        bool isRepeatable = false,
+        string? description = null,
+        FormVisibilityRule? visibility = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        ArgumentNullException.ThrowIfNull(fields);
+
+        var normalizedId = FormIdentifier.Normalize(id);
+        if (string.IsNullOrWhiteSpace(normalizedId))
+        {
+            throw new InvalidOperationException("Section identifiers cannot be empty after normalization.");
+        }
+
+        var resolvedTitle = title.Trim();
+        if (resolvedTitle.Length == 0)
+        {
+            throw new InvalidOperationException("Section titles cannot be empty.");
+        }
+
+        var resolvedDescription = string.IsNullOrWhiteSpace(description) ? null : description.Trim();
+
+        var materializedFields = new List<FormField>();
+        foreach (var field in fields)
+        {
+            ArgumentNullException.ThrowIfNull(field);
+            materializedFields.Add(field);
+        }
+
+        if (materializedFields.Count == 0)
+        {
+            throw new InvalidOperationException($"Section '{resolvedTitle}' must contain at least one field.");
+        }
+
+        var duplicateFieldIds = materializedFields
+            .GroupBy(field => field.Id, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
+
+        if (duplicateFieldIds.Count > 0)
+        {
+            throw new InvalidOperationException($"Field identifiers must be unique. Duplicates: {string.Join(", ", duplicateFieldIds)}");
+        }
+
+        var materializedChildren = new List<FormSection>();
+        if (children is not null)
+        {
+            foreach (var child in children)
+            {
+                ArgumentNullException.ThrowIfNull(child);
+                materializedChildren.Add(child);
+            }
+
+            var duplicateChildIds = materializedChildren
+                .GroupBy(section => section.Id, StringComparer.Ordinal)
+                .Where(group => group.Count() > 1)
+                .Select(group => group.Key)
+                .ToList();
+
+            if (duplicateChildIds.Count > 0)
+            {
+                throw new InvalidOperationException($"Child section identifiers must be unique. Duplicates: {string.Join(", ", duplicateChildIds)}");
+            }
+        }
+
+        return new FormSection(
+            normalizedId,
+            resolvedTitle,
+            new ReadOnlyCollection<FormField>(materializedFields),
+            new ReadOnlyCollection<FormSection>(materializedChildren),
+            isRepeatable,
+            resolvedDescription,
+            visibility);
+    }
+}

--- a/src/LM.Review.Core/Models/Forms/FormUserContext.cs
+++ b/src/LM.Review.Core/Models/Forms/FormUserContext.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Security.Principal;
+
+namespace LM.Review.Core.Models.Forms;
+
+internal static class FormUserContext
+{
+    public static string ResolveUserName(string? proposedValue = null)
+    {
+        if (!string.IsNullOrWhiteSpace(proposedValue))
+        {
+            return proposedValue.Trim();
+        }
+
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                using var identity = WindowsIdentity.GetCurrent();
+                if (!string.IsNullOrWhiteSpace(identity?.Name))
+                {
+                    return identity.Name.Trim();
+                }
+            }
+        }
+        catch
+        {
+            // Ignore failures and fallback to environment values.
+        }
+
+        var environmentUser = Environment.UserName;
+        if (!string.IsNullOrWhiteSpace(environmentUser))
+        {
+            return environmentUser.Trim();
+        }
+
+        var machineName = Environment.MachineName;
+        if (!string.IsNullOrWhiteSpace(machineName))
+        {
+            return machineName.Trim();
+        }
+
+        return "unknown";
+    }
+}

--- a/src/LM.Review.Core/Models/Forms/FormValidationMode.cs
+++ b/src/LM.Review.Core/Models/Forms/FormValidationMode.cs
@@ -1,0 +1,8 @@
+namespace LM.Review.Core.Models.Forms;
+
+public enum FormValidationMode
+{
+    Required = 0,
+    Range = 1,
+    Regex = 2
+}

--- a/src/LM.Review.Core/Models/Forms/FormVisibilityRule.cs
+++ b/src/LM.Review.Core/Models/Forms/FormVisibilityRule.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace LM.Review.Core.Models.Forms;
+
+public sealed class FormVisibilityRule
+{
+    private FormVisibilityRule(
+        string sourceFieldId,
+        IReadOnlyList<string> expectedValues,
+        bool isVisibleWhenMatches)
+    {
+        SourceFieldId = sourceFieldId;
+        ExpectedValues = expectedValues;
+        IsVisibleWhenMatches = isVisibleWhenMatches;
+    }
+
+    public string SourceFieldId { get; }
+
+    public IReadOnlyList<string> ExpectedValues { get; }
+
+    public bool IsVisibleWhenMatches { get; }
+
+    public static FormVisibilityRule Create(
+        string sourceFieldId,
+        IEnumerable<string>? expectedValues = null,
+        bool isVisibleWhenMatches = true)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceFieldId);
+
+        var normalizedSourceId = FormIdentifier.Normalize(sourceFieldId);
+        if (string.IsNullOrWhiteSpace(normalizedSourceId))
+        {
+            throw new InvalidOperationException("Visibility rule source identifiers cannot be empty after normalization.");
+        }
+
+        var materializedValues = new List<string>();
+        if (expectedValues is not null)
+        {
+            foreach (var value in expectedValues)
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    continue;
+                }
+
+                materializedValues.Add(value.Trim());
+            }
+        }
+
+        return new FormVisibilityRule(
+            normalizedSourceId,
+            new ReadOnlyCollection<string>(materializedValues),
+            isVisibleWhenMatches);
+    }
+}

--- a/src/LM.Review.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Review.Core/PublicAPI.Unshipped.txt
@@ -93,3 +93,94 @@ LM.Review.Core.Models.ScreeningAssignment.ReviewerId.get -> string!
 LM.Review.Core.Models.ScreeningAssignment.Role.get -> LM.Review.Core.Models.ReviewerRole
 LM.Review.Core.Models.ScreeningAssignment.StageId.get -> string!
 LM.Review.Core.Models.ScreeningAssignment.Status.get -> LM.Review.Core.Models.ScreeningStatus
+LM.Review.Core.Models.Forms.ExtractionForm
+LM.Review.Core.Models.Forms.ExtractionForm.Category.get -> string?
+static LM.Review.Core.Models.Forms.ExtractionForm.Create(string! id, string! name, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Forms.FormSection!>! sections, string? description = null, string? category = null) -> LM.Review.Core.Models.Forms.ExtractionForm!
+LM.Review.Core.Models.Forms.ExtractionForm.Description.get -> string?
+LM.Review.Core.Models.Forms.ExtractionForm.Id.get -> string!
+LM.Review.Core.Models.Forms.ExtractionForm.Name.get -> string!
+LM.Review.Core.Models.Forms.ExtractionForm.Sections.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Forms.FormSection!>!
+LM.Review.Core.Models.Forms.FormField
+LM.Review.Core.Models.Forms.FormField.AllowFreeTextFallback.get -> bool
+LM.Review.Core.Models.Forms.FormField.Description.get -> string?
+LM.Review.Core.Models.Forms.FormField.FieldType.get -> LM.Review.Core.Models.Forms.FormFieldType
+LM.Review.Core.Models.Forms.FormField.Id.get -> string!
+LM.Review.Core.Models.Forms.FormField.Options.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Forms.FormFieldOption!>!
+LM.Review.Core.Models.Forms.FormField.Title.get -> string!
+LM.Review.Core.Models.Forms.FormField.Validation.get -> LM.Review.Core.Models.Forms.FormFieldValidation?
+LM.Review.Core.Models.Forms.FormField.Visibility.get -> LM.Review.Core.Models.Forms.FormVisibilityRule?
+static LM.Review.Core.Models.Forms.FormField.Create(string! id, string! title, LM.Review.Core.Models.Forms.FormFieldType fieldType, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Forms.FormFieldOption!>? options = null, string? description = null, LM.Review.Core.Models.Forms.FormFieldValidation? validation = null, LM.Review.Core.Models.Forms.FormVisibilityRule? visibility = null, bool allowFreeTextFallback = false) -> LM.Review.Core.Models.Forms.FormField!
+LM.Review.Core.Models.Forms.FormFieldOption
+LM.Review.Core.Models.Forms.FormFieldOption.Description.get -> string?
+LM.Review.Core.Models.Forms.FormFieldOption.Id.get -> string!
+LM.Review.Core.Models.Forms.FormFieldOption.IsDefault.get -> bool
+LM.Review.Core.Models.Forms.FormFieldOption.Label.get -> string!
+static LM.Review.Core.Models.Forms.FormFieldOption.Create(string! id, string! label, string? description = null, bool isDefault = false) -> LM.Review.Core.Models.Forms.FormFieldOption!
+LM.Review.Core.Models.Forms.FormFieldType
+LM.Review.Core.Models.Forms.FormFieldType.SingleSelect = 0 -> LM.Review.Core.Models.Forms.FormFieldType
+LM.Review.Core.Models.Forms.FormFieldType.MultiSelect = 1 -> LM.Review.Core.Models.Forms.FormFieldType
+LM.Review.Core.Models.Forms.FormFieldType.Text = 2 -> LM.Review.Core.Models.Forms.FormFieldType
+LM.Review.Core.Models.Forms.FormFieldType.Numeric = 3 -> LM.Review.Core.Models.Forms.FormFieldType
+LM.Review.Core.Models.Forms.FormFieldType.Date = 4 -> LM.Review.Core.Models.Forms.FormFieldType
+LM.Review.Core.Models.Forms.FormFieldType.Reference = 5 -> LM.Review.Core.Models.Forms.FormFieldType
+LM.Review.Core.Models.Forms.FormFieldValidation
+LM.Review.Core.Models.Forms.FormFieldValidation.Expression.get -> string?
+LM.Review.Core.Models.Forms.FormFieldValidation.Maximum.get -> decimal?
+LM.Review.Core.Models.Forms.FormFieldValidation.MaximumDateUtc.get -> System.DateTime?
+LM.Review.Core.Models.Forms.FormFieldValidation.Minimum.get -> decimal?
+LM.Review.Core.Models.Forms.FormFieldValidation.MinimumDateUtc.get -> System.DateTime?
+LM.Review.Core.Models.Forms.FormFieldValidation.Mode.get -> LM.Review.Core.Models.Forms.FormValidationMode
+static LM.Review.Core.Models.Forms.FormFieldValidation.CreateDateRange(System.DateTime? minimumUtc, System.DateTime? maximumUtc) -> LM.Review.Core.Models.Forms.FormFieldValidation!
+static LM.Review.Core.Models.Forms.FormFieldValidation.CreateNumericRange(decimal? minimum, decimal? maximum) -> LM.Review.Core.Models.Forms.FormFieldValidation!
+static LM.Review.Core.Models.Forms.FormFieldValidation.CreateRegex(string! pattern) -> LM.Review.Core.Models.Forms.FormFieldValidation!
+static LM.Review.Core.Models.Forms.FormFieldValidation.CreateRequired() -> LM.Review.Core.Models.Forms.FormFieldValidation!
+LM.Review.Core.Models.Forms.FormIdentifier
+static bool LM.Review.Core.Models.Forms.FormIdentifier.IsNormalized(string! identifier) -> bool
+static string LM.Review.Core.Models.Forms.FormIdentifier.Normalize(string! identifier) -> string!
+LM.Review.Core.Models.Forms.FormSection
+LM.Review.Core.Models.Forms.FormSection.Children.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Forms.FormSection!>!
+LM.Review.Core.Models.Forms.FormSection.Description.get -> string?
+LM.Review.Core.Models.Forms.FormSection.Fields.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Forms.FormField!>!
+LM.Review.Core.Models.Forms.FormSection.Id.get -> string!
+LM.Review.Core.Models.Forms.FormSection.IsRepeatable.get -> bool
+LM.Review.Core.Models.Forms.FormSection.Title.get -> string!
+LM.Review.Core.Models.Forms.FormSection.Visibility.get -> LM.Review.Core.Models.Forms.FormVisibilityRule?
+static LM.Review.Core.Models.Forms.FormSection.Create(string! id, string! title, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Forms.FormField!>! fields, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Forms.FormSection!>? children = null, bool isRepeatable = false, string? description = null, LM.Review.Core.Models.Forms.FormVisibilityRule? visibility = null) -> LM.Review.Core.Models.Forms.FormSection!
+LM.Review.Core.Models.Forms.FormValidationMode
+LM.Review.Core.Models.Forms.FormValidationMode.Required = 0 -> LM.Review.Core.Models.Forms.FormValidationMode
+LM.Review.Core.Models.Forms.FormValidationMode.Range = 1 -> LM.Review.Core.Models.Forms.FormValidationMode
+LM.Review.Core.Models.Forms.FormValidationMode.Regex = 2 -> LM.Review.Core.Models.Forms.FormValidationMode
+LM.Review.Core.Models.Forms.FormVisibilityRule
+LM.Review.Core.Models.Forms.FormVisibilityRule.ExpectedValues.get -> System.Collections.Generic.IReadOnlyList<string>!
+LM.Review.Core.Models.Forms.FormVisibilityRule.IsVisibleWhenMatches.get -> bool
+LM.Review.Core.Models.Forms.FormVisibilityRule.SourceFieldId.get -> string!
+static LM.Review.Core.Models.Forms.FormVisibilityRule.Create(string! sourceFieldId, System.Collections.Generic.IEnumerable<string>? expectedValues = null, bool isVisibleWhenMatches = true) -> LM.Review.Core.Models.Forms.FormVisibilityRule!
+LM.Review.Core.Models.Forms.ExtractionFormSnapshot
+LM.Review.Core.Models.Forms.ExtractionFormSnapshot.CapturedBy.get -> string!
+LM.Review.Core.Models.Forms.ExtractionFormSnapshot.CapturedUtc.get -> System.DateTime
+LM.Review.Core.Models.Forms.ExtractionFormSnapshot.FormId.get -> string!
+LM.Review.Core.Models.Forms.ExtractionFormSnapshot.Values.get -> System.Collections.Generic.IReadOnlyDictionary<string, object?>!
+LM.Review.Core.Models.Forms.ExtractionFormSnapshot.VersionId.get -> string!
+static LM.Review.Core.Models.Forms.ExtractionFormSnapshot.Create(string! formId, string! versionId, System.Collections.Generic.IDictionary<string, object?>! values, string? capturedBy = null, System.DateTime? capturedUtc = null) -> LM.Review.Core.Models.Forms.ExtractionFormSnapshot!
+LM.Review.Core.Models.Forms.ExtractionFormVersion
+LM.Review.Core.Models.Forms.ExtractionFormVersion.CreatedBy.get -> string!
+LM.Review.Core.Models.Forms.ExtractionFormVersion.CreatedUtc.get -> System.DateTime
+LM.Review.Core.Models.Forms.ExtractionFormVersion.Form.get -> LM.Review.Core.Models.Forms.ExtractionForm!
+LM.Review.Core.Models.Forms.ExtractionFormVersion.Metadata.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>!
+LM.Review.Core.Models.Forms.ExtractionFormVersion.VersionId.get -> string!
+static LM.Review.Core.Models.Forms.ExtractionFormVersion.Create(string! versionId, LM.Review.Core.Models.Forms.ExtractionForm! form, System.Collections.Generic.IDictionary<string, string>? metadata = null, string? createdBy = null, System.DateTime? createdUtc = null) -> LM.Review.Core.Models.Forms.ExtractionFormVersion!
+LM.Review.Core.Validation.FormSchemaIssue
+LM.Review.Core.Validation.FormSchemaIssue.Code.get -> string!
+LM.Review.Core.Validation.FormSchemaIssue.FieldId.get -> string?
+LM.Review.Core.Validation.FormSchemaIssue.Message.get -> string!
+LM.Review.Core.Validation.FormSchemaIssue.SectionId.get -> string?
+LM.Review.Core.Validation.FormSchemaIssue.Severity.get -> LM.Review.Core.Validation.FormSchemaSeverity
+static LM.Review.Core.Validation.FormSchemaIssue.Error(string! code, string! message, string? sectionId = null, string? fieldId = null) -> LM.Review.Core.Validation.FormSchemaIssue!
+static LM.Review.Core.Validation.FormSchemaIssue.Warning(string! code, string! message, string? sectionId = null, string? fieldId = null) -> LM.Review.Core.Validation.FormSchemaIssue!
+LM.Review.Core.Validation.FormSchemaSeverity
+LM.Review.Core.Validation.FormSchemaSeverity.Warning = 0 -> LM.Review.Core.Validation.FormSchemaSeverity
+LM.Review.Core.Validation.FormSchemaSeverity.Error = 1 -> LM.Review.Core.Validation.FormSchemaSeverity
+LM.Review.Core.Validation.FormSchemaValidator
+LM.Review.Core.Validation.FormSchemaValidator.Validate(LM.Review.Core.Models.Forms.ExtractionForm! form) -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Validation.FormSchemaIssue!>!
+LM.Review.Core.Validation.FormSchemaValidator.Validate(LM.Review.Core.Models.Forms.ExtractionFormSnapshot! snapshot, LM.Review.Core.Models.Forms.ExtractionFormVersion! version) -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Validation.FormSchemaIssue!>!
+LM.Review.Core.Validation.FormSchemaValidator.Validate(LM.Review.Core.Models.Forms.ExtractionFormVersion! version) -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Validation.FormSchemaIssue!>!

--- a/src/LM.Review.Core/Validation/FormSchemaIssue.cs
+++ b/src/LM.Review.Core/Validation/FormSchemaIssue.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace LM.Review.Core.Validation;
+
+public sealed class FormSchemaIssue
+{
+    private FormSchemaIssue(
+        string code,
+        string message,
+        FormSchemaSeverity severity,
+        string? sectionId,
+        string? fieldId)
+    {
+        Code = code;
+        Message = message;
+        Severity = severity;
+        SectionId = sectionId;
+        FieldId = fieldId;
+    }
+
+    public string Code { get; }
+
+    public string Message { get; }
+
+    public FormSchemaSeverity Severity { get; }
+
+    public string? SectionId { get; }
+
+    public string? FieldId { get; }
+
+    public static FormSchemaIssue Error(string code, string message, string? sectionId = null, string? fieldId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        return new FormSchemaIssue(code.Trim(), message.Trim(), FormSchemaSeverity.Error, sectionId, fieldId);
+    }
+
+    public static FormSchemaIssue Warning(string code, string message, string? sectionId = null, string? fieldId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        return new FormSchemaIssue(code.Trim(), message.Trim(), FormSchemaSeverity.Warning, sectionId, fieldId);
+    }
+}

--- a/src/LM.Review.Core/Validation/FormSchemaSeverity.cs
+++ b/src/LM.Review.Core/Validation/FormSchemaSeverity.cs
@@ -1,0 +1,7 @@
+namespace LM.Review.Core.Validation;
+
+public enum FormSchemaSeverity
+{
+    Warning = 0,
+    Error = 1
+}

--- a/src/LM.Review.Core/Validation/FormSchemaValidator.Definition.cs
+++ b/src/LM.Review.Core/Validation/FormSchemaValidator.Definition.cs
@@ -1,0 +1,180 @@
+using System.Collections.Generic;
+using System.Linq;
+using LM.Review.Core.Models.Forms;
+
+namespace LM.Review.Core.Validation;
+
+public sealed partial class FormSchemaValidator
+{
+    private static void CollectSection(
+        FormSection section,
+        IDictionary<string, FormField> fieldIndex,
+        IList<(FormVisibilityRule Rule, string OwnerId, string? SectionId, bool AppliesToSection)> visibilityRules,
+        ICollection<FormSchemaIssue> issues)
+    {
+        if (!FormIdentifier.IsNormalized(section.Id))
+        {
+            issues.Add(FormSchemaIssue.Warning("Section.Id.NotNormalized", $"Section id '{section.Id}' is not normalized.", section.Id));
+        }
+
+        if (section.Visibility is not null)
+        {
+            visibilityRules.Add((section.Visibility, section.Id, section.Id, true));
+        }
+
+        foreach (var field in section.Fields)
+        {
+            if (!FormIdentifier.IsNormalized(field.Id))
+            {
+                issues.Add(FormSchemaIssue.Warning(
+                    "Field.Id.NotNormalized",
+                    $"Field id '{field.Id}' is not normalized.",
+                    section.Id,
+                    field.Id));
+            }
+
+            if (!fieldIndex.TryAdd(field.Id, field))
+            {
+                issues.Add(FormSchemaIssue.Error(
+                    "Field.Id.Duplicate",
+                    $"Field identifier '{field.Id}' is reused across the form.",
+                    section.Id,
+                    field.Id));
+            }
+
+            ValidateFieldDefinition(field, section, issues);
+
+            if (field.Visibility is not null)
+            {
+                visibilityRules.Add((field.Visibility, field.Id, section.Id, false));
+            }
+        }
+
+        foreach (var child in section.Children)
+        {
+            CollectSection(child, fieldIndex, visibilityRules, issues);
+        }
+    }
+
+    private static void ValidateFieldDefinition(FormField field, FormSection section, ICollection<FormSchemaIssue> issues)
+    {
+        if (field.Options.Count == 0 && field.FieldType is FormFieldType.SingleSelect or FormFieldType.MultiSelect)
+        {
+            issues.Add(FormSchemaIssue.Error(
+                "Field.Options.Empty",
+                $"Selection field '{field.Id}' must define at least one option.",
+                section.Id,
+                field.Id));
+        }
+
+        if (field.FieldType is not (FormFieldType.SingleSelect or FormFieldType.MultiSelect) && field.Options.Count > 0)
+        {
+            issues.Add(FormSchemaIssue.Error(
+                "Field.Options.Unsupported",
+                $"Field type '{field.FieldType}' does not support options.",
+                section.Id,
+                field.Id));
+        }
+
+        if (field.FieldType == FormFieldType.SingleSelect)
+        {
+            var defaults = field.Options.Count(option => option.IsDefault);
+            if (defaults > 1)
+            {
+                issues.Add(FormSchemaIssue.Error(
+                    "Field.Options.Default",
+                    $"Single-select field '{field.Id}' declares multiple default options.",
+                    section.Id,
+                    field.Id));
+            }
+        }
+
+        foreach (var option in field.Options)
+        {
+            if (!FormIdentifier.IsNormalized(option.Id))
+            {
+                issues.Add(FormSchemaIssue.Warning(
+                    "Option.Id.NotNormalized",
+                    $"Option id '{option.Id}' is not normalized.",
+                    section.Id,
+                    field.Id));
+            }
+        }
+
+        if (field.Validation is null)
+        {
+            return;
+        }
+
+        switch (field.Validation.Mode)
+        {
+            case FormValidationMode.Range:
+            {
+                var hasNumericBounds = field.Validation.Minimum is not null || field.Validation.Maximum is not null;
+                var hasDateBounds = field.Validation.MinimumDateUtc is not null || field.Validation.MaximumDateUtc is not null;
+
+                if (field.FieldType == FormFieldType.Numeric)
+                {
+                    if (!hasNumericBounds)
+                    {
+                        issues.Add(FormSchemaIssue.Warning(
+                            "Field.Validation.Range.Bounds",
+                            $"Numeric field '{field.Id}' declares range validation without bounds.",
+                            section.Id,
+                            field.Id));
+                    }
+
+                    if (hasDateBounds)
+                    {
+                        issues.Add(FormSchemaIssue.Error(
+                            "Field.Validation.Range.BoundsType",
+                            "Numeric fields cannot use date bounds.",
+                            section.Id,
+                            field.Id));
+                    }
+                }
+                else if (field.FieldType == FormFieldType.Date)
+                {
+                    if (!hasDateBounds)
+                    {
+                        issues.Add(FormSchemaIssue.Warning(
+                            "Field.Validation.Range.Bounds",
+                            $"Date field '{field.Id}' declares range validation without bounds.",
+                            section.Id,
+                            field.Id));
+                    }
+
+                    if (hasNumericBounds)
+                    {
+                        issues.Add(FormSchemaIssue.Error(
+                            "Field.Validation.Range.BoundsType",
+                            "Date fields cannot use numeric bounds.",
+                            section.Id,
+                            field.Id));
+                    }
+                }
+                else
+                {
+                    issues.Add(FormSchemaIssue.Error(
+                        "Field.Validation.Range",
+                        "Range validation is only supported for numeric or date fields.",
+                        section.Id,
+                        field.Id));
+                }
+
+                break;
+            }
+            case FormValidationMode.Regex:
+                if (field.FieldType is not FormFieldType.Text)
+                {
+                    issues.Add(FormSchemaIssue.Error(
+                        "Field.Validation.Regex",
+                        "Regex validation is only supported for text fields.",
+                        section.Id,
+                        field.Id));
+                }
+
+                break;
+        }
+    }
+}

--- a/src/LM.Review.Core/Validation/FormSchemaValidator.Snapshot.cs
+++ b/src/LM.Review.Core/Validation/FormSchemaValidator.Snapshot.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using LM.Review.Core.Models.Forms;
+
+namespace LM.Review.Core.Validation;
+
+public sealed partial class FormSchemaValidator
+{
+    public IReadOnlyList<FormSchemaIssue> Validate(ExtractionFormSnapshot snapshot, ExtractionFormVersion version)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        ArgumentNullException.ThrowIfNull(version);
+
+        var issues = new List<FormSchemaIssue>();
+        if (!string.Equals(snapshot.FormId, version.Form.Id, StringComparison.Ordinal))
+        {
+            issues.Add(FormSchemaIssue.Error(
+                "Snapshot.Form.Mismatch",
+                $"Snapshot references form '{snapshot.FormId}' but version is '{version.Form.Id}'."));
+        }
+
+        if (!string.Equals(snapshot.VersionId, version.VersionId, StringComparison.Ordinal))
+        {
+            issues.Add(FormSchemaIssue.Error(
+                "Snapshot.Version.Mismatch",
+                $"Snapshot references version '{snapshot.VersionId}' but definition is '{version.VersionId}'."));
+        }
+
+        if (snapshot.CapturedUtc.Kind != DateTimeKind.Utc)
+        {
+            issues.Add(FormSchemaIssue.Warning("Snapshot.CapturedUtc.Kind", "CapturedUtc timestamps should be stored as UTC."));
+        }
+
+        var fieldIndex = BuildFieldIndex(version.Form);
+
+        foreach (var kvp in snapshot.Values)
+        {
+            if (!fieldIndex.TryGetValue(kvp.Key, out var field))
+            {
+                issues.Add(FormSchemaIssue.Error(
+                    "Snapshot.Field.Unknown",
+                    $"Snapshot includes value for unknown field '{kvp.Key}'.",
+                    fieldId: kvp.Key));
+                continue;
+            }
+
+            var optionIssue = ValidateFieldValue(field, kvp.Value);
+            if (optionIssue is not null)
+            {
+                issues.Add(optionIssue);
+            }
+        }
+
+        foreach (var pair in fieldIndex)
+        {
+            if (pair.Value.Validation?.Mode != FormValidationMode.Required)
+            {
+                continue;
+            }
+
+            if (!snapshot.Values.TryGetValue(pair.Key, out var value) || !HasValue(value))
+            {
+                issues.Add(FormSchemaIssue.Error(
+                    "Snapshot.Field.Required",
+                    $"Required field '{pair.Key}' is missing a value.",
+                    fieldId: pair.Key));
+            }
+        }
+
+        return issues.AsReadOnly();
+    }
+
+    private static Dictionary<string, FormField> BuildFieldIndex(ExtractionForm form)
+    {
+        var index = new Dictionary<string, FormField>(StringComparer.Ordinal);
+        var sections = new Stack<FormSection>(form.Sections.Reverse());
+        while (sections.Count > 0)
+        {
+            var section = sections.Pop();
+            foreach (var field in section.Fields)
+            {
+                if (!index.ContainsKey(field.Id))
+                {
+                    index[field.Id] = field;
+                }
+            }
+
+            foreach (var child in section.Children)
+            {
+                sections.Push(child);
+            }
+        }
+
+        return index;
+    }
+
+    private static FormSchemaIssue? ValidateFieldValue(FormField field, object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        return field.FieldType switch
+        {
+            FormFieldType.SingleSelect => ValidateSingleSelect(field, value),
+            FormFieldType.MultiSelect => ValidateMultiSelect(field, value),
+            FormFieldType.Numeric => ValidateNumeric(field, value),
+            FormFieldType.Date => ValidateDate(field, value),
+            _ => null
+        };
+    }
+
+    private static FormSchemaIssue? ValidateSingleSelect(FormField field, object? value)
+    {
+        if (value is string singleValue)
+        {
+            if (IsOptionMatch(field, singleValue) || field.AllowFreeTextFallback)
+            {
+                return null;
+            }
+
+            return FormSchemaIssue.Error(
+                "Snapshot.Field.OptionMismatch",
+                $"Value '{singleValue}' is not a valid option for field '{field.Id}'.",
+                fieldId: field.Id);
+        }
+
+        return FormSchemaIssue.Error(
+            "Snapshot.Field.TypeMismatch",
+            $"Field '{field.Id}' expects a single option identifier.",
+            fieldId: field.Id);
+    }
+
+    private static FormSchemaIssue? ValidateMultiSelect(FormField field, object? value)
+    {
+        if (value is string singleValue)
+        {
+            return ValidateSingleSelect(field, singleValue);
+        }
+
+        if (value is IEnumerable enumerable)
+        {
+            foreach (var item in enumerable)
+            {
+                if (item is null)
+                {
+                    continue;
+                }
+
+                if (item is not string stringItem)
+                {
+                    return FormSchemaIssue.Error(
+                        "Snapshot.Field.TypeMismatch",
+                        $"Field '{field.Id}' expects option identifiers.",
+                        fieldId: field.Id);
+                }
+
+                if (!IsOptionMatch(field, stringItem) && !field.AllowFreeTextFallback)
+                {
+                    return FormSchemaIssue.Error(
+                        "Snapshot.Field.OptionMismatch",
+                        $"Value '{stringItem}' is not a valid option for field '{field.Id}'.",
+                        fieldId: field.Id);
+                }
+            }
+
+            return null;
+        }
+
+        return FormSchemaIssue.Error(
+            "Snapshot.Field.TypeMismatch",
+            $"Field '{field.Id}' expects a collection of option identifiers.",
+            fieldId: field.Id);
+    }
+
+    private static FormSchemaIssue? ValidateNumeric(FormField field, object? value)
+    {
+        if (value is IConvertible convertible)
+        {
+            try
+            {
+                var numericValue = convertible.ToDecimal(CultureInfo.InvariantCulture);
+                if (field.Validation?.Mode == FormValidationMode.Range)
+                {
+                    if (field.Validation.Minimum is not null && numericValue < field.Validation.Minimum)
+                    {
+                        return FormSchemaIssue.Error(
+                            "Snapshot.Field.Range",
+                            $"Value {numericValue} is less than the minimum for field '{field.Id}'.",
+                            fieldId: field.Id);
+                    }
+
+                    if (field.Validation.Maximum is not null && numericValue > field.Validation.Maximum)
+                    {
+                        return FormSchemaIssue.Error(
+                            "Snapshot.Field.Range",
+                            $"Value {numericValue} exceeds the maximum for field '{field.Id}'.",
+                            fieldId: field.Id);
+                    }
+                }
+
+                return null;
+            }
+            catch
+            {
+                // Fall through and return mismatch issue below.
+            }
+        }
+
+        return FormSchemaIssue.Error(
+            "Snapshot.Field.TypeMismatch",
+            $"Field '{field.Id}' expects a numeric value.",
+            fieldId: field.Id);
+    }
+
+    private static FormSchemaIssue? ValidateDate(FormField field, object? value)
+    {
+        DateTime? normalizedDate = value switch
+        {
+            DateTime dateTime => dateTime.Kind switch
+            {
+                DateTimeKind.Utc => dateTime,
+                DateTimeKind.Unspecified => DateTime.SpecifyKind(dateTime, DateTimeKind.Utc),
+                _ => dateTime.ToUniversalTime()
+            },
+            DateOnly dateOnly => DateTime.SpecifyKind(dateOnly.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc),
+            _ => null
+        };
+
+        if (normalizedDate is null)
+        {
+            return FormSchemaIssue.Error(
+                "Snapshot.Field.TypeMismatch",
+                $"Field '{field.Id}' expects a date value.",
+                fieldId: field.Id);
+        }
+
+        if (field.Validation?.Mode == FormValidationMode.Range)
+        {
+            if (field.Validation.MinimumDateUtc is not null && normalizedDate < field.Validation.MinimumDateUtc)
+            {
+                return FormSchemaIssue.Error(
+                    "Snapshot.Field.Range",
+                    $"Value '{normalizedDate.Value:u}' is earlier than the minimum for field '{field.Id}'.",
+                    fieldId: field.Id);
+            }
+
+            if (field.Validation.MaximumDateUtc is not null && normalizedDate > field.Validation.MaximumDateUtc)
+            {
+                return FormSchemaIssue.Error(
+                    "Snapshot.Field.Range",
+                    $"Value '{normalizedDate.Value:u}' is later than the maximum for field '{field.Id}'.",
+                    fieldId: field.Id);
+            }
+        }
+
+        return null;
+    }
+
+    private static bool HasValue(object? value)
+    {
+        if (value is null)
+        {
+            return false;
+        }
+
+        if (value is string text)
+        {
+            return !string.IsNullOrWhiteSpace(text);
+        }
+
+        if (value is IEnumerable enumerable)
+        {
+            foreach (var _ in enumerable)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsOptionMatch(FormField field, string candidate)
+    {
+        var normalized = candidate.Trim();
+        return field.Options.Any(option => string.Equals(option.Id, normalized, StringComparison.Ordinal));
+    }
+}

--- a/src/LM.Review.Core/Validation/FormSchemaValidator.cs
+++ b/src/LM.Review.Core/Validation/FormSchemaValidator.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using LM.Review.Core.Models.Forms;
+
+namespace LM.Review.Core.Validation;
+
+public sealed partial class FormSchemaValidator
+{
+    public IReadOnlyList<FormSchemaIssue> Validate(ExtractionForm form)
+    {
+        ArgumentNullException.ThrowIfNull(form);
+
+        var issues = new List<FormSchemaIssue>();
+        if (!FormIdentifier.IsNormalized(form.Id))
+        {
+            issues.Add(FormSchemaIssue.Warning("Form.Id.NotNormalized", $"Form id '{form.Id}' is not normalized."));
+        }
+
+        var fieldIndex = new Dictionary<string, FormField>(StringComparer.Ordinal);
+        var visibilityRules = new List<(FormVisibilityRule Rule, string OwnerId, string? SectionId, bool AppliesToSection)>();
+
+        foreach (var rootSection in form.Sections)
+        {
+            CollectSection(rootSection, fieldIndex, visibilityRules, issues);
+        }
+
+        foreach (var pending in visibilityRules)
+        {
+            if (!fieldIndex.ContainsKey(pending.Rule.SourceFieldId))
+            {
+                issues.Add(FormSchemaIssue.Error(
+                    "Visibility.Source.Missing",
+                    $"Visibility rule references unknown field '{pending.Rule.SourceFieldId}'.",
+                    pending.SectionId,
+                    pending.AppliesToSection ? null : pending.OwnerId));
+                continue;
+            }
+
+            if (string.Equals(pending.Rule.SourceFieldId, pending.OwnerId, StringComparison.Ordinal))
+            {
+                issues.Add(FormSchemaIssue.Error(
+                    "Visibility.SelfReference",
+                    "Visibility rules cannot depend on the field they control.",
+                    pending.SectionId,
+                    pending.AppliesToSection ? null : pending.OwnerId));
+            }
+        }
+
+        return issues.AsReadOnly();
+    }
+
+    public IReadOnlyList<FormSchemaIssue> Validate(ExtractionFormVersion version)
+    {
+        ArgumentNullException.ThrowIfNull(version);
+
+        var issues = new List<FormSchemaIssue>();
+        if (!FormIdentifier.IsNormalized(version.VersionId))
+        {
+            issues.Add(FormSchemaIssue.Warning("Version.Id.NotNormalized", $"Version id '{version.VersionId}' is not normalized."));
+        }
+
+        if (string.IsNullOrWhiteSpace(version.CreatedBy))
+        {
+            issues.Add(FormSchemaIssue.Error("Version.CreatedBy.Missing", "Version metadata must include a creator."));
+        }
+
+        if (version.CreatedUtc.Kind != DateTimeKind.Utc)
+        {
+            issues.Add(FormSchemaIssue.Warning("Version.CreatedUtc.Kind", "CreatedUtc timestamps should be stored as UTC."));
+        }
+
+        issues.AddRange(Validate(version.Form));
+        return issues.AsReadOnly();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce extraction form domain models with identifier normalization, user attribution, and runtime snapshot support
- add schema validation utilities to guard form definitions and snapshots before persistence, and update public API declarations

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: SDK 8.0.414 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d6729f96c4832bbfc9664070470697