### PR TITLE
Add JSON-based review project store with concurrency safeguards

### DIFF
--- a/src/LM.Infrastructure.Tests/Review/JsonReviewProjectStoreTests.cs
+++ b/src/LM.Infrastructure.Tests/Review/JsonReviewProjectStoreTests.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using LM.Infrastructure.FileSystem;
+using LM.Infrastructure.Review;
+using LM.Review.Core.Models;
+using LM.Review.Core.Models.Forms;
+using Xunit;
+
+namespace LM.Infrastructure.Tests.Review;
+
+public sealed class JsonReviewProjectStoreTests
+{
+    [Fact]
+    public async Task InitializeAsync_LoadsExistingProjectGraph()
+    {
+        using var workspace = new TempWorkspace();
+        var store = await CreateStoreAsync(workspace.Path);
+
+        var definition = CreateStageDefinition();
+        var project = ReviewProject.Create(
+            "proj-1",
+            "Cardio Screening",
+            DateTimeOffset.UtcNow,
+            new[] { definition },
+            ReviewAuditTrail.Create(new[]
+            {
+                ReviewAuditTrail.AuditEntry.Create("audit-1", "alice", "created", DateTimeOffset.UtcNow, "seed")
+            }));
+
+        await store.SaveProjectAsync(project);
+
+        var assignment = ScreeningAssignment.Create(
+            "assign-1",
+            "stage-1",
+            "reviewer-1",
+            ReviewerRole.Primary,
+            ScreeningStatus.Included,
+            DateTimeOffset.UtcNow.AddMinutes(-30),
+            DateTimeOffset.UtcNow,
+            ReviewerDecision.Create("assign-1", "reviewer-1", ScreeningStatus.Included, DateTimeOffset.UtcNow, "looks good"));
+
+        var stage = ReviewStage.Create(
+            "stage-1",
+            project.Id,
+            definition,
+            new[] { assignment },
+            ConflictState.Resolved,
+            DateTimeOffset.UtcNow.AddHours(-1),
+            DateTimeOffset.UtcNow,
+            ConsensusOutcome.Create("stage-1", true, ConflictState.Resolved, DateTimeOffset.UtcNow, "approved", "alice"));
+
+        await store.SaveStageAsync(stage);
+        await store.SaveAssignmentAsync(project.Id, assignment);
+
+        var snapshot = ExtractionFormSnapshot.Create(
+            "extraction-form",
+            "v1",
+            new Dictionary<string, object?> { ["field1"] = "value" },
+            "alice",
+            DateTime.UtcNow);
+
+        var response = new JsonReviewProjectStore.FormResponse("response-1", project.Id, stage.Id, assignment.Id, snapshot);
+        await store.SaveFormResponseAsync(response);
+
+        var hydrated = await CreateStoreAsync(workspace.Path);
+
+        var loadedProject = await hydrated.GetProjectAsync(project.Id);
+        Assert.NotNull(loadedProject);
+        Assert.Equal(project.Name, loadedProject!.Name);
+
+        var stages = await hydrated.GetStagesByProjectAsync(project.Id);
+        var loadedStage = Assert.Single(stages);
+        Assert.Equal(stage.Id, loadedStage.Id);
+        Assert.Equal(stage.ConflictState, loadedStage.ConflictState);
+        Assert.Single(loadedStage.Assignments);
+
+        var assignments = await hydrated.GetAssignmentsByStageAsync(stage.Id);
+        var loadedAssignment = Assert.Single(assignments);
+        Assert.Equal(assignment.ReviewerId, loadedAssignment.ReviewerId);
+        Assert.Equal(ScreeningStatus.Included, loadedAssignment.Status);
+
+        var responses = await hydrated.GetFormResponsesAsync(project.Id);
+        var loadedResponse = Assert.Single(responses);
+        Assert.Equal(response.Id, loadedResponse.Id);
+        Assert.Equal("value", loadedResponse.Snapshot.Values["field1"]);
+    }
+
+    [Fact]
+    public async Task SaveStageAsync_AllowsConcurrentWritesForDifferentStages()
+    {
+        using var workspace = new TempWorkspace();
+        var store = await CreateStoreAsync(workspace.Path);
+
+        var definition = CreateStageDefinition();
+        var project = ReviewProject.Create("proj-2", "Parallel", DateTimeOffset.UtcNow, new[] { definition }, ReviewAuditTrail.Create());
+        await store.SaveProjectAsync(project);
+
+        var stage1 = ReviewStage.Create(
+            "stage-1",
+            project.Id,
+            definition,
+            new[]
+            {
+                ScreeningAssignment.Create(
+                    "assign-a",
+                    "stage-1",
+                    "reviewer-a",
+                    ReviewerRole.Primary,
+                    ScreeningStatus.Included,
+                    DateTimeOffset.UtcNow.AddMinutes(-15),
+                    DateTimeOffset.UtcNow,
+                    ReviewerDecision.Create("assign-a", "reviewer-a", ScreeningStatus.Included, DateTimeOffset.UtcNow))
+            },
+            ConflictState.None,
+            DateTimeOffset.UtcNow,
+            null,
+            null);
+
+        var stage2 = ReviewStage.Create(
+            "stage-2",
+            project.Id,
+            definition,
+            new[]
+            {
+                ScreeningAssignment.Create(
+                    "assign-b",
+                    "stage-2",
+                    "reviewer-b",
+                    ReviewerRole.Primary,
+                    ScreeningStatus.Included,
+                    DateTimeOffset.UtcNow.AddMinutes(-10),
+                    DateTimeOffset.UtcNow,
+                    ReviewerDecision.Create("assign-b", "reviewer-b", ScreeningStatus.Included, DateTimeOffset.UtcNow))
+            },
+            ConflictState.None,
+            DateTimeOffset.UtcNow,
+            null,
+            null);
+
+        await Task.WhenAll(
+            store.SaveStageAsync(stage1),
+            store.SaveStageAsync(stage2));
+
+        var stageIds = (await store.GetStagesByProjectAsync(project.Id)).Select(s => s.Id).ToArray();
+        Assert.Contains("stage-1", stageIds);
+        Assert.Contains("stage-2", stageIds);
+    }
+
+    [Fact]
+    public async Task SaveAssignmentAsync_WhenLockIsFresh_ThrowsIOException()
+    {
+        using var workspace = new TempWorkspace();
+        var store = await CreateStoreAsync(workspace.Path);
+
+        var definition = CreateStageDefinition();
+        var project = ReviewProject.Create("proj-3", "Conflicts", DateTimeOffset.UtcNow, new[] { definition }, ReviewAuditTrail.Create());
+        await store.SaveProjectAsync(project);
+
+        var stage = ReviewStage.Create(
+            "stage-1",
+            project.Id,
+            definition,
+            new[]
+            {
+                ScreeningAssignment.Create(
+                    "assign-1",
+                    "stage-1",
+                    "reviewer-1",
+                    ReviewerRole.Primary,
+                    ScreeningStatus.Included,
+                    DateTimeOffset.UtcNow.AddMinutes(-5),
+                    DateTimeOffset.UtcNow,
+                    ReviewerDecision.Create("assign-1", "reviewer-1", ScreeningStatus.Included, DateTimeOffset.UtcNow))
+            },
+            ConflictState.None,
+            DateTimeOffset.UtcNow,
+            null,
+            null);
+
+        await store.SaveStageAsync(stage);
+
+        var assignment = ScreeningAssignment.Create(
+            "assign-1",
+            "stage-1",
+            "reviewer-1",
+            ReviewerRole.Primary,
+            ScreeningStatus.Included,
+            DateTimeOffset.UtcNow.AddMinutes(-5),
+            DateTimeOffset.UtcNow,
+            ReviewerDecision.Create("assign-1", "reviewer-1", ScreeningStatus.Included, DateTimeOffset.UtcNow));
+
+        await store.SaveAssignmentAsync(project.Id, assignment);
+
+        var concurrent = Task.WhenAll(
+            store.SaveAssignmentAsync(project.Id, assignment),
+            store.SaveAssignmentAsync(project.Id, assignment));
+
+        await Assert.ThrowsAsync<IOException>(async () => await concurrent);
+
+        var assignments = await store.GetAssignmentsByStageAsync(stage.Id);
+        Assert.Single(assignments);
+    }
+
+    [Fact]
+    public async Task SaveAssignmentAsync_IgnoresStaleLock()
+    {
+        using var workspace = new TempWorkspace();
+        var store = await CreateStoreAsync(workspace.Path);
+
+        var definition = CreateStageDefinition();
+        var project = ReviewProject.Create("proj-4", "Stale", DateTimeOffset.UtcNow, new[] { definition }, ReviewAuditTrail.Create());
+        await store.SaveProjectAsync(project);
+
+        var stage = ReviewStage.Create(
+            "stage-1",
+            project.Id,
+            definition,
+            new[]
+            {
+                ScreeningAssignment.Create(
+                    "assign-1",
+                    "stage-1",
+                    "reviewer-1",
+                    ReviewerRole.Primary,
+                    ScreeningStatus.Included,
+                    DateTimeOffset.UtcNow.AddMinutes(-15),
+                    DateTimeOffset.UtcNow,
+                    ReviewerDecision.Create("assign-1", "reviewer-1", ScreeningStatus.Included, DateTimeOffset.UtcNow))
+            },
+            ConflictState.None,
+            DateTimeOffset.UtcNow,
+            null,
+            null);
+
+        await store.SaveStageAsync(stage);
+
+        var initial = ScreeningAssignment.Create(
+            "assign-1",
+            "stage-1",
+            "reviewer-1",
+            ReviewerRole.Primary,
+            ScreeningStatus.Included,
+            DateTimeOffset.UtcNow.AddMinutes(-10),
+            DateTimeOffset.UtcNow,
+            ReviewerDecision.Create("assign-1", "reviewer-1", ScreeningStatus.Included, DateTimeOffset.UtcNow));
+
+        await store.SaveAssignmentAsync(project.Id, initial);
+
+        var lockPath = Path.Combine(workspace.Path, "reviews", project.Id, "assignments", "assign-1.json.lock");
+        await File.WriteAllTextAsync(lockPath, string.Empty);
+        File.SetLastWriteTimeUtc(lockPath, DateTime.UtcNow.AddMinutes(-6));
+
+        var updated = ScreeningAssignment.Create(
+            "assign-1",
+            "stage-1",
+            "reviewer-1",
+            ReviewerRole.Primary,
+            ScreeningStatus.Included,
+            DateTimeOffset.UtcNow.AddMinutes(-8),
+            DateTimeOffset.UtcNow,
+            ReviewerDecision.Create("assign-1", "reviewer-1", ScreeningStatus.Included, DateTimeOffset.UtcNow, "refresh"));
+
+        await store.SaveAssignmentAsync(project.Id, updated);
+
+        var stored = await store.GetAssignmentAsync("assign-1");
+        Assert.NotNull(stored);
+        Assert.Equal("refresh", stored!.Decision!.Notes);
+    }
+
+    private static StageDefinition CreateStageDefinition()
+    {
+        var requirement = ReviewerRequirement.Create(new[]
+        {
+            new KeyValuePair<ReviewerRole, int>(ReviewerRole.Primary, 1)
+        });
+
+        return StageDefinition.Create(
+            "definition-1",
+            "Title Screening",
+            ReviewStageType.Screening,
+            requirement,
+            StageConsensusPolicy.RequireAgreement(1, false, null));
+    }
+
+    private static async Task<JsonReviewProjectStore> CreateStoreAsync(string workspacePath)
+    {
+        var workspace = new WorkspaceService();
+        await workspace.EnsureWorkspaceAsync(workspacePath);
+        var store = new JsonReviewProjectStore(workspace);
+        await store.InitializeAsync();
+        return store;
+    }
+
+    private sealed class TempWorkspace : IDisposable
+    {
+        public string Path { get; }
+
+        public TempWorkspace()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "lm_review_store_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { }
+        }
+    }
+}

