### PR TITLE
Refactor staging editor into tabbed workflow

### DIFF
--- a/src/LM.App.Wpf.Tests/Dialogs/Staging/StagingEditorViewModelTests.cs
+++ b/src/LM.App.Wpf.Tests/Dialogs/Staging/StagingEditorViewModelTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Linq;
+using LM.App.Wpf.Common.Dialogs;
+using LM.App.Wpf.ViewModels;
+using LM.App.Wpf.ViewModels.Dialogs;
+using LM.App.Wpf.ViewModels.Dialogs.Staging;
+using LM.Core.Abstractions;
+using LM.Infrastructure.FileSystem;
+using LM.Infrastructure.Hooks;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.Dialogs.Staging
+{
+    public sealed class StagingEditorViewModelTests : IDisposable
+    {
+        private readonly WorkspaceService _workspace;
+        private readonly HookOrchestrator _orchestrator;
+
+        public StagingEditorViewModelTests()
+        {
+            _workspace = new WorkspaceService();
+            var root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "kw_editor_" + Guid.NewGuid().ToString("N"));
+            _workspace.EnsureWorkspaceAsync(root).GetAwaiter().GetResult();
+            _orchestrator = new HookOrchestrator(_workspace);
+        }
+
+        [Fact]
+        public void Constructor_Builds_All_Tabs()
+        {
+            var list = new StagingListViewModel(new StubPipeline());
+            var dialogService = new StubDialogService();
+            var tables = new StagingTablesTabViewModel(_workspace, dialogService, _orchestrator);
+
+            var editor = new StagingEditorViewModel(
+                list,
+                new StagingMetadataTabViewModel(list),
+                tables,
+                new StagingFiguresTabViewModel(),
+                new StagingEndpointsTabViewModel(),
+                new StagingPopulationTabViewModel(),
+                new StagingReviewCommitTabViewModel());
+
+            Assert.Equal(6, editor.Tabs.Count);
+            Assert.Equal("Metadata", editor.SelectedTab?.Header);
+
+            var item = new StagingItem { Title = "Example" };
+            list.Current = item;
+
+            var metadata = editor.Tabs.OfType<StagingMetadataTabViewModel>().First();
+            Assert.Equal(item, metadata.Current);
+
+            editor.Dispose();
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (_workspace.WorkspacePath is not null && System.IO.Directory.Exists(_workspace.WorkspacePath))
+                    System.IO.Directory.Delete(_workspace.WorkspacePath, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+
+        private sealed class StubPipeline : IAddPipeline
+        {
+            public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<StagingItem>> StagePathsAsync(System.Collections.Generic.IEnumerable<string> paths, System.Threading.CancellationToken ct)
+                => System.Threading.Tasks.Task.FromResult<System.Collections.Generic.IReadOnlyList<StagingItem>>(Array.Empty<StagingItem>());
+
+            public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<StagingItem>> CommitAsync(System.Collections.Generic.IEnumerable<StagingItem> selectedRows, System.Threading.CancellationToken ct)
+                => System.Threading.Tasks.Task.FromResult<System.Collections.Generic.IReadOnlyList<StagingItem>>(Array.Empty<StagingItem>());
+        }
+
+        private sealed class StubDialogService : IDialogService
+        {
+            public string[]? ShowOpenFileDialog(FilePickerOptions options) => Array.Empty<string>();
+            public string? ShowFolderBrowserDialog(FolderPickerOptions options) => null;
+            public bool? ShowStagingEditor(StagingListViewModel stagingList) => false;
+        }
+    }
+}

--- a/src/LM.App.Wpf.Tests/Dialogs/Staging/StagingEndpointsTabViewModelTests.cs
+++ b/src/LM.App.Wpf.Tests/Dialogs/Staging/StagingEndpointsTabViewModelTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using LM.App.Wpf.ViewModels;
+using LM.App.Wpf.ViewModels.Dialogs.Staging;
+using LM.HubSpoke.Models;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.Dialogs.Staging
+{
+    public sealed class StagingEndpointsTabViewModelTests
+    {
+        [Fact]
+        public void Confirming_Endpoint_Updates_Model()
+        {
+            var hook = new DataExtractionHook
+            {
+                Populations = new List<DataExtractionPopulation>
+                {
+                    new DataExtractionPopulation { Id = "p1", Label = "Adults" }
+                },
+                Interventions = new List<DataExtractionIntervention>
+                {
+                    new DataExtractionIntervention { Id = "i1", Name = "Drug A" }
+                },
+                Endpoints = new List<DataExtractionEndpoint>
+                {
+                    new DataExtractionEndpoint
+                    {
+                        Id = "e1",
+                        Name = "Mortality",
+                        PopulationIds = new List<string> { "p1" },
+                        InterventionIds = new List<string> { "i1" },
+                        Confirmed = false
+                    }
+                }
+            };
+
+            var item = new StagingItem
+            {
+                DataExtractionHook = hook
+            };
+
+            var viewModel = new StagingEndpointsTabViewModel();
+            viewModel.Update(item);
+
+            var endpoint = Assert.Single(viewModel.Endpoints);
+            Assert.False(endpoint.IsConfirmed);
+
+            endpoint.IsConfirmed = true;
+
+            Assert.True(item.DataExtractionHook!.Endpoints[0].Confirmed);
+        }
+    }
+}

--- a/src/LM.App.Wpf.Tests/Dialogs/Staging/StagingTablesTabViewModelTests.cs
+++ b/src/LM.App.Wpf.Tests/Dialogs/Staging/StagingTablesTabViewModelTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using LM.App.Wpf.Common.Dialogs;
+using LM.App.Wpf.ViewModels;
+using LM.App.Wpf.ViewModels.Dialogs.Staging;
+using LM.Core.Models;
+using LM.Core.Models.DataExtraction;
+using LM.HubSpoke.Models;
+using LM.Infrastructure.FileSystem;
+using LM.Infrastructure.Hooks;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.Dialogs.Staging
+{
+    public sealed class StagingTablesTabViewModelTests : IDisposable
+    {
+        private readonly string _workspaceRoot;
+        private readonly WorkspaceService _workspace;
+        private readonly HookOrchestrator _orchestrator;
+
+        public StagingTablesTabViewModelTests()
+        {
+            _workspaceRoot = Path.Combine(Path.GetTempPath(), "kw_tests_" + Guid.NewGuid().ToString("N"));
+            _workspace = new WorkspaceService();
+            _workspace.EnsureWorkspaceAsync(_workspaceRoot).GetAwaiter().GetResult();
+            _orchestrator = new HookOrchestrator(_workspace);
+        }
+
+        [Fact]
+        public void Classification_Update_Persists_To_DataExtractionHook()
+        {
+            var dialog = new StubDialogService();
+            var viewModel = new StagingTablesTabViewModel(_workspace, dialog, _orchestrator);
+            var item = BuildItem();
+
+            viewModel.Update(item);
+            var row = Assert.Single(viewModel.Tables);
+
+            row.Classification = TableClassificationKind.Baseline;
+
+            Assert.Equal("Baseline", item.DataExtractionHook!.Tables[0].Caption);
+        }
+
+        [Fact]
+        public async Task Reupload_Updates_SourcePath_And_ChangeLog()
+        {
+            var tempCsv = Path.Combine(_workspaceRoot, "source.csv");
+            await File.WriteAllTextAsync(tempCsv, "col1,col2\n1,2\n");
+
+            var dialog = new StubDialogService(tempCsv);
+            var viewModel = new StagingTablesTabViewModel(_workspace, dialog, _orchestrator);
+            var item = BuildItem();
+            item.AttachToEntryId = null; // avoid writing changelog to disk
+
+            viewModel.Update(item);
+            var row = Assert.Single(viewModel.Tables);
+            viewModel.SelectedTable = row;
+
+            await viewModel.ReuploadDigitizedCommand.ExecuteAsync(row);
+
+            var updatedTable = item.DataExtractionHook!.Tables[0];
+            Assert.False(string.IsNullOrWhiteSpace(updatedTable.SourcePath));
+            var absolute = _workspace.GetAbsolutePath(updatedTable.SourcePath!);
+            Assert.True(File.Exists(absolute));
+            Assert.StartsWith("sha256-", updatedTable.ProvenanceHash, StringComparison.OrdinalIgnoreCase);
+
+            Assert.Single(item.PendingChangeLogEvents);
+            var change = item.PendingChangeLogEvents[0];
+            Assert.Equal("DigitizedCsvUpdated", change.Action);
+            Assert.Equal(Environment.UserName ?? "unknown", change.PerformedBy);
+            Assert.Equal(item.DataExtractionHook.ExtractedBy, change.PerformedBy);
+        }
+
+        private static StagingItem BuildItem()
+        {
+            var preview = new StagingEvidencePreview
+            {
+                Tables = new List<StagingEvidencePreview.TablePreview>
+                {
+                    new StagingEvidencePreview.TablePreview
+                    {
+                        Title = "Table 1",
+                        Classification = TableClassificationKind.Unknown,
+                        Populations = new List<string> { "Adults" },
+                        Endpoints = new List<string> { "Mortality" },
+                        Pages = new List<int> { 1 }
+                    }
+                }
+            };
+
+            var extraction = new DataExtractionHook
+            {
+                Tables = new List<DataExtractionTable>
+                {
+                    new DataExtractionTable
+                    {
+                        Title = "Table 1",
+                        Caption = TableClassificationKind.Unknown.ToString(),
+                        SourcePath = string.Empty,
+                        Pages = new List<string> { "1" },
+                        LinkedEndpointIds = new List<string>(),
+                        LinkedInterventionIds = new List<string>()
+                    }
+                }
+            };
+
+            return new StagingItem
+            {
+                FilePath = Path.Combine(Path.GetTempPath(), "alpha.pdf"),
+                Title = "Sample",
+                EvidencePreview = preview,
+                DataExtractionHook = extraction
+            };
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(_workspaceRoot))
+                    Directory.Delete(_workspaceRoot, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+
+        private sealed class StubDialogService : IDialogService
+        {
+            private readonly string? _path;
+
+            public StubDialogService(string? path = null)
+            {
+                _path = path;
+            }
+
+            public string[]? ShowOpenFileDialog(FilePickerOptions options)
+                => _path is null ? Array.Empty<string>() : new[] { _path };
+
+            public string? ShowFolderBrowserDialog(FolderPickerOptions options) => null;
+
+            public bool? ShowStagingEditor(StagingListViewModel stagingList) => false;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Composition/Modules/AddModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/AddModule.cs
@@ -2,6 +2,7 @@ using LM.App.Wpf.Common.Dialogs;
 using LM.App.Wpf.ViewModels;
 using LM.App.Wpf.ViewModels.Dialogs;
 using LM.App.Wpf.Views;
+using LM.App.Wpf.ViewModels.Dialogs.Staging;
 using LM.Core.Abstractions;
 using LM.Core.Abstractions.Configuration;
 using LM.HubSpoke.Abstractions;
@@ -33,6 +34,12 @@ namespace LM.App.Wpf.Composition.Modules
 
             services.AddSingleton<WatchedFolderScanner>(sp => new WatchedFolderScanner(sp.GetRequiredService<IAddPipeline>()));
             services.AddSingleton<IDialogService, WpfDialogService>();
+            services.AddTransient<StagingMetadataTabViewModel>();
+            services.AddTransient<StagingTablesTabViewModel>();
+            services.AddTransient<StagingFiguresTabViewModel>();
+            services.AddTransient<StagingEndpointsTabViewModel>();
+            services.AddTransient<StagingPopulationTabViewModel>();
+            services.AddTransient<StagingReviewCommitTabViewModel>();
             services.AddTransient<StagingEditorViewModel>();
             services.AddTransient<StagingEditorWindow>();
             services.AddSingleton<StagingListViewModel>(sp => new StagingListViewModel(sp.GetRequiredService<IAddPipeline>()));

--- a/src/LM.App.Wpf/ViewModels/Add/AddPipeline.cs
+++ b/src/LM.App.Wpf/ViewModels/Add/AddPipeline.cs
@@ -774,6 +774,17 @@ namespace LM.App.Wpf.ViewModels
             var article = BuildArticleHook(stagingItem, entry, relativePath, sha256);
             var changeLog = BuildEntryCreationChangeLog(entry, addedBy);
 
+            if (stagingItem.PendingChangeLogEvents.Count > 0)
+            {
+                changeLog ??= new HookM.EntryChangeLogHook();
+                foreach (var evt in stagingItem.PendingChangeLogEvents)
+                {
+                    if (evt is null)
+                        continue;
+                    changeLog.Events.Add(evt);
+                }
+            }
+
             if (article is null && changeLog is null)
                 return null;
 

--- a/src/LM.App.Wpf/ViewModels/Add/StagingItem.cs
+++ b/src/LM.App.Wpf/ViewModels/Add/StagingItem.cs
@@ -1,10 +1,10 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using LM.Core.Models;
-// NEW:
-using LM.HubSpoke.Models;
+using HookM = LM.HubSpoke.Models;
 
 namespace LM.App.Wpf.ViewModels
 {
@@ -88,8 +88,9 @@ namespace LM.App.Wpf.ViewModels
         public bool Internal { get => IsInternal; set => IsInternal = value; }
 
         // NEW: the fully-populated hooks built at staging
-        public ArticleHook? ArticleHook { get; set; }
+        public HookM.ArticleHook? ArticleHook { get; set; }
         public HookM.DataExtractionHook? DataExtractionHook { get; set; }
+        public List<HookM.EntryChangeLogEvent> PendingChangeLogEvents { get; } = new();
         public StagingEvidencePreview? EvidencePreview { get; set; }
     }
 }

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingEndpointViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingEndpointViewModel.cs
@@ -1,0 +1,55 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal sealed class StagingEndpointViewModel : ObservableObject
+    {
+        private readonly Action<StagingEndpointViewModel> _stateChanged;
+        private bool _confirmed;
+
+        public StagingEndpointViewModel(HookM.DataExtractionEndpoint endpoint,
+                                        IReadOnlyList<string> populationLabels,
+                                        IReadOnlyList<string> interventionLabels,
+                                        Action<StagingEndpointViewModel> stateChanged)
+        {
+            Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+            _stateChanged = stateChanged ?? throw new ArgumentNullException(nameof(stateChanged));
+
+            Name = string.IsNullOrWhiteSpace(endpoint.Name) ? "Endpoint" : endpoint.Name;
+            Populations = string.Join(", ", populationLabels ?? Array.Empty<string>());
+            Interventions = string.Join(", ", interventionLabels ?? Array.Empty<string>());
+            _confirmed = endpoint.Confirmed;
+        }
+
+        public HookM.DataExtractionEndpoint Endpoint { get; private set; }
+
+        public string Id => Endpoint.Id;
+
+        public string Name { get; }
+
+        public string Populations { get; }
+
+        public string Interventions { get; }
+
+        public bool IsConfirmed
+        {
+            get => _confirmed;
+            set
+            {
+                if (SetProperty(ref _confirmed, value))
+                    _stateChanged(this);
+            }
+        }
+
+        public void UpdateEndpoint(HookM.DataExtractionEndpoint endpoint)
+        {
+            Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingEndpointsTabViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingEndpointsTabViewModel.cs
@@ -1,0 +1,101 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using LM.App.Wpf.ViewModels;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal sealed class StagingEndpointsTabViewModel : StagingTabViewModel
+    {
+        public StagingEndpointsTabViewModel()
+            : base("Endpoints")
+        {
+        }
+
+        public ObservableCollection<StagingEndpointViewModel> Endpoints { get; } = new();
+
+        protected override void OnItemUpdated(StagingItem? item)
+        {
+            Endpoints.Clear();
+
+            if (item?.DataExtractionHook is null)
+                return;
+
+            var hook = item.DataExtractionHook;
+            var populationLookup = hook.Populations.ToDictionary(p => p.Id, p => p.Label ?? p.Id, StringComparer.OrdinalIgnoreCase);
+            var interventionLookup = hook.Interventions.ToDictionary(i => i.Id, i => i.Name ?? i.Id, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var endpoint in hook.Endpoints)
+            {
+                if (endpoint is null)
+                    continue;
+
+                var populations = endpoint.PopulationIds
+                    .Select(id => populationLookup.TryGetValue(id, out var label) ? label : id)
+                    .ToList();
+                var interventions = endpoint.InterventionIds
+                    .Select(id => interventionLookup.TryGetValue(id, out var label) ? label : id)
+                    .ToList();
+
+                var viewModel = new StagingEndpointViewModel(endpoint, populations, interventions, OnEndpointStateChanged);
+                Endpoints.Add(viewModel);
+            }
+        }
+
+        protected override void RefreshValidation()
+        {
+            if (Item is null)
+            {
+                SetValidationMessages(new[] { "Select a staged item to review endpoints." });
+                return;
+            }
+
+            if (Endpoints.Count == 0)
+            {
+                SetValidationMessages(Array.Empty<string>());
+                return;
+            }
+
+            var messages = new List<string>();
+            if (Endpoints.Any(static e => !e.IsConfirmed))
+                messages.Add("Confirm extracted endpoints before committing.");
+
+            SetValidationMessages(messages);
+        }
+
+        private void OnEndpointStateChanged(StagingEndpointViewModel viewModel)
+        {
+            if (Item?.DataExtractionHook is null)
+                return;
+
+            var endpoints = Item.DataExtractionHook.Endpoints;
+            var index = endpoints.FindIndex(e => e.Id == viewModel.Id);
+            if (index < 0)
+                return;
+
+            var source = endpoints[index];
+            var updated = new HookM.DataExtractionEndpoint
+            {
+                Id = source.Id,
+                Name = source.Name,
+                Description = source.Description,
+                Timepoint = source.Timepoint,
+                Measure = source.Measure,
+                PopulationIds = new List<string>(source.PopulationIds),
+                InterventionIds = new List<string>(source.InterventionIds),
+                ResultSummary = source.ResultSummary,
+                EffectSize = source.EffectSize,
+                Notes = source.Notes,
+                Confirmed = viewModel.IsConfirmed
+            };
+
+            endpoints[index] = updated;
+            viewModel.UpdateEndpoint(updated);
+            RefreshValidation();
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingFigureViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingFigureViewModel.cs
@@ -1,0 +1,41 @@
+#nullable enable
+
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using LM.App.Wpf.ViewModels;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal sealed class StagingFigureViewModel : ObservableObject
+    {
+        private HookM.DataExtractionFigure _hook;
+
+        public StagingFigureViewModel(HookM.DataExtractionFigure hook, StagingEvidencePreview.FigurePreview? preview)
+        {
+            _hook = hook ?? throw new ArgumentNullException(nameof(hook));
+            Title = string.IsNullOrWhiteSpace(hook.Title) ? preview?.Caption ?? "Figure" : hook.Title;
+            Caption = preview?.Caption ?? hook.Caption ?? string.Empty;
+            Pages = string.Join(", ", hook.Pages);
+        }
+
+        public string Id => _hook.Id;
+
+        public string Title { get; }
+
+        public string Caption { get; }
+
+        public string Pages { get; }
+
+        public string SourcePath => _hook.SourcePath ?? string.Empty;
+
+        public string ProvenanceHash => _hook.ProvenanceHash ?? string.Empty;
+
+        public void Update(HookM.DataExtractionFigure hook)
+        {
+            _hook = hook ?? throw new ArgumentNullException(nameof(hook));
+            OnPropertyChanged(nameof(SourcePath));
+            OnPropertyChanged(nameof(ProvenanceHash));
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingFiguresTabViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingFiguresTabViewModel.cs
@@ -1,0 +1,70 @@
+#nullable enable
+
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using LM.App.Wpf.ViewModels;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal sealed class StagingFiguresTabViewModel : StagingTabViewModel
+    {
+        private StagingFigureViewModel? _selected;
+
+        public StagingFiguresTabViewModel()
+            : base("Figures")
+        {
+        }
+
+        public ObservableCollection<StagingFigureViewModel> Figures { get; } = new();
+
+        public StagingFigureViewModel? Selected
+        {
+            get => _selected;
+            set => SetProperty(ref _selected, value);
+        }
+
+        protected override void OnItemUpdated(StagingItem? item)
+        {
+            Figures.Clear();
+            Selected = null;
+
+            if (item is null)
+                return;
+
+            item.DataExtractionHook ??= new HookM.DataExtractionHook
+            {
+                ExtractedAtUtc = DateTime.UtcNow,
+                ExtractedBy = Environment.UserName ?? "unknown"
+            };
+
+            var hookFigures = item.DataExtractionHook.Figures;
+            var previewFigures = item.EvidencePreview?.Figures ?? Array.Empty<StagingEvidencePreview.FigurePreview>();
+
+            for (var i = 0; i < Math.Max(hookFigures.Count, previewFigures.Count); i++)
+            {
+                if (i >= hookFigures.Count)
+                    hookFigures.Add(new HookM.DataExtractionFigure());
+
+                var hook = hookFigures[i];
+                var preview = previewFigures.ElementAtOrDefault(i);
+                var viewModel = new StagingFigureViewModel(hook, preview);
+                Figures.Add(viewModel);
+            }
+
+            Selected = Figures.FirstOrDefault();
+        }
+
+        protected override void RefreshValidation()
+        {
+            if (Item is null)
+            {
+                SetValidationMessages(new[] { "Select a staged item to inspect figures." });
+                return;
+            }
+
+            SetValidationMessages(Array.Empty<string>());
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingInterventionItemViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingInterventionItemViewModel.cs
@@ -1,0 +1,22 @@
+#nullable enable
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal sealed class StagingInterventionItemViewModel : ObservableObject
+    {
+        public StagingInterventionItemViewModel(HookM.DataExtractionIntervention intervention)
+        {
+            Intervention = intervention;
+            Name = string.IsNullOrWhiteSpace(intervention.Name) ? intervention.Id : intervention.Name;
+        }
+
+        public HookM.DataExtractionIntervention Intervention { get; }
+
+        public string Id => Intervention.Id;
+
+        public string Name { get; }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingMetadataTabViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingMetadataTabViewModel.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using LM.App.Wpf.ViewModels;
+using LM.Core.Models;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal sealed class StagingMetadataTabViewModel : StagingTabViewModel
+    {
+        private readonly StagingListViewModel _stagingList;
+
+        public StagingMetadataTabViewModel(StagingListViewModel stagingList)
+            : base("Metadata")
+        {
+            _stagingList = stagingList ?? throw new ArgumentNullException(nameof(stagingList));
+        }
+
+        public StagingItem? Current => _stagingList.Current;
+
+        public Array EntryTypes => _stagingList.EntryTypes;
+
+        public string IndexLabel => _stagingList.IndexLabel;
+
+        public bool IsDuplicate => Current?.IsDuplicate ?? false;
+
+        public bool IsNearMatch => Current?.IsNearMatch ?? false;
+
+        protected override void OnItemUpdated(StagingItem? item)
+        {
+            OnPropertyChanged(nameof(Current));
+            OnPropertyChanged(nameof(IndexLabel));
+            OnPropertyChanged(nameof(IsDuplicate));
+            OnPropertyChanged(nameof(IsNearMatch));
+        }
+
+        protected override void RefreshValidation()
+        {
+            var messages = new List<string>();
+            if (Current is null)
+            {
+                messages.Add("Select a staged item to edit metadata.");
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(Current.Title))
+                    messages.Add("Title is required before committing.");
+
+                if (Current.Type == EntryType.Publication && string.IsNullOrWhiteSpace(Current.AuthorsCsv))
+                    messages.Add("Consider providing authors for publications.");
+            }
+
+            SetValidationMessages(messages);
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingPopulationItemViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingPopulationItemViewModel.cs
@@ -1,0 +1,22 @@
+#nullable enable
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal sealed class StagingPopulationItemViewModel : ObservableObject
+    {
+        public StagingPopulationItemViewModel(HookM.DataExtractionPopulation population)
+        {
+            Population = population;
+            Label = string.IsNullOrWhiteSpace(population.Label) ? population.Id : population.Label;
+        }
+
+        public HookM.DataExtractionPopulation Population { get; }
+
+        public string Id => Population.Id;
+
+        public string Label { get; }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingPopulationTabViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingPopulationTabViewModel.cs
@@ -1,0 +1,59 @@
+#nullable enable
+
+using System;
+using System.Collections.ObjectModel;
+using LM.App.Wpf.ViewModels;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal sealed class StagingPopulationTabViewModel : StagingTabViewModel
+    {
+        public StagingPopulationTabViewModel()
+            : base("Population")
+        {
+        }
+
+        public ObservableCollection<StagingPopulationItemViewModel> Populations { get; } = new();
+
+        public ObservableCollection<StagingInterventionItemViewModel> Interventions { get; } = new();
+
+        protected override void OnItemUpdated(StagingItem? item)
+        {
+            Populations.Clear();
+            Interventions.Clear();
+
+            if (item?.DataExtractionHook is null)
+                return;
+
+            foreach (var population in item.DataExtractionHook.Populations)
+            {
+                if (population is null)
+                    continue;
+                Populations.Add(new StagingPopulationItemViewModel(population));
+            }
+
+            foreach (var intervention in item.DataExtractionHook.Interventions)
+            {
+                if (intervention is null)
+                    continue;
+                Interventions.Add(new StagingInterventionItemViewModel(intervention));
+            }
+        }
+
+        protected override void RefreshValidation()
+        {
+            if (Item is null)
+            {
+                SetValidationMessages(new[] { "Select a staged item to inspect population details." });
+                return;
+            }
+
+            var issues = Populations.Count == 0
+                ? new[] { "No populations detected; confirm extraction coverage." }
+                : Array.Empty<string>();
+
+            SetValidationMessages(issues);
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingReviewCommitTabViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingReviewCommitTabViewModel.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal sealed class StagingReviewCommitTabViewModel : StagingTabViewModel
+    {
+        private IReadOnlyList<StagingTabViewModel>? _tabs;
+
+        public StagingReviewCommitTabViewModel()
+            : base("Review & Commit")
+        {
+        }
+
+        public ObservableCollection<string> Messages { get; } = new();
+
+        public bool IsReady => Messages.Count == 0;
+
+        public void Sync(StagingItem? item, IReadOnlyList<StagingTabViewModel> tabs)
+        {
+            _tabs = tabs ?? Array.Empty<StagingTabViewModel>();
+            Update(item);
+        }
+
+        protected override void OnItemUpdated(StagingItem? item)
+        {
+            // nothing extra; validation covers summary state.
+        }
+
+        protected override void RefreshValidation()
+        {
+            var collected = new List<string>();
+
+            if (Item is null)
+            {
+                collected.Add("Select a staged item to review before committing.");
+            }
+            else if (_tabs is not null)
+            {
+                foreach (var tab in _tabs.Where(t => !ReferenceEquals(t, this) && !t.IsValid))
+                {
+                    collected.AddRange(tab.ValidationErrors.Select(msg => $"{tab.Header}: {msg}"));
+                }
+            }
+
+            Messages.Clear();
+            foreach (var message in collected.Where(static m => !string.IsNullOrWhiteSpace(m)))
+            {
+                Messages.Add(message);
+            }
+
+            SetValidationMessages(collected);
+            OnPropertyChanged(nameof(IsReady));
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingTabViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingTabViewModel.cs
@@ -1,0 +1,62 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using LM.App.Wpf.ViewModels;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal abstract class StagingTabViewModel : ObservableObject
+    {
+        private bool _isActive;
+        private StagingItem? _currentItem;
+
+        protected StagingTabViewModel(string header)
+        {
+            Header = header ?? throw new ArgumentNullException(nameof(header));
+        }
+
+        public string Header { get; }
+
+        public bool IsActive
+        {
+            get => _isActive;
+            set => SetProperty(ref _isActive, value);
+        }
+
+        protected StagingItem? Item => _currentItem;
+
+        public ObservableCollection<string> ValidationErrors { get; } = new();
+
+        public virtual bool IsValid => ValidationErrors.Count == 0;
+
+        public void Update(StagingItem? item)
+        {
+            _currentItem = item;
+            OnItemUpdated(item);
+            RefreshValidation();
+        }
+
+        protected abstract void OnItemUpdated(StagingItem? item);
+
+        protected virtual void RefreshValidation()
+        {
+            ValidationErrors.Clear();
+            OnPropertyChanged(nameof(IsValid));
+        }
+
+        protected void SetValidationMessages(IEnumerable<string> messages)
+        {
+            ValidationErrors.Clear();
+            foreach (var message in messages.Where(static m => !string.IsNullOrWhiteSpace(m)))
+            {
+                ValidationErrors.Add(message);
+            }
+
+            OnPropertyChanged(nameof(IsValid));
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingTableRowViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingTableRowViewModel.cs
@@ -1,0 +1,80 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+using LM.App.Wpf.ViewModels;
+using LM.Core.Models.DataExtraction;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal sealed class StagingTableRowViewModel : ObservableObject
+    {
+        private readonly Action<StagingTableRowViewModel> _classificationChanged;
+        private TableClassificationKind _classification;
+        private HookM.DataExtractionTable _hook;
+
+        public StagingTableRowViewModel(HookM.DataExtractionTable hook,
+                                        StagingEvidencePreview.TablePreview? preview,
+                                        Action<StagingTableRowViewModel> classificationChanged)
+        {
+            _hook = hook ?? throw new ArgumentNullException(nameof(hook));
+            _classificationChanged = classificationChanged ?? throw new ArgumentNullException(nameof(classificationChanged));
+
+            Title = string.IsNullOrWhiteSpace(hook.Title) ? preview?.Title ?? "Table" : hook.Title;
+            Populations = preview?.Populations ?? Array.Empty<string>();
+            Endpoints = preview?.Endpoints ?? Array.Empty<string>();
+            Pages = preview?.Pages ?? Array.Empty<int>();
+
+            _classification = TryParseClassification(hook.Caption, preview?.Classification) ?? TableClassificationKind.Unknown;
+        }
+
+        public string Id => _hook.Id;
+
+        public string Title { get; }
+
+        public IReadOnlyList<string> Populations { get; }
+
+        public IReadOnlyList<string> Endpoints { get; }
+
+        public IReadOnlyList<int> Pages { get; }
+
+        public string PopulationSummary => string.Join(", ", Populations);
+
+        public string EndpointSummary => string.Join(", ", Endpoints);
+
+        public string PageSummary => string.Join(", ", Pages);
+
+        public string SourcePath => _hook.SourcePath ?? string.Empty;
+
+        public string ProvenanceHash => _hook.ProvenanceHash ?? string.Empty;
+
+        public TableClassificationKind Classification
+        {
+            get => _classification;
+            set
+            {
+                if (SetProperty(ref _classification, value))
+                    _classificationChanged(this);
+            }
+        }
+
+        public void UpdateHook(HookM.DataExtractionTable updated)
+        {
+            _hook = updated ?? throw new ArgumentNullException(nameof(updated));
+            OnPropertyChanged(nameof(SourcePath));
+            OnPropertyChanged(nameof(ProvenanceHash));
+        }
+
+        public HookM.DataExtractionTable Snapshot => _hook;
+
+        private static TableClassificationKind? TryParseClassification(string? caption, TableClassificationKind? fallback)
+        {
+            if (!string.IsNullOrWhiteSpace(caption) && Enum.TryParse<TableClassificationKind>(caption, true, out var parsed))
+                return parsed;
+
+            return fallback;
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingTablesTabViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingTablesTabViewModel.cs
@@ -1,0 +1,318 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Globalization;
+using CommunityToolkit.Mvvm.Input;
+using LM.App.Wpf.Common.Dialogs;
+using LM.App.Wpf.ViewModels;
+using LM.Core.Abstractions;
+using LM.Core.Models;
+using LM.Core.Models.DataExtraction;
+using LM.Infrastructure.Hooks;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal sealed partial class StagingTablesTabViewModel : StagingTabViewModel
+    {
+        private readonly IWorkSpaceService _workspace;
+        private readonly IDialogService _dialogs;
+        private readonly HookOrchestrator _hookOrchestrator;
+        private StagingTableRowViewModel? _selectedTable;
+
+        public StagingTablesTabViewModel(IWorkSpaceService workspace,
+                                         IDialogService dialogs,
+                                         HookOrchestrator hookOrchestrator)
+            : base("Tables")
+        {
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+            _dialogs = dialogs ?? throw new ArgumentNullException(nameof(dialogs));
+            _hookOrchestrator = hookOrchestrator ?? throw new ArgumentNullException(nameof(hookOrchestrator));
+        }
+
+        public ObservableCollection<StagingTableRowViewModel> Tables { get; } = new();
+
+        public IReadOnlyList<TableClassificationKind> ClassificationOptions { get; } = Enum.GetValues<TableClassificationKind>();
+
+        public StagingTableRowViewModel? SelectedTable
+        {
+            get => _selectedTable;
+            set => SetProperty(ref _selectedTable, value);
+        }
+
+        protected override void OnItemUpdated(StagingItem? item)
+        {
+            Tables.Clear();
+            SelectedTable = null;
+
+            if (item is null)
+                return;
+
+            item.DataExtractionHook ??= CreateEmptyExtractionHook();
+
+            var previewTables = item.EvidencePreview?.Tables ?? Array.Empty<StagingEvidencePreview.TablePreview>();
+            var hookTables = item.DataExtractionHook.Tables;
+
+            for (var i = 0; i < Math.Max(previewTables.Count, hookTables.Count); i++)
+            {
+                if (i >= hookTables.Count)
+                {
+                    var fallback = previewTables.ElementAtOrDefault(i);
+                    hookTables.Add(CreateTableFromPreview(fallback));
+                }
+
+                var hookTable = hookTables[i];
+                var preview = previewTables.ElementAtOrDefault(i);
+                var row = new StagingTableRowViewModel(hookTable, preview, OnClassificationChanged);
+                Tables.Add(row);
+            }
+
+            SelectedTable = Tables.FirstOrDefault();
+        }
+
+        protected override void RefreshValidation()
+        {
+            if (Item is null)
+            {
+                SetValidationMessages(new[] { "Select a staged item to review tables." });
+                return;
+            }
+
+            var issues = new List<string>();
+            if (Tables.Count == 0)
+            {
+                issues.Add("No tables were detected for this staged evidence.");
+            }
+            else if (Tables.Any(static t => t.Classification == TableClassificationKind.Unknown))
+            {
+                issues.Add("Classify each table before committing evidence.");
+            }
+
+            SetValidationMessages(issues);
+        }
+
+        private void OnClassificationChanged(StagingTableRowViewModel row)
+        {
+            if (Item?.DataExtractionHook is null)
+                return;
+
+            var list = Item.DataExtractionHook.Tables;
+            var index = list.FindIndex(t => t.Id == row.Id);
+            if (index < 0)
+                return;
+
+            var existing = list[index];
+            var updated = CloneTable(existing, caption: row.Classification.ToString());
+            list[index] = updated;
+            row.UpdateHook(updated);
+            RefreshValidation();
+        }
+
+        [RelayCommand]
+        private void LaunchDigitizer(StagingTableRowViewModel? row)
+        {
+            if (row is null)
+                return;
+
+            var path = ResolveAbsolutePath(row.SourcePath, row.Id);
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+                return;
+
+            try
+            {
+                var info = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = path,
+                    UseShellExecute = true
+                };
+                System.Diagnostics.Process.Start(info);
+            }
+            catch
+            {
+                // Swallow: launching external tooling should not crash the dialog.
+            }
+        }
+
+        [RelayCommand]
+        private async Task ReuploadDigitizedAsync(StagingTableRowViewModel? row)
+        {
+            if (row is null || Item is null)
+                return;
+
+            var pick = _dialogs.ShowOpenFileDialog(new FilePickerOptions
+            {
+                AllowMultiple = false,
+                Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*"
+            });
+
+            var selected = pick?.FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(selected) || !File.Exists(selected))
+                return;
+
+            var absoluteTarget = ResolveAbsolutePath(row.SourcePath, row.Id);
+            if (string.IsNullOrWhiteSpace(absoluteTarget))
+                return;
+
+            Directory.CreateDirectory(Path.GetDirectoryName(absoluteTarget)!);
+            File.Copy(selected, absoluteTarget, overwrite: true);
+
+            var relative = NormalizeRelativePath(absoluteTarget);
+            var provenance = ComputeSha256Provenance(absoluteTarget);
+
+            var hook = Item.DataExtractionHook ?? CreateEmptyExtractionHook();
+            Item.DataExtractionHook = hook;
+
+            var tables = hook.Tables;
+            var index = tables.FindIndex(t => t.Id == row.Id);
+            if (index < 0)
+                return;
+
+            var updated = CloneTable(tables[index], sourcePath: relative, provenanceHash: provenance, caption: row.Classification.ToString());
+            tables[index] = updated;
+            row.UpdateHook(updated);
+
+            TouchExtractionMetadata(Item);
+            await AppendReuploadChangeLogAsync(Item, updated, CancellationToken.None).ConfigureAwait(false);
+
+            RefreshValidation();
+        }
+
+        private async Task AppendReuploadChangeLogAsync(StagingItem item, HookM.DataExtractionTable table, CancellationToken ct)
+        {
+            var evt = new HookM.EntryChangeLogEvent
+            {
+                EventId = Guid.NewGuid().ToString("N"),
+                TimestampUtc = DateTime.UtcNow,
+                PerformedBy = GetCurrentUserName(),
+                Action = "DigitizedCsvUpdated",
+                Details = new HookM.ChangeLogAttachmentDetails
+                {
+                    AttachmentId = table.Id,
+                    Title = table.Title,
+                    LibraryPath = table.SourcePath ?? string.Empty,
+                    Purpose = AttachmentKind.Supplement,
+                    Tags = new List<string>()
+                }
+            };
+
+            item.PendingChangeLogEvents.Add(evt);
+
+            if (!string.IsNullOrWhiteSpace(item.AttachToEntryId))
+            {
+                var ctx = new HookContext
+                {
+                    ChangeLog = new HookM.EntryChangeLogHook
+                    {
+                        Events = new List<HookM.EntryChangeLogEvent> { evt }
+                    }
+                };
+
+                await _hookOrchestrator.ProcessAsync(item.AttachToEntryId!, ctx, ct).ConfigureAwait(false);
+            }
+        }
+
+        private static HookM.DataExtractionHook CreateEmptyExtractionHook()
+            => new()
+            {
+                ExtractedAtUtc = DateTime.UtcNow,
+                ExtractedBy = GetCurrentUserName()
+            };
+
+        private static HookM.DataExtractionTable CreateTableFromPreview(StagingEvidencePreview.TablePreview? preview)
+        {
+            var title = preview?.Title;
+            if (string.IsNullOrWhiteSpace(title))
+                title = "Table";
+
+            return new HookM.DataExtractionTable
+            {
+                Title = title!,
+                Caption = preview?.Classification.ToString(),
+                SourcePath = string.Empty,
+                ProvenanceHash = string.Empty,
+                Pages = preview?.Pages.Select(static p => p.ToString(System.Globalization.CultureInfo.InvariantCulture)).ToList() ?? new List<string>()
+            };
+        }
+
+        private static HookM.DataExtractionTable CloneTable(HookM.DataExtractionTable source,
+                                                            string? caption = null,
+                                                            string? sourcePath = null,
+                                                            string? provenanceHash = null)
+        {
+            return new HookM.DataExtractionTable
+            {
+                Id = source.Id,
+                Title = source.Title,
+                Caption = caption ?? source.Caption,
+                SourcePath = sourcePath ?? source.SourcePath,
+                Pages = new List<string>(source.Pages),
+                LinkedEndpointIds = new List<string>(source.LinkedEndpointIds),
+                LinkedInterventionIds = new List<string>(source.LinkedInterventionIds),
+                ProvenanceHash = provenanceHash ?? source.ProvenanceHash,
+                Notes = source.Notes,
+                TableLabel = source.TableLabel,
+                Summary = source.Summary
+            };
+        }
+
+        private string ResolveAbsolutePath(string sourcePath, string tableId)
+        {
+            var normalized = sourcePath;
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                normalized = Path.Combine("staging", "manual", "tables", tableId + ".csv").Replace(Path.DirectorySeparatorChar, '/');
+            }
+
+            return _workspace.GetAbsolutePath(normalized);
+        }
+
+        private string NormalizeRelativePath(string absolute)
+        {
+            var root = _workspace.GetWorkspaceRoot();
+            var relative = Path.GetRelativePath(root, absolute);
+            return relative.Replace(Path.DirectorySeparatorChar, '/');
+        }
+
+        private static string ComputeSha256Provenance(string path)
+        {
+            using var stream = File.OpenRead(path);
+            using var sha = SHA256.Create();
+            var hash = sha.ComputeHash(stream);
+            var hex = Convert.ToHexString(hash).ToLowerInvariant();
+            return $"sha256-{hex}";
+        }
+
+        private static void TouchExtractionMetadata(StagingItem item)
+        {
+            var hook = item.DataExtractionHook;
+            if (hook is null)
+                return;
+
+            item.DataExtractionHook = new HookM.DataExtractionHook
+            {
+                SchemaVersion = hook.SchemaVersion,
+                ExtractedAtUtc = DateTime.UtcNow,
+                ExtractedBy = GetCurrentUserName(),
+                Populations = hook.Populations,
+                Interventions = hook.Interventions,
+                Endpoints = hook.Endpoints,
+                Figures = hook.Figures,
+                Tables = hook.Tables,
+                Notes = hook.Notes
+            };
+        }
+
+        private static string GetCurrentUserName()
+        {
+            var user = Environment.UserName;
+            return string.IsNullOrWhiteSpace(user) ? "unknown" : user;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/StagingEditorWindow.xaml
+++ b/src/LM.App.Wpf/Views/StagingEditorWindow.xaml
@@ -3,114 +3,98 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:core="clr-namespace:LM.Core.Models;assembly=LM.Core"
+        xmlns:swc="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
         mc:Ignorable="d"
         Title="Review staged items"
-        Height="520"
-        Width="800"
+        Height="540"
+        Width="900"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize">
   <Window.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="/LM.App.Wpf;component/Views/Templates/StagingEditorTemplates.xaml" />
+        <ResourceDictionary Source="/LM.App.Wpf;component/Views/Templates/Staging/StagingMetadataTemplates.xaml" />
+        <ResourceDictionary Source="/LM.App.Wpf;component/Views/Templates/Staging/StagingTablesTemplates.xaml" />
+        <ResourceDictionary Source="/LM.App.Wpf;component/Views/Templates/Staging/StagingFiguresTemplates.xaml" />
+        <ResourceDictionary Source="/LM.App.Wpf;component/Views/Templates/Staging/StagingEndpointsTemplates.xaml" />
+        <ResourceDictionary Source="/LM.App.Wpf;component/Views/Templates/Staging/StagingPopulationTemplates.xaml" />
+        <ResourceDictionary Source="/LM.App.Wpf;component/Views/Templates/Staging/StagingReviewTemplates.xaml" />
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
   </Window.Resources>
 
-  <Grid Margin="12" DataContext="{Binding StagingList}">
-    <Grid.RowDefinitions>
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="*" />
-      <RowDefinition Height="Auto" />
-    </Grid.RowDefinitions>
+  <swc:Grid Margin="12">
+    <swc:Grid.RowDefinitions>
+      <swc:RowDefinition Height="Auto" />
+      <swc:RowDefinition Height="*" />
+      <swc:RowDefinition Height="Auto" />
+    </swc:Grid.RowDefinitions>
 
-    <StackPanel Grid.Row="0"
-                Orientation="Horizontal"
-                Margin="0,0,0,8"
-                VerticalAlignment="Center">
-      <TextBlock Text="Review and edit metadata" FontWeight="Bold" />
-      <TextBlock Text="{Binding IndexLabel}" Margin="12,0,0,0" />
-
-      <TextBlock Text="Type:" Margin="24,0,6,0" VerticalAlignment="Center" />
-      <ComboBox ItemsSource="{Binding EntryTypes}"
-                SelectedItem="{Binding SelectedType, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                Width="150" />
-
-      <Border Background="#FFE0E0E0"
-              CornerRadius="4"
-              Padding="6,2"
-              Margin="16,0,0,0"
-              Visibility="{Binding Current.IsDuplicate, Converter={StaticResource BoolToVis}}">
-        <TextBlock Text="Exact duplicate in library" Foreground="#FF404040" FontWeight="SemiBold" />
-      </Border>
-
-      <Border Background="#FFFDEEB5"
-              CornerRadius="4"
-              Padding="6,2"
-              Margin="8,0,0,0"
-              Visibility="{Binding Current.IsNearMatch, Converter={StaticResource BoolToVis}}">
-        <TextBlock>
-          <Run Text="Near match: " />
-          <Run Text="{Binding Current.MatchedTitle}" FontStyle="Italic" />
-        </TextBlock>
-      </Border>
-    </StackPanel>
-
-    <Border Grid.Row="1">
-      <Border.Style>
-        <Style TargetType="Border">
-          <Setter Property="Background" Value="{x:Null}" />
-          <Setter Property="Opacity" Value="1" />
-          <Setter Property="IsEnabled" Value="True" />
-          <Style.Triggers>
-            <DataTrigger Binding="{Binding Current.IsDuplicate}" Value="True">
-              <Setter Property="Opacity" Value="0.5" />
-              <Setter Property="IsEnabled" Value="False" />
-              <Setter Property="Background">
-                <Setter.Value>
-                  <SolidColorBrush Color="#FFF0F0F0" />
-                </Setter.Value>
-              </Setter>
-            </DataTrigger>
-
-            <DataTrigger Binding="{Binding Current.IsNearMatch}" Value="True">
-              <Setter Property="Background">
-                <Setter.Value>
-                  <SolidColorBrush Color="#FFFDEEB5" />
-                </Setter.Value>
-              </Setter>
-            </DataTrigger>
-          </Style.Triggers>
-        </Style>
-      </Border.Style>
-
-      <ContentControl Content="{Binding Current}">
-        <ContentControl.Style>
-          <Style TargetType="ContentControl">
-            <Setter Property="ContentTemplate" Value="{StaticResource DocumentTemplate}" />
+    <swc:StackPanel Grid.Row="0"
+                    Orientation="Horizontal"
+                    Margin="0,0,0,8"
+                    VerticalAlignment="Center">
+      <swc:TextBlock Text="Review staged evidence" FontWeight="Bold" />
+      <swc:TextBlock Text="{Binding StagingList.IndexLabel}" Margin="12,0,0,0" />
+      <swc:TextBlock Text="Validation" Margin="24,0,0,0" FontWeight="SemiBold" />
+      <swc:TextBlock Text="Issues pending"
+                     Foreground="Red"
+                     Margin="6,0,0,0">
+        <swc:TextBlock.Style>
+          <Style TargetType="swc:TextBlock">
+            <Setter Property="Visibility" Value="Collapsed" />
             <Style.Triggers>
-              <DataTrigger Binding="{Binding Current.Type}" Value="{x:Static core:EntryType.Publication}">
-                <Setter Property="ContentTemplate" Value="{StaticResource PublicationTemplate}" />
+              <DataTrigger Binding="{Binding HasValidationErrors}" Value="True">
+                <Setter Property="Visibility" Value="Visible" />
               </DataTrigger>
             </Style.Triggers>
           </Style>
-        </ContentControl.Style>
-      </ContentControl>
-    </Border>
+        </swc:TextBlock.Style>
+      </swc:TextBlock>
+      <swc:TextBlock Text="All checks passed"
+                     Foreground="Green"
+                     Margin="6,0,0,0">
+        <swc:TextBlock.Style>
+          <Style TargetType="swc:TextBlock">
+            <Setter Property="Visibility" Value="Collapsed" />
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding HasValidationErrors}" Value="False">
+                <Setter Property="Visibility" Value="Visible" />
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </swc:TextBlock.Style>
+      </swc:TextBlock>
+    </swc:StackPanel>
 
-    <StackPanel Grid.Row="2"
-                Orientation="Horizontal"
-                HorizontalAlignment="Right"
-                Margin="0,8,0,0">
-      <Button Content="◀ Previous"
-              Margin="0,0,8,0"
-              Command="{Binding DataContext.PrevCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
-      <Button Content="Next ▶"
-              Margin="0,0,8,0"
-              Command="{Binding DataContext.NextCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
-      <Button Content="Close"
-              Command="{Binding DataContext.CloseCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
-    </StackPanel>
-  </Grid>
+    <swc:TabControl Grid.Row="1"
+                    ItemsSource="{Binding Tabs}"
+                    SelectedItem="{Binding SelectedTab, Mode=TwoWay}"
+                    Margin="0,0,0,8">
+      <swc:TabControl.ItemTemplate>
+        <DataTemplate>
+          <swc:TextBlock Text="{Binding Header}" />
+        </DataTemplate>
+      </swc:TabControl.ItemTemplate>
+      <swc:TabControl.ContentTemplate>
+        <DataTemplate>
+          <ContentPresenter Content="{Binding}" />
+        </DataTemplate>
+      </swc:TabControl.ContentTemplate>
+    </swc:TabControl>
+
+    <swc:StackPanel Grid.Row="2"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,8,0,0">
+      <swc:Button Content="◀ Previous"
+                  Margin="0,0,8,0"
+                  Command="{Binding PrevCommand}" />
+      <swc:Button Content="Next ▶"
+                  Margin="0,0,8,0"
+                  Command="{Binding NextCommand}" />
+      <swc:Button Content="Close"
+                  Command="{Binding CloseCommand}" />
+    </swc:StackPanel>
+  </swc:Grid>
 </Window>

--- a/src/LM.App.Wpf/Views/Templates/Staging/StagingEndpointsTemplates.xaml
+++ b/src/LM.App.Wpf/Views/Templates/Staging/StagingEndpointsTemplates.xaml
@@ -1,0 +1,34 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:swc="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+                    xmlns:vm="clr-namespace:LM.App.Wpf.ViewModels.Dialogs.Staging">
+  <DataTemplate DataType="{x:Type vm:StagingEndpointsTabViewModel}">
+    <swc:Grid>
+      <swc:Grid.RowDefinitions>
+        <swc:RowDefinition Height="*" />
+        <swc:RowDefinition Height="Auto" />
+      </swc:Grid.RowDefinitions>
+
+      <swc:ListView ItemsSource="{Binding Endpoints}">
+        <swc:ListView.View>
+          <swc:GridView>
+            <swc:GridViewColumn Header="Name" DisplayMemberBinding="{Binding Name}" Width="200" />
+            <swc:GridViewColumn Header="Populations" DisplayMemberBinding="{Binding Populations}" Width="220" />
+            <swc:GridViewColumn Header="Interventions" DisplayMemberBinding="{Binding Interventions}" Width="220" />
+            <swc:GridViewColumn Header="Confirmed">
+              <swc:GridViewColumn.CellTemplate>
+                <DataTemplate>
+                  <swc:CheckBox IsChecked="{Binding IsConfirmed, Mode=TwoWay}" HorizontalAlignment="Center" />
+                </DataTemplate>
+              </swc:GridViewColumn.CellTemplate>
+            </swc:GridViewColumn>
+          </swc:GridView>
+        </swc:ListView.View>
+      </swc:ListView>
+
+      <swc:TextBlock Grid.Row="1"
+                     Margin="0,8,0,0"
+                     Text="Mark endpoints as confirmed once reviewed." />
+    </swc:Grid>
+  </DataTemplate>
+</ResourceDictionary>

--- a/src/LM.App.Wpf/Views/Templates/Staging/StagingFiguresTemplates.xaml
+++ b/src/LM.App.Wpf/Views/Templates/Staging/StagingFiguresTemplates.xaml
@@ -1,0 +1,29 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:swc="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+                    xmlns:vm="clr-namespace:LM.App.Wpf.ViewModels.Dialogs.Staging">
+  <DataTemplate DataType="{x:Type vm:StagingFiguresTabViewModel}">
+    <swc:Grid>
+      <swc:Grid.RowDefinitions>
+        <swc:RowDefinition Height="*" />
+        <swc:RowDefinition Height="Auto" />
+      </swc:Grid.RowDefinitions>
+
+      <swc:ListView ItemsSource="{Binding Figures}"
+                    SelectedItem="{Binding Selected, Mode=TwoWay}">
+        <swc:ListView.View>
+          <swc:GridView>
+            <swc:GridViewColumn Header="Title" DisplayMemberBinding="{Binding Title}" Width="200" />
+            <swc:GridViewColumn Header="Caption" DisplayMemberBinding="{Binding Caption}" Width="250" />
+            <swc:GridViewColumn Header="Pages" DisplayMemberBinding="{Binding Pages}" Width="120" />
+            <swc:GridViewColumn Header="Source" DisplayMemberBinding="{Binding SourcePath}" Width="200" />
+          </swc:GridView>
+        </swc:ListView.View>
+      </swc:ListView>
+
+      <swc:TextBlock Grid.Row="1"
+                     Margin="0,8,0,0"
+                     Text="Figures are extracted automatically. Use table re-upload to refresh thumbnails." />
+    </swc:Grid>
+  </DataTemplate>
+</ResourceDictionary>

--- a/src/LM.App.Wpf/Views/Templates/Staging/StagingMetadataTemplates.xaml
+++ b/src/LM.App.Wpf/Views/Templates/Staging/StagingMetadataTemplates.xaml
@@ -1,0 +1,101 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:swc="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+                    xmlns:vm="clr-namespace:LM.App.Wpf.ViewModels.Dialogs.Staging"
+                    xmlns:core="clr-namespace:LM.Core.Models;assembly=LM.Core">
+  <BooleanToVisibilityConverter x:Key="BoolToVis" />
+
+  <DataTemplate DataType="{x:Type vm:StagingMetadataTabViewModel}">
+    <swc:ScrollViewer VerticalScrollBarVisibility="Auto">
+      <swc:Grid Margin="0,4,0,0">
+        <swc:Grid.ColumnDefinitions>
+          <swc:ColumnDefinition Width="*" />
+          <swc:ColumnDefinition Width="*" />
+        </swc:Grid.ColumnDefinitions>
+
+        <swc:StackPanel Grid.Column="0">
+          <swc:TextBlock Text="Title" />
+          <swc:TextBox Text="{Binding Current.Title, UpdateSourceTrigger=PropertyChanged}" />
+
+          <swc:TextBlock Text="Display name" Margin="0,12,0,0" />
+          <swc:DockPanel>
+            <swc:TextBox Text="{Binding Current.DisplayName, UpdateSourceTrigger=PropertyChanged}" />
+            <swc:Button Content="Generate"
+                        Margin="8,0,0,0"
+                        Command="{Binding DataContext.GenerateShortTitleCommand, RelativeSource={RelativeSource AncestorType={x:Type swc:Window}}}" />
+          </swc:DockPanel>
+
+          <swc:TextBlock Text="Authors (comma-separated)" Margin="0,12,0,0" />
+          <swc:TextBox Text="{Binding Current.AuthorsCsv, UpdateSourceTrigger=PropertyChanged}" />
+
+          <swc:DockPanel Margin="0,12,0,0">
+            <swc:StackPanel Width="160">
+              <swc:TextBlock Text="Year" />
+              <swc:TextBox Text="{Binding Current.Year, UpdateSourceTrigger=PropertyChanged}" />
+            </swc:StackPanel>
+            <swc:StackPanel Margin="12,0,0,0">
+              <swc:TextBlock Text="Source (journal/venue)" />
+              <swc:TextBox Text="{Binding Current.Source, UpdateSourceTrigger=PropertyChanged}" />
+            </swc:StackPanel>
+          </swc:DockPanel>
+
+          <swc:TextBlock Text="Tags (comma-separated)" Margin="0,12,0,0" />
+          <swc:TextBox Text="{Binding Current.TagsCsv, UpdateSourceTrigger=PropertyChanged}" />
+
+          <swc:CheckBox Content="Internal"
+                         Margin="0,12,0,0"
+                         IsChecked="{Binding Current.IsInternal, Mode=TwoWay}" />
+        </swc:StackPanel>
+
+        <swc:StackPanel Grid.Column="1" Margin="12,0,0,0">
+          <swc:StackPanel Orientation="Horizontal">
+            <swc:TextBlock Text="Type:" VerticalAlignment="Center" />
+            <swc:ComboBox ItemsSource="{Binding EntryTypes}"
+                          SelectedItem="{Binding Current.Type, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                          Width="150"
+                          Margin="8,0,0,0" />
+          </swc:StackPanel>
+
+          <swc:Border Background="#FFE0E0E0"
+                      CornerRadius="4"
+                      Padding="6,2"
+                      Margin="0,12,0,0"
+                      Visibility="{Binding IsDuplicate, Converter={StaticResource BoolToVis}}">
+            <swc:TextBlock Text="Exact duplicate in library" FontWeight="SemiBold" />
+          </swc:Border>
+
+          <swc:Border Background="#FFFDEEB5"
+                      CornerRadius="4"
+                      Padding="6,2"
+                      Margin="0,8,0,0"
+                      Visibility="{Binding IsNearMatch, Converter={StaticResource BoolToVis}}">
+            <swc:TextBlock>
+              <Run Text="Near match: " />
+              <Run Text="{Binding Current.MatchedTitle}" FontStyle="Italic" />
+            </swc:TextBlock>
+          </swc:Border>
+
+          <swc:StackPanel Margin="0,12,0,0">
+            <swc:TextBlock Text="Internal ID" />
+            <swc:TextBox Text="{Binding Current.InternalId, UpdateSourceTrigger=PropertyChanged}" />
+          </swc:StackPanel>
+
+          <swc:StackPanel Margin="0,12,0,0">
+            <swc:TextBlock Text="DOI" />
+            <swc:TextBox Text="{Binding Current.Doi, UpdateSourceTrigger=PropertyChanged}" />
+          </swc:StackPanel>
+
+          <swc:StackPanel Margin="0,12,0,0">
+            <swc:TextBlock Text="PMID" />
+            <swc:TextBox Text="{Binding Current.Pmid, UpdateSourceTrigger=PropertyChanged}" />
+          </swc:StackPanel>
+
+          <swc:TextBlock Text="Notes" Margin="0,12,0,0" />
+          <swc:TextBox Text="{Binding Current.Notes, UpdateSourceTrigger=PropertyChanged}"
+                       AcceptsReturn="True"
+                       Height="120" />
+        </swc:StackPanel>
+      </swc:Grid>
+    </swc:ScrollViewer>
+  </DataTemplate>
+</ResourceDictionary>

--- a/src/LM.App.Wpf/Views/Templates/Staging/StagingPopulationTemplates.xaml
+++ b/src/LM.App.Wpf/Views/Templates/Staging/StagingPopulationTemplates.xaml
@@ -1,0 +1,21 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:swc="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+                    xmlns:vm="clr-namespace:LM.App.Wpf.ViewModels.Dialogs.Staging">
+  <DataTemplate DataType="{x:Type vm:StagingPopulationTabViewModel}">
+    <swc:Grid>
+      <swc:Grid.ColumnDefinitions>
+        <swc:ColumnDefinition Width="*" />
+        <swc:ColumnDefinition Width="*" />
+      </swc:Grid.ColumnDefinitions>
+
+      <swc:GroupBox Header="Populations" Margin="0,0,8,0">
+        <swc:ListBox ItemsSource="{Binding Populations}" DisplayMemberPath="Label" />
+      </swc:GroupBox>
+
+      <swc:GroupBox Header="Interventions" Grid.Column="1" Margin="8,0,0,0">
+        <swc:ListBox ItemsSource="{Binding Interventions}" DisplayMemberPath="Name" />
+      </swc:GroupBox>
+    </swc:Grid>
+  </DataTemplate>
+</ResourceDictionary>

--- a/src/LM.App.Wpf/Views/Templates/Staging/StagingReviewTemplates.xaml
+++ b/src/LM.App.Wpf/Views/Templates/Staging/StagingReviewTemplates.xaml
@@ -1,0 +1,29 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:swc="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+                    xmlns:vm="clr-namespace:LM.App.Wpf.ViewModels.Dialogs.Staging">
+  <BooleanToVisibilityConverter x:Key="BoolToVis" />
+
+  <DataTemplate DataType="{x:Type vm:StagingReviewCommitTabViewModel}">
+    <swc:StackPanel>
+      <swc:TextBlock Text="Review staged evidence before committing." FontWeight="Bold" />
+      <swc:ItemsControl ItemsSource="{Binding Messages}" Margin="0,8,0,0">
+        <swc:ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <swc:TextBlock Margin="0,2,0,0">
+              <swc:TextBlock.Inlines>
+                <Run Text="• " />
+                <Run Text="{Binding .}" />
+              </swc:TextBlock.Inlines>
+            </swc:TextBlock>
+          </DataTemplate>
+        </swc:ItemsControl.ItemTemplate>
+      </swc:ItemsControl>
+
+      <swc:TextBlock Margin="0,12,0,0"
+                     Text="All validations passed. You can proceed to commit."
+                     Foreground="Green"
+                     Visibility="{Binding IsReady, Converter={StaticResource BoolToVis}}" />
+    </swc:StackPanel>
+  </DataTemplate>
+</ResourceDictionary>

--- a/src/LM.App.Wpf/Views/Templates/Staging/StagingTablesTemplates.xaml
+++ b/src/LM.App.Wpf/Views/Templates/Staging/StagingTablesTemplates.xaml
@@ -1,0 +1,43 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:swc="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+                    xmlns:vm="clr-namespace:LM.App.Wpf.ViewModels.Dialogs.Staging">
+  <DataTemplate DataType="{x:Type vm:StagingTablesTabViewModel}">
+    <swc:DockPanel>
+      <swc:StackPanel Orientation="Horizontal"
+                      DockPanel.Dock="Bottom"
+                      HorizontalAlignment="Right"
+                      Margin="0,8,0,0">
+        <swc:Button Content="Launch digitizer"
+                    Margin="0,0,8,0"
+                    Command="{Binding LaunchDigitizerCommand}"
+                    CommandParameter="{Binding SelectedTable}" />
+        <swc:Button Content="Re-upload CSV"
+                    Command="{Binding ReuploadDigitizedCommand}"
+                    CommandParameter="{Binding SelectedTable}" />
+      </swc:StackPanel>
+
+      <swc:DataGrid ItemsSource="{Binding Tables}"
+                    SelectedItem="{Binding SelectedTable, Mode=TwoWay}"
+                    AutoGenerateColumns="False"
+                    HeadersVisibility="Column"
+                    CanUserAddRows="False"
+                    IsReadOnly="False">
+        <swc:DataGrid.Columns>
+          <swc:DataGridTextColumn Header="Title" Binding="{Binding Title}" IsReadOnly="True" Width="200" />
+          <swc:DataGridComboBoxColumn Header="Classification"
+                                      SelectedItemBinding="{Binding Classification, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      ItemsSource="{Binding DataContext.ClassificationOptions, RelativeSource={RelativeSource AncestorType={x:Type swc:DataGrid}}}"
+                                      Width="150" />
+          <swc:DataGridTextColumn Header="Populations" Binding="{Binding PopulationSummary}" IsReadOnly="True" Width="200" />
+          <swc:DataGridTextColumn Header="Endpoints" Binding="{Binding EndpointSummary}" IsReadOnly="True" Width="200" />
+          <swc:DataGridTextColumn Header="Pages" Binding="{Binding PageSummary}" IsReadOnly="True" Width="80" />
+          <swc:DataGridTextColumn Header="Source"
+                                  Binding="{Binding SourcePath}"
+                                  Width="*"
+                                  IsReadOnly="True" />
+        </swc:DataGrid.Columns>
+      </swc:DataGrid>
+    </swc:DockPanel>
+  </DataTemplate>
+</ResourceDictionary>

--- a/src/LM.HubAndSpoke/Models/DataExtraction/DataExtractionEndpoint.cs
+++ b/src/LM.HubAndSpoke/Models/DataExtraction/DataExtractionEndpoint.cs
@@ -37,5 +37,8 @@ namespace LM.HubSpoke.Models
 
         [JsonPropertyName("notes")]
         public string? Notes { get; init; }
+
+        [JsonPropertyName("confirmed")]
+        public bool Confirmed { get; init; }
     }
 }

--- a/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
+++ b/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
@@ -401,6 +401,8 @@ LM.HubSpoke.Models.DataExtractionEndpoint.ResultSummary.get -> string?
 LM.HubSpoke.Models.DataExtractionEndpoint.ResultSummary.init -> void
 LM.HubSpoke.Models.DataExtractionEndpoint.Timepoint.get -> string?
 LM.HubSpoke.Models.DataExtractionEndpoint.Timepoint.init -> void
+LM.HubSpoke.Models.DataExtractionEndpoint.Confirmed.get -> bool
+LM.HubSpoke.Models.DataExtractionEndpoint.Confirmed.init -> void
 LM.HubSpoke.Models.DataExtractionPopulation
 LM.HubSpoke.Models.DataExtractionPopulation.DataExtractionPopulation() -> void
 LM.HubSpoke.Models.DataExtractionPopulation.Description.get -> string?


### PR DESCRIPTION
## Summary
- replace the staging editor surface with a tabbed workflow that hosts dedicated view models for metadata, tables, figures, endpoints, population, and review
- surface new commands for launching external digitizers, re-uploading digitized CSVs, and tracking pending change log events directly on the staged item
- add unit coverage for the new staging tab view models and extend change-log/data-extraction models for endpoint confirmation state

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: current container only has the .NET 8 SDK; solution targets net9)*
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: current container only has the .NET 8 SDK; solution targets net9)*

------
https://chatgpt.com/codex/tasks/task_e_68d67fb4d46c832b8fd8d5a097037235