--- a/src/LM.Infrastructure/LM.Infrastructure.csproj
+++ b/src/LM.Infrastructure/LM.Infrastructure.csproj
@@ -7,7 +7,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\LM.Core\LM.Core.csproj" />
-	<ProjectReference Include="..\LM.HubAndSpoke\LM.HubSpoke.csproj" />
+    <ProjectReference Include="..\LM.HubAndSpoke\LM.HubSpoke.csproj" />
+    <ProjectReference Include="..\LM.Review.Core\LM.Review.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LM.Infrastructure/Review/JsonReviewProjectStore.Documents.cs
+++ b/src/LM.Infrastructure/Review/JsonReviewProjectStore.Documents.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using LM.Review.Core.Models;
+using LM.Review.Core.Models.Forms;
+
+namespace LM.Infrastructure.Review;
+
+internal sealed partial class JsonReviewProjectStore
+{
+    internal sealed record FormResponse(string Id, string ProjectId, string? StageId, string? AssignmentId, ExtractionFormSnapshot Snapshot);
+
+    private sealed class ProjectDocument
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public DateTimeOffset CreatedAt { get; set; }
+        public List<StageDefinitionDocument> StageDefinitions { get; set; } = new();
+        public List<AuditEntryDocument> AuditTrail { get; set; } = new();
+    }
+
+    private sealed class StageDocument
+    {
+        public string Id { get; set; } = string.Empty;
+        public string ProjectId { get; set; } = string.Empty;
+        public string DefinitionId { get; set; } = string.Empty;
+        public ConflictState ConflictState { get; set; }
+        public DateTimeOffset ActivatedAt { get; set; }
+        public DateTimeOffset? CompletedAt { get; set; }
+        public ConsensusOutcomeDocument? Consensus { get; set; }
+    }
+
+    private sealed class AssignmentDocument
+    {
+        public string Id { get; set; } = string.Empty;
+        public string ProjectId { get; set; } = string.Empty;
+        public string StageId { get; set; } = string.Empty;
+        public string ReviewerId { get; set; } = string.Empty;
+        public ReviewerRole Role { get; set; }
+        public ScreeningStatus Status { get; set; }
+        public DateTimeOffset AssignedAt { get; set; }
+        public DateTimeOffset? CompletedAt { get; set; }
+        public ReviewerDecisionDocument? Decision { get; set; }
+    }
+
+    private sealed class FormResponseDocument
+    {
+        public string Id { get; set; } = string.Empty;
+        public string ProjectId { get; set; } = string.Empty;
+        public string? StageId { get; set; }
+        public string? AssignmentId { get; set; }
+        public string FormId { get; set; } = string.Empty;
+        public string VersionId { get; set; } = string.Empty;
+        public string CapturedBy { get; set; } = string.Empty;
+        public DateTime CapturedUtc { get; set; }
+        public Dictionary<string, JsonElement> Values { get; set; } = new(StringComparer.Ordinal);
+    }
+
+    private sealed class StageDefinitionDocument
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public ReviewStageType StageType { get; set; }
+        public Dictionary<ReviewerRole, int> ReviewerRequirements { get; set; } = new();
+        public StageConsensusPolicyDocument Consensus { get; set; } = new();
+    }
+
+    private sealed class StageConsensusPolicyDocument
+    {
+        public bool RequiresConsensus { get; set; }
+        public int MinimumAgreements { get; set; }
+        public bool EscalateOnDisagreement { get; set; }
+        public ReviewerRole? ArbitrationRole { get; set; }
+    }
+
+    private sealed class AuditEntryDocument
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Actor { get; set; } = string.Empty;
+        public string Action { get; set; } = string.Empty;
+        public DateTimeOffset OccurredAt { get; set; }
+        public string? Details { get; set; }
+    }
+
+    private sealed class ConsensusOutcomeDocument
+    {
+        public string StageId { get; set; } = string.Empty;
+        public bool Approved { get; set; }
+        public ConflictState ResultingState { get; set; }
+        public DateTimeOffset ResolvedAt { get; set; }
+        public string? Notes { get; set; }
+        public string? ResolvedBy { get; set; }
+    }
+
+    private sealed class ReviewerDecisionDocument
+    {
+        public string AssignmentId { get; set; } = string.Empty;
+        public string ReviewerId { get; set; } = string.Empty;
+        public ScreeningStatus Decision { get; set; }
+        public DateTimeOffset DecidedAt { get; set; }
+        public string? Notes { get; set; }
+    }
+}

--- a/src/LM.Infrastructure/Review/JsonReviewProjectStore.Helpers.cs
+++ b/src/LM.Infrastructure/Review/JsonReviewProjectStore.Helpers.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Review.Core.Models;
+
+namespace LM.Infrastructure.Review;
+
+internal sealed partial class JsonReviewProjectStore
+{
+    private async Task LoadAssignmentsAsync(string projectDir, string projectId, CancellationToken ct)
+    {
+        var assignmentDir = Path.Combine(projectDir, "assignments");
+        if (!Directory.Exists(assignmentDir))
+        {
+            return;
+        }
+
+        foreach (var file in Directory.EnumerateFiles(assignmentDir, "*.json", SearchOption.TopDirectoryOnly))
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var doc = await ReadJsonAsync<AssignmentDocument>(file, ct).ConfigureAwait(false);
+            if (doc is null || string.IsNullOrWhiteSpace(doc.Id))
+            {
+                continue;
+            }
+
+            if (!string.Equals(doc.ProjectId, projectId, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            try
+            {
+                var assignment = AssignmentMapper.ToDomain(doc);
+                _assignmentDocs[assignment.Id] = doc;
+                _assignments[assignment.Id] = assignment;
+                if (!_assignmentIdsByStage.ContainsKey(assignment.StageId))
+                {
+                    _assignmentIdsByStage[assignment.StageId] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                }
+                _assignmentIdsByStage[assignment.StageId].Add(assignment.Id);
+            }
+            catch
+            {
+                // Ignore malformed assignment files during initialization.
+            }
+        }
+    }
+
+    private async Task LoadStagesAsync(string projectDir, ReviewProject project, CancellationToken ct)
+    {
+        var stageDir = Path.Combine(projectDir, "stages");
+        if (!Directory.Exists(stageDir))
+        {
+            return;
+        }
+
+        var definitions = project.StageDefinitions.ToDictionary(d => d.Id, StringComparer.Ordinal);
+        foreach (var file in Directory.EnumerateFiles(stageDir, "*.json", SearchOption.TopDirectoryOnly))
+        {
+            ct.ThrowIfCancellationRequested();
+            var doc = await ReadJsonAsync<StageDocument>(file, ct).ConfigureAwait(false);
+            if (doc is null || string.IsNullOrWhiteSpace(doc.Id))
+            {
+                continue;
+            }
+
+            if (!string.Equals(doc.ProjectId, project.Id, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!definitions.TryGetValue(doc.DefinitionId, out var definition))
+            {
+                continue;
+            }
+
+            try
+            {
+                var stage = StageMapper.ToDomain(doc, definition, CollectAssignments(doc.Id));
+                _stageDocs[doc.Id] = doc;
+                _stages[doc.Id] = stage;
+                _stageIdsByProject.TryAdd(project.Id, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+                _stageIdsByProject[project.Id].Add(doc.Id);
+            }
+            catch
+            {
+                // Skip malformed stage files.
+            }
+        }
+    }
+
+    private async Task LoadFormResponsesAsync(string projectDir, string projectId, CancellationToken ct)
+    {
+        var formsDir = Path.Combine(projectDir, "forms");
+        if (!Directory.Exists(formsDir))
+        {
+            return;
+        }
+
+        foreach (var file in Directory.EnumerateFiles(formsDir, "*.json", SearchOption.TopDirectoryOnly))
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var doc = await ReadJsonAsync<FormResponseDocument>(file, ct).ConfigureAwait(false);
+            if (doc is null || string.IsNullOrWhiteSpace(doc.Id))
+            {
+                continue;
+            }
+
+            if (!string.Equals(doc.ProjectId, projectId, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            try
+            {
+                var response = FormResponseMapper.ToDomain(doc, _jsonOptions);
+                var key = FormKey(projectId, response.Id);
+                _formDocs[key] = doc;
+                _formResponses[key] = response;
+                _formIdsByProject.TryAdd(projectId, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+                _formIdsByProject[projectId].Add(response.Id);
+            }
+            catch
+            {
+                // Ignore malformed form responses.
+            }
+        }
+    }
+
+    private IReadOnlyCollection<ScreeningAssignment> CollectAssignments(string stageId)
+    {
+        if (!_assignmentIdsByStage.TryGetValue(stageId, out var ids) || ids.Count == 0)
+        {
+            return Array.Empty<ScreeningAssignment>();
+        }
+
+        return ids.Select(id => _assignments[id]).ToList();
+    }
+
+    private void RebuildStage(string stageId)
+    {
+        if (!_stageDocs.TryGetValue(stageId, out var doc))
+        {
+            return;
+        }
+
+        if (!_projects.TryGetValue(doc.ProjectId, out var project))
+        {
+            return;
+        }
+
+        var definition = project.StageDefinitions.FirstOrDefault(d => string.Equals(d.Id, doc.DefinitionId, StringComparison.Ordinal));
+        if (definition is null)
+        {
+            return;
+        }
+
+        var assignments = CollectAssignments(stageId);
+        try
+        {
+            var stage = StageMapper.ToDomain(doc, definition, assignments);
+            _stages[stageId] = stage;
+        }
+        catch
+        {
+            // ignore rebuild failures; stage will be refreshed on next initialize
+        }
+    }
+
+    private async Task<T?> ReadJsonAsync<T>(string path, CancellationToken ct)
+    {
+        try
+        {
+            await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return await JsonSerializer.DeserializeAsync<T>(stream, _jsonOptions, ct).ConfigureAwait(false);
+        }
+        catch
+        {
+            return default;
+        }
+    }
+
+    private async Task WriteJsonAsync<T>(string path, T payload, CancellationToken ct)
+    {
+        var directory = Path.GetDirectoryName(path)!;
+        Directory.CreateDirectory(directory);
+
+        var lockPath = path + ".lock";
+        var tmpPath = path + ".tmp";
+
+        try
+        {
+            await using (AcquireLock(lockPath)) { }
+
+            await using var stream = new FileStream(tmpPath, FileMode.Create, FileAccess.Write, FileShare.None, 4096, useAsync: true);
+            await JsonSerializer.SerializeAsync(stream, payload, _jsonOptions, ct).ConfigureAwait(false);
+            await stream.FlushAsync(ct).ConfigureAwait(false);
+
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+
+            File.Move(tmpPath, path, overwrite: true);
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(lockPath);
+            }
+            catch
+            {
+                // Ignore lock cleanup issues.
+            }
+
+            if (File.Exists(tmpPath))
+            {
+                try { File.Delete(tmpPath); } catch { }
+            }
+        }
+    }
+
+    private FileStream AcquireLock(string lockPath)
+    {
+        while (true)
+        {
+            try
+            {
+                return new FileStream(lockPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            }
+            catch (IOException) when (File.Exists(lockPath))
+            {
+                var lastWrite = File.GetLastWriteTimeUtc(lockPath);
+                if (lastWrite == DateTime.MinValue || DateTime.UtcNow - lastWrite <= _lockTimeout)
+                {
+                    throw;
+                }
+
+                try
+                {
+                    File.Delete(lockPath);
+                    continue;
+                }
+                catch
+                {
+                    throw;
+                }
+            }
+        }
+    }
+
+    private string GetProjectPath(string projectId) => Path.Combine(_reviewsRoot, projectId, "project.json");
+    private string GetStagePath(string projectId, string stageId) => Path.Combine(_reviewsRoot, projectId, "stages", stageId + ".json");
+    private string GetAssignmentPath(string projectId, string assignmentId) => Path.Combine(_reviewsRoot, projectId, "assignments", assignmentId + ".json");
+    private string GetFormResponsePath(string projectId, string responseId) => Path.Combine(_reviewsRoot, projectId, "forms", responseId + ".json");
+
+    private static string FormKey(string projectId, string responseId) => string.Concat(projectId, "::", responseId);
+
+    private void EnsureInitialized()
+    {
+        if (string.IsNullOrWhiteSpace(_reviewsRoot))
+        {
+            throw new InvalidOperationException("Store must be initialized before use.");
+        }
+    }
+
+    private static void DeleteFileIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/src/LM.Infrastructure/Review/JsonReviewProjectStore.Mappers.cs
+++ b/src/LM.Infrastructure/Review/JsonReviewProjectStore.Mappers.cs
@@ -1,0 +1,223 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LM.Review.Core.Models;
+using LM.Review.Core.Models.Forms;
+
+namespace LM.Infrastructure.Review;
+
+internal sealed partial class JsonReviewProjectStore
+{
+    private static class ProjectMapper
+    {
+        public static ProjectDocument FromDomain(ReviewProject project)
+        {
+            return new ProjectDocument
+            {
+                Id = project.Id,
+                Name = project.Name,
+                CreatedAt = project.CreatedAt,
+                StageDefinitions = project.StageDefinitions.Select(StageDefinitionMapper.FromDomain).ToList(),
+                AuditTrail = project.AuditTrail.Entries.Select(AuditEntryMapper.FromDomain).ToList()
+            };
+        }
+
+        public static ReviewProject ToDomain(ProjectDocument doc)
+        {
+            var definitions = doc.StageDefinitions?.Select(StageDefinitionMapper.ToDomain).ToList() ?? new List<StageDefinition>();
+            var auditEntries = doc.AuditTrail?.Select(AuditEntryMapper.ToDomain).ToList() ?? new List<ReviewAuditTrail.AuditEntry>();
+            var auditTrail = ReviewAuditTrail.Create(auditEntries);
+            return ReviewProject.Create(doc.Id, doc.Name, doc.CreatedAt, definitions, auditTrail);
+        }
+    }
+
+    private static class StageMapper
+    {
+        public static StageDocument FromDomain(ReviewStage stage)
+        {
+            return new StageDocument
+            {
+                Id = stage.Id,
+                ProjectId = stage.ProjectId,
+                DefinitionId = stage.Definition.Id,
+                ConflictState = stage.ConflictState,
+                ActivatedAt = stage.ActivatedAt,
+                CompletedAt = stage.CompletedAt,
+                Consensus = stage.Consensus is null ? null : ConsensusOutcomeMapper.FromDomain(stage.Consensus)
+            };
+        }
+
+        public static ReviewStage ToDomain(StageDocument doc, StageDefinition definition, IReadOnlyCollection<ScreeningAssignment> assignments)
+        {
+            var consensus = doc.Consensus is null ? null : ConsensusOutcomeMapper.ToDomain(doc.Consensus);
+            return ReviewStage.Create(doc.Id, doc.ProjectId, definition, assignments, doc.ConflictState, doc.ActivatedAt, doc.CompletedAt, consensus);
+        }
+    }
+
+    private static class AssignmentMapper
+    {
+        public static AssignmentDocument FromDomain(string projectId, ScreeningAssignment assignment)
+        {
+            return new AssignmentDocument
+            {
+                Id = assignment.Id,
+                ProjectId = projectId,
+                StageId = assignment.StageId,
+                ReviewerId = assignment.ReviewerId,
+                Role = assignment.Role,
+                Status = assignment.Status,
+                AssignedAt = assignment.AssignedAt,
+                CompletedAt = assignment.CompletedAt,
+                Decision = assignment.Decision is null ? null : ReviewerDecisionMapper.FromDomain(assignment.Decision)
+            };
+        }
+
+        public static ScreeningAssignment ToDomain(AssignmentDocument doc)
+        {
+            var decision = doc.Decision is null ? null : ReviewerDecisionMapper.ToDomain(doc.Decision);
+            return ScreeningAssignment.Create(doc.Id, doc.StageId, doc.ReviewerId, doc.Role, doc.Status, doc.AssignedAt, doc.CompletedAt, decision);
+        }
+    }
+
+    private static class FormResponseMapper
+    {
+        public static FormResponseDocument FromDomain(FormResponse response, JsonSerializerOptions options)
+        {
+            return new FormResponseDocument
+            {
+                Id = response.Id,
+                ProjectId = response.ProjectId,
+                StageId = response.StageId,
+                AssignmentId = response.AssignmentId,
+                FormId = response.Snapshot.FormId,
+                VersionId = response.Snapshot.VersionId,
+                CapturedBy = response.Snapshot.CapturedBy,
+                CapturedUtc = response.Snapshot.CapturedUtc,
+                Values = response.Snapshot.Values.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => JsonSerializer.SerializeToElement(kvp.Value, options))
+            };
+        }
+
+        public static FormResponse ToDomain(FormResponseDocument doc, JsonSerializerOptions options)
+        {
+            var elements = doc.Values ?? new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+            var values = new Dictionary<string, object?>(elements.Count, StringComparer.Ordinal);
+            foreach (var (key, element) in elements)
+            {
+                values[key] = element.Deserialize<object?>(options);
+            }
+
+            var snapshot = ExtractionFormSnapshot.Create(doc.FormId, doc.VersionId, values, doc.CapturedBy, doc.CapturedUtc);
+            return new FormResponse(doc.Id, doc.ProjectId, doc.StageId, doc.AssignmentId, snapshot);
+        }
+    }
+
+    private static class StageDefinitionMapper
+    {
+        public static StageDefinitionDocument FromDomain(StageDefinition definition)
+        {
+            return new StageDefinitionDocument
+            {
+                Id = definition.Id,
+                Name = definition.Name,
+                StageType = definition.StageType,
+                ReviewerRequirements = definition.ReviewerRequirement.Requirements.ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
+                Consensus = StageConsensusPolicyMapper.FromDomain(definition.ConsensusPolicy)
+            };
+        }
+
+        public static StageDefinition ToDomain(StageDefinitionDocument doc)
+        {
+            var requirement = ReviewerRequirement.Create(doc.ReviewerRequirements);
+            var consensus = StageConsensusPolicyMapper.ToDomain(doc.Consensus ?? new StageConsensusPolicyDocument());
+            return StageDefinition.Create(doc.Id, doc.Name, doc.StageType, requirement, consensus);
+        }
+    }
+
+    private static class StageConsensusPolicyMapper
+    {
+        public static StageConsensusPolicyDocument FromDomain(StageConsensusPolicy policy)
+        {
+            return new StageConsensusPolicyDocument
+            {
+                RequiresConsensus = policy.RequiresConsensus,
+                MinimumAgreements = policy.MinimumAgreements,
+                EscalateOnDisagreement = policy.EscalateOnDisagreement,
+                ArbitrationRole = policy.ArbitrationRole
+            };
+        }
+
+        public static StageConsensusPolicy ToDomain(StageConsensusPolicyDocument doc)
+        {
+            if (!doc.RequiresConsensus)
+            {
+                return StageConsensusPolicy.Disabled();
+            }
+
+            return StageConsensusPolicy.RequireAgreement(doc.MinimumAgreements, doc.EscalateOnDisagreement, doc.ArbitrationRole);
+        }
+    }
+
+    private static class AuditEntryMapper
+    {
+        public static AuditEntryDocument FromDomain(ReviewAuditTrail.AuditEntry entry)
+        {
+            return new AuditEntryDocument
+            {
+                Id = entry.Id,
+                Actor = entry.Actor,
+                Action = entry.Action,
+                OccurredAt = entry.OccurredAt,
+                Details = entry.Details
+            };
+        }
+
+        public static ReviewAuditTrail.AuditEntry ToDomain(AuditEntryDocument doc)
+        {
+            return ReviewAuditTrail.AuditEntry.Create(doc.Id, doc.Actor, doc.Action, doc.OccurredAt, doc.Details);
+        }
+    }
+
+    private static class ConsensusOutcomeMapper
+    {
+        public static ConsensusOutcomeDocument FromDomain(ConsensusOutcome consensus)
+        {
+            return new ConsensusOutcomeDocument
+            {
+                StageId = consensus.StageId,
+                Approved = consensus.Approved,
+                ResultingState = consensus.ResultingState,
+                ResolvedAt = consensus.ResolvedAt,
+                Notes = consensus.Notes,
+                ResolvedBy = consensus.ResolvedBy
+            };
+        }
+
+        public static ConsensusOutcome ToDomain(ConsensusOutcomeDocument doc)
+        {
+            return ConsensusOutcome.Create(doc.StageId, doc.Approved, doc.ResultingState, doc.ResolvedAt, doc.Notes, doc.ResolvedBy);
+        }
+    }
+
+    private static class ReviewerDecisionMapper
+    {
+        public static ReviewerDecisionDocument FromDomain(ReviewerDecision decision)
+        {
+            return new ReviewerDecisionDocument
+            {
+                AssignmentId = decision.AssignmentId,
+                ReviewerId = decision.ReviewerId,
+                Decision = decision.Decision,
+                DecidedAt = decision.DecidedAt,
+                Notes = decision.Notes
+            };
+        }
+
+        public static ReviewerDecision ToDomain(ReviewerDecisionDocument doc)
+        {
+            return ReviewerDecision.Create(doc.AssignmentId, doc.ReviewerId, doc.Decision, doc.DecidedAt, doc.Notes);
+        }
+    }
+}

--- a/src/LM.Infrastructure/Review/JsonReviewProjectStore.cs
+++ b/src/LM.Infrastructure/Review/JsonReviewProjectStore.cs
@@ -1,0 +1,510 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Abstractions;
+using LM.Review.Core.Models;
+using LM.Review.Core.Models.Forms;
+
+namespace LM.Infrastructure.Review;
+
+internal sealed partial class JsonReviewProjectStore
+{
+    private readonly IWorkSpaceService _workspace;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+    private readonly TimeSpan _lockTimeout = TimeSpan.FromMinutes(5);
+
+    private readonly Dictionary<string, ReviewProject> _projects = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, StageDocument> _stageDocs = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, ReviewStage> _stages = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, AssignmentDocument> _assignmentDocs = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, ScreeningAssignment> _assignments = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, FormResponseDocument> _formDocs = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, FormResponse> _formResponses = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, HashSet<string>> _stageIdsByProject = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, HashSet<string>> _assignmentIdsByStage = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, HashSet<string>> _formIdsByProject = new(StringComparer.OrdinalIgnoreCase);
+
+    private string _reviewsRoot = string.Empty;
+
+    internal JsonReviewProjectStore(IWorkSpaceService workspace)
+    {
+        _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+        _jsonOptions.Converters.Add(new JsonStringEnumConverter());
+    }
+
+    internal async Task InitializeAsync(CancellationToken ct = default)
+    {
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            _reviewsRoot = Path.Combine(_workspace.GetWorkspaceRoot(), "reviews");
+            Directory.CreateDirectory(_reviewsRoot);
+
+            _projects.Clear();
+            _stageDocs.Clear();
+            _stages.Clear();
+            _assignmentDocs.Clear();
+            _assignments.Clear();
+            _formDocs.Clear();
+            _formResponses.Clear();
+            _stageIdsByProject.Clear();
+            _assignmentIdsByStage.Clear();
+            _formIdsByProject.Clear();
+
+            foreach (var projectDir in Directory.EnumerateDirectories(_reviewsRoot))
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var projectPath = Path.Combine(projectDir, "project.json");
+                if (!File.Exists(projectPath))
+                {
+                    continue;
+                }
+
+                var projectDoc = await ReadJsonAsync<ProjectDocument>(projectPath, ct).ConfigureAwait(false);
+                if (projectDoc is null || string.IsNullOrWhiteSpace(projectDoc.Id))
+                {
+                    continue;
+                }
+
+                var project = ProjectMapper.ToDomain(projectDoc);
+                _projects[project.Id] = project;
+                _stageIdsByProject[project.Id] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                _formIdsByProject[project.Id] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            foreach (var (projectId, project) in _projects)
+            {
+                ct.ThrowIfCancellationRequested();
+                var projectDir = Path.Combine(_reviewsRoot, projectId);
+
+                await LoadAssignmentsAsync(projectDir, projectId, ct).ConfigureAwait(false);
+                await LoadStagesAsync(projectDir, project, ct).ConfigureAwait(false);
+                await LoadFormResponsesAsync(projectDir, projectId, ct).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task SaveProjectAsync(ReviewProject project, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            var doc = ProjectMapper.FromDomain(project);
+            var path = GetProjectPath(project.Id);
+            await WriteJsonAsync(path, doc, ct).ConfigureAwait(false);
+            _projects[project.Id] = project;
+            _stageIdsByProject.TryAdd(project.Id, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+            _formIdsByProject.TryAdd(project.Id, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task<ReviewProject?> GetProjectAsync(string projectId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            return _projects.TryGetValue(projectId, out var project) ? project : null;
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task<IReadOnlyList<ReviewProject>> GetProjectsAsync(CancellationToken ct = default)
+    {
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            return _projects.Values.ToList();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task DeleteProjectAsync(string projectId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            var dir = Path.Combine(_reviewsRoot, projectId);
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+
+            if (_projects.Remove(projectId))
+            {
+                if (_stageIdsByProject.TryGetValue(projectId, out var stageIds))
+                {
+                    foreach (var stageId in stageIds)
+                    {
+                        _stageDocs.Remove(stageId);
+                        _stages.Remove(stageId);
+                        if (_assignmentIdsByStage.TryGetValue(stageId, out var assignmentIds))
+                        {
+                            foreach (var assignmentId in assignmentIds)
+                            {
+                                _assignmentDocs.Remove(assignmentId);
+                                _assignments.Remove(assignmentId);
+                            }
+                            _assignmentIdsByStage.Remove(stageId);
+                        }
+                    }
+                    _stageIdsByProject.Remove(projectId);
+                }
+
+                if (_formIdsByProject.TryGetValue(projectId, out var formIds))
+                {
+                    foreach (var formId in formIds)
+                    {
+                        _formDocs.Remove(FormKey(projectId, formId));
+                        _formResponses.Remove(FormKey(projectId, formId));
+                    }
+                    _formIdsByProject.Remove(projectId);
+                }
+            }
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task SaveStageAsync(ReviewStage stage, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(stage);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            if (!_projects.ContainsKey(stage.ProjectId))
+            {
+                throw new InvalidOperationException($"Project '{stage.ProjectId}' must be saved before stages can be persisted.");
+            }
+
+            var doc = StageMapper.FromDomain(stage);
+            var path = GetStagePath(stage.ProjectId, stage.Id);
+            await WriteJsonAsync(path, doc, ct).ConfigureAwait(false);
+
+            _stageDocs[stage.Id] = doc;
+            _stageIdsByProject.TryAdd(stage.ProjectId, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+            _stageIdsByProject[stage.ProjectId].Add(stage.Id);
+            _stages[stage.Id] = stage;
+            if (!_assignmentIdsByStage.ContainsKey(stage.Id))
+            {
+                _assignmentIdsByStage[stage.Id] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task<ReviewStage?> GetStageAsync(string stageId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stageId);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            return _stages.TryGetValue(stageId, out var stage) ? stage : null;
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task<IReadOnlyList<ReviewStage>> GetStagesByProjectAsync(string projectId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            if (!_stageIdsByProject.TryGetValue(projectId, out var ids))
+            {
+                return Array.Empty<ReviewStage>();
+            }
+
+            return ids.Select(id => _stages[id]).ToList();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task DeleteStageAsync(string projectId, string stageId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(stageId);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            var path = GetStagePath(projectId, stageId);
+            DeleteFileIfExists(path);
+
+            if (_stageDocs.Remove(stageId))
+            {
+                _stages.Remove(stageId);
+            }
+
+            if (_stageIdsByProject.TryGetValue(projectId, out var ids))
+            {
+                ids.Remove(stageId);
+                if (ids.Count == 0)
+                {
+                    _stageIdsByProject.Remove(projectId);
+                }
+            }
+
+            if (_assignmentIdsByStage.TryGetValue(stageId, out var assignmentIds))
+            {
+                foreach (var assignmentId in assignmentIds)
+                {
+                    var assignmentPath = GetAssignmentPath(projectId, assignmentId);
+                    DeleteFileIfExists(assignmentPath);
+                    _assignmentDocs.Remove(assignmentId);
+                    _assignments.Remove(assignmentId);
+                }
+
+                _assignmentIdsByStage.Remove(stageId);
+            }
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task SaveAssignmentAsync(string projectId, ScreeningAssignment assignment, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentNullException.ThrowIfNull(assignment);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            if (!_stageDocs.TryGetValue(assignment.StageId, out var stageDoc) || !string.Equals(stageDoc.ProjectId, projectId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Stage '{assignment.StageId}' must be saved before assignments can be persisted.");
+            }
+
+            var doc = AssignmentMapper.FromDomain(projectId, assignment);
+            var path = GetAssignmentPath(projectId, assignment.Id);
+            await WriteJsonAsync(path, doc, ct).ConfigureAwait(false);
+
+            _assignmentDocs[assignment.Id] = doc;
+            _assignments[assignment.Id] = assignment;
+            if (!_assignmentIdsByStage.ContainsKey(assignment.StageId))
+            {
+                _assignmentIdsByStage[assignment.StageId] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+            _assignmentIdsByStage[assignment.StageId].Add(assignment.Id);
+
+            RebuildStage(assignment.StageId);
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task<ScreeningAssignment?> GetAssignmentAsync(string assignmentId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assignmentId);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            return _assignments.TryGetValue(assignmentId, out var assignment) ? assignment : null;
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task<IReadOnlyList<ScreeningAssignment>> GetAssignmentsByStageAsync(string stageId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stageId);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            if (!_assignmentIdsByStage.TryGetValue(stageId, out var ids))
+            {
+                return Array.Empty<ScreeningAssignment>();
+            }
+
+            return ids.Select(id => _assignments[id]).ToList();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task DeleteAssignmentAsync(string projectId, string assignmentId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(assignmentId);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            var path = GetAssignmentPath(projectId, assignmentId);
+            DeleteFileIfExists(path);
+
+            if (_assignmentDocs.Remove(assignmentId, out var doc))
+            {
+                _assignments.Remove(assignmentId);
+                if (_assignmentIdsByStage.TryGetValue(doc.StageId, out var ids))
+                {
+                    ids.Remove(assignmentId);
+                    if (ids.Count == 0)
+                    {
+                        _assignmentIdsByStage.Remove(doc.StageId);
+                    }
+                }
+
+                RebuildStage(doc.StageId);
+            }
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task SaveFormResponseAsync(FormResponse response, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            if (!_projects.ContainsKey(response.ProjectId))
+            {
+                throw new InvalidOperationException($"Project '{response.ProjectId}' must be saved before form responses can be persisted.");
+            }
+
+            var doc = FormResponseMapper.FromDomain(response, _jsonOptions);
+            var path = GetFormResponsePath(response.ProjectId, response.Id);
+            await WriteJsonAsync(path, doc, ct).ConfigureAwait(false);
+
+            var key = FormKey(response.ProjectId, response.Id);
+            _formDocs[key] = doc;
+            _formResponses[key] = response;
+            _formIdsByProject.TryAdd(response.ProjectId, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+            _formIdsByProject[response.ProjectId].Add(response.Id);
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task<FormResponse?> GetFormResponseAsync(string projectId, string responseId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(responseId);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            var key = FormKey(projectId, responseId);
+            return _formResponses.TryGetValue(key, out var response) ? response : null;
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task<IReadOnlyList<FormResponse>> GetFormResponsesAsync(string projectId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            if (!_formIdsByProject.TryGetValue(projectId, out var ids))
+            {
+                return Array.Empty<FormResponse>();
+            }
+
+            return ids.Select(id => _formResponses[FormKey(projectId, id)]).ToList();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    internal async Task DeleteFormResponseAsync(string projectId, string responseId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(responseId);
+        await _mutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureInitialized();
+            var path = GetFormResponsePath(projectId, responseId);
+            DeleteFileIfExists(path);
+
+            var key = FormKey(projectId, responseId);
+            if (_formDocs.Remove(key))
+            {
+                _formResponses.Remove(key);
+            }
+
+            if (_formIdsByProject.TryGetValue(projectId, out var ids))
+            {
+                ids.Remove(responseId);
+                if (ids.Count == 0)
+                {
+                    _formIdsByProject.Remove(projectId);
+                }
+            }
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
- implement a JSON-backed review project store that caches projects, stages, assignments, and form responses with lock-protected writes
- split persistence documents and mappers into partial files for readability while reusing shared serialization helpers
- add integration tests that exercise initialization, concurrent writes, and stale lock handling via temporary workspaces

## Testing
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: SDK 8.0.414 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d678281970832bb4e8666691fdea34