### PR TITLE
Add review extraction commit workflow with change logging

### DIFF
--- a/src/LM.App.Wpf.Tests/AddPipelineExtractionCommitTests.cs
+++ b/src/LM.App.Wpf.Tests/AddPipelineExtractionCommitTests.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.App.Wpf.ViewModels;
+using LM.Core.Abstractions;
+using LM.Core.Models;
+using LM.Core.Utils;
+using LM.Infrastructure.FileSystem;
+using LM.Infrastructure.Hooks;
+using LM.Infrastructure.Entries;
+using LM.Infrastructure.Storage;
+using LM.Infrastructure.Utils;
+using Xunit;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.Tests
+{
+    public sealed class AddPipelineExtractionCommitTests : IDisposable
+    {
+        private readonly TempDir _temp;
+        private readonly WorkspaceService _workspace;
+        private readonly JsonEntryStore _entryStore;
+        private readonly FileStorageService _storage;
+        private readonly HashingService _hasher;
+        private readonly HookOrchestrator _orchestrator;
+        private readonly AddPipeline _pipeline;
+
+        public AddPipelineExtractionCommitTests()
+        {
+            _temp = new TempDir();
+            _workspace = new WorkspaceService();
+            _workspace.EnsureWorkspaceAsync(_temp.Path).GetAwaiter().GetResult();
+
+            _entryStore = new JsonEntryStore(_workspace);
+            _entryStore.InitializeAsync().GetAwaiter().GetResult();
+            _storage = new FileStorageService(_workspace);
+            _hasher = new HashingService();
+            _orchestrator = new HookOrchestrator(_workspace);
+
+            var similarity = new NullSimilarityService();
+            var metadata = new StubMetadataExtractor();
+
+            _pipeline = new AddPipeline(
+                _entryStore,
+                _storage,
+                _hasher,
+                similarity,
+                _workspace,
+                metadata,
+                NullPublicationLookup.Instance,
+                NullDoiNormalizer.Instance,
+                _orchestrator,
+                new NullPmidNormalizer(),
+                NullDataExtractionPreprocessor.Instance);
+        }
+
+        [Fact]
+        public async Task CommitAsync_WithExtraction_PersistsExtractionAndLogs()
+        {
+            var file = _temp.CreateFile("evidence.pdf", "sample content");
+            var staging = CreateStagingItem(file);
+
+            await _pipeline.CommitAsync(new[] { staging }, CancellationToken.None);
+
+            var sha = await _hasher.ComputeSha256Async(file, CancellationToken.None);
+            var entry = await _entryStore.FindByHashAsync(sha, CancellationToken.None);
+            Assert.NotNull(entry);
+            var entryId = entry!.Id;
+            Assert.False(string.IsNullOrWhiteSpace(entryId));
+
+            var hubPath = Path.Combine(_workspace.GetWorkspaceRoot(), "entries", entryId, "hub.json");
+            Assert.True(File.Exists(hubPath));
+            var hubJson = await File.ReadAllTextAsync(hubPath);
+            using var doc = JsonDocument.Parse(hubJson);
+            var hooksNode = doc.RootElement.GetProperty("hooks");
+            Assert.True(hooksNode.TryGetProperty("data_extraction", out var pointer));
+            var relativeExtraction = pointer.GetString();
+            Assert.False(string.IsNullOrWhiteSpace(relativeExtraction));
+            var extractionAbsolute = _workspace.GetAbsolutePath(relativeExtraction!.Replace('/', Path.DirectorySeparatorChar));
+            Assert.True(File.Exists(extractionAbsolute));
+
+            var changeLogPath = Path.Combine(_workspace.GetWorkspaceRoot(), "entries", entryId, "hooks", "changelog.json");
+            Assert.True(File.Exists(changeLogPath));
+            var changeLog = JsonSerializer.Deserialize<HookM.EntryChangeLogHook>(await File.ReadAllTextAsync(changeLogPath), HookM.JsonStd.Options);
+            Assert.NotNull(changeLog);
+            var extractionEvent = changeLog!.Events.Last(evt => evt.Action == "DataExtractionCommitted");
+            Assert.Equal(GetCurrentUserName(), extractionEvent.PerformedBy);
+            Assert.Contains($"asset:article:sha256-{sha}", extractionEvent.Details!.Tags);
+            var expectedExtractionHash = ComputeExtractionHash(staging.DataExtractionHook!);
+            Assert.Contains($"asset:data-extraction:{expectedExtractionHash}", extractionEvent.Details!.Tags);
+        }
+
+        [Fact]
+        public async Task CommitAsync_MetadataOnly_SkipsExtractionButLogs()
+        {
+            var file = _temp.CreateFile("metadata.pdf", "metadata only");
+            var staging = CreateStagingItem(file);
+            staging.CommitMetadataOnly = true;
+
+            await _pipeline.CommitAsync(new[] { staging }, CancellationToken.None);
+
+            var sha = await _hasher.ComputeSha256Async(file, CancellationToken.None);
+            var entry = await _entryStore.FindByHashAsync(sha, CancellationToken.None);
+            Assert.NotNull(entry);
+            var entryId = entry!.Id;
+
+            var hubPath = Path.Combine(_workspace.GetWorkspaceRoot(), "entries", entryId, "hub.json");
+            var hubJson = await File.ReadAllTextAsync(hubPath);
+            using var doc = JsonDocument.Parse(hubJson);
+            var hooksNode = doc.RootElement.GetProperty("hooks");
+            Assert.False(hooksNode.TryGetProperty("data_extraction", out _));
+
+            var changeLogPath = Path.Combine(_workspace.GetWorkspaceRoot(), "entries", entryId, "hooks", "changelog.json");
+            var changeLog = JsonSerializer.Deserialize<HookM.EntryChangeLogHook>(await File.ReadAllTextAsync(changeLogPath), HookM.JsonStd.Options);
+            Assert.NotNull(changeLog);
+            var extractionEvent = changeLog!.Events.Last(evt => evt.Action == "DataExtractionSkipped");
+            Assert.Equal(GetCurrentUserName(), extractionEvent.PerformedBy);
+            Assert.Contains($"asset:article:sha256-{sha}", extractionEvent.Details!.Tags);
+            Assert.Contains("asset:data-extraction:none", extractionEvent.Details!.Tags);
+        }
+
+        public void Dispose()
+        {
+            _temp.Dispose();
+        }
+
+        private static string ComputeExtractionHash(HookM.DataExtractionHook hook)
+        {
+            var json = JsonSerializer.Serialize(hook, HookM.JsonStd.Options);
+            using var sha = System.Security.Cryptography.SHA256.Create();
+            var bytes = Encoding.UTF8.GetBytes(json);
+            var hash = sha.ComputeHash(bytes);
+            return $"sha256-{Convert.ToHexString(hash).ToLowerInvariant()}";
+        }
+
+        private static string GetCurrentUserName()
+        {
+            var user = Environment.UserName;
+            return string.IsNullOrWhiteSpace(user) ? "unknown" : user;
+        }
+
+        private static HookM.DataExtractionHook CreateExtractionHook()
+        {
+            var population = new HookM.DataExtractionPopulation
+            {
+                Id = "pop-1",
+                Label = "Adults",
+                SampleSize = 42
+            };
+
+            var intervention = new HookM.DataExtractionIntervention
+            {
+                Id = "arm-1",
+                Name = "Drug A",
+                PopulationIds = { "pop-1" },
+                Dosage = "10mg"
+            };
+
+            var endpoint = new HookM.DataExtractionEndpoint
+            {
+                Id = "end-1",
+                Name = "Mortality",
+                PopulationIds = { "pop-1" },
+                InterventionIds = { "arm-1" },
+                Confirmed = true
+            };
+
+            var table = new HookM.DataExtractionTable
+            {
+                Id = "tbl-1",
+                Title = "Primary Outcome",
+                Caption = "Efficacy",
+                SourcePath = "staging/manual/tables/tbl-1.csv",
+                ProvenanceHash = "sha256-abcd",
+                Pages = { "1" }
+            };
+
+            return new HookM.DataExtractionHook
+            {
+                ExtractedBy = GetCurrentUserName(),
+                ExtractedAtUtc = DateTime.UtcNow,
+                Populations = { population },
+                Interventions = { intervention },
+                Endpoints = { endpoint },
+                Tables = { table }
+            };
+        }
+
+        private static StagingItem CreateStagingItem(string filePath)
+        {
+            return new StagingItem
+            {
+                Selected = true,
+                FilePath = filePath,
+                SuggestedAction = "New",
+                Type = EntryType.Publication,
+                Title = "Sample Trial",
+                DisplayName = "Sample Trial",
+                AuthorsCsv = "Doe",
+                Year = 2024,
+                Source = "Journal of Tests",
+                TagsCsv = "evidence",
+                DataExtractionHook = CreateExtractionHook()
+            };
+        }
+
+        private sealed class NullSimilarityService : ISimilarityService
+        {
+            public Task<double> ComputeFileSimilarityAsync(string filePathA, string filePathB, CancellationToken ct = default)
+                => Task.FromResult(0d);
+        }
+
+        private sealed class StubMetadataExtractor : IMetadataExtractor
+        {
+            public Task<FileMetadata> ExtractAsync(string absolutePath, CancellationToken ct = default)
+                => Task.FromResult(new FileMetadata());
+        }
+
+        private sealed class TempDir : IDisposable
+        {
+            public string Path { get; }
+
+            public TempDir()
+            {
+                Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "lm_pipeline_" + Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(Path);
+            }
+
+            public string CreateFile(string name, string contents)
+            {
+                var full = System.IO.Path.Combine(Path, name);
+                File.WriteAllText(full, contents);
+                return full;
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    Directory.Delete(Path, recursive: true);
+                }
+                catch
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/Composition/Modules/AddModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/AddModule.cs
@@ -34,12 +34,15 @@ namespace LM.App.Wpf.Composition.Modules
 
             services.AddSingleton<WatchedFolderScanner>(sp => new WatchedFolderScanner(sp.GetRequiredService<IAddPipeline>()));
             services.AddSingleton<IDialogService, WpfDialogService>();
+            services.AddSingleton<IDataExtractionCommitBuilder, DataExtractionCommitBuilder>();
             services.AddTransient<StagingMetadataTabViewModel>();
             services.AddTransient<StagingTablesTabViewModel>();
             services.AddTransient<StagingFiguresTabViewModel>();
             services.AddTransient<StagingEndpointsTabViewModel>();
             services.AddTransient<StagingPopulationTabViewModel>();
-            services.AddTransient<StagingReviewCommitTabViewModel>();
+            services.AddTransient<StagingReviewCommitTabViewModel>(sp => new StagingReviewCommitTabViewModel(
+                sp.GetRequiredService<StagingListViewModel>(),
+                sp.GetRequiredService<IDataExtractionCommitBuilder>()));
             services.AddTransient<StagingEditorViewModel>();
             services.AddTransient<StagingEditorWindow>();
             services.AddSingleton<StagingListViewModel>(sp => new StagingListViewModel(sp.GetRequiredService<IAddPipeline>()));

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -254,6 +254,7 @@ LM.App.Wpf.ViewModels.StagingListViewModel
 LM.App.Wpf.ViewModels.StagingListViewModel.AddStagedItemsAsync(System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>! items) -> System.Threading.Tasks.Task!
 LM.App.Wpf.ViewModels.StagingListViewModel.Clear() -> void
 LM.App.Wpf.ViewModels.StagingListViewModel.CommitSelectedAsync(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.StagingListViewModel.CommitAsync(System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.StagingItem!>! items, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
 LM.App.Wpf.ViewModels.StagingListViewModel.Current.get -> LM.App.Wpf.ViewModels.StagingItem?
 LM.App.Wpf.ViewModels.StagingListViewModel.Current.set -> void
 LM.App.Wpf.ViewModels.StagingListViewModel.Dispose() -> void
@@ -563,6 +564,8 @@ LM.App.Wpf.ViewModels.StagingItem.SimilarToTitle.set -> void
 LM.App.Wpf.ViewModels.StagingItem.Source.get -> string?
 LM.App.Wpf.ViewModels.StagingItem.Source.set -> void
 LM.App.Wpf.ViewModels.StagingItem.StagingItem() -> void
+LM.App.Wpf.ViewModels.StagingItem.CommitMetadataOnly.get -> bool
+LM.App.Wpf.ViewModels.StagingItem.CommitMetadataOnly.set -> void
 LM.App.Wpf.ViewModels.StagingItem.SuggestedAction.get -> string!
 LM.App.Wpf.ViewModels.StagingItem.SuggestedAction.set -> void
 LM.App.Wpf.ViewModels.StagingItem.TagsCsv.get -> string?

--- a/src/LM.App.Wpf/ViewModels/Add/StagingItem.cs
+++ b/src/LM.App.Wpf/ViewModels/Add/StagingItem.cs
@@ -92,5 +92,7 @@ namespace LM.App.Wpf.ViewModels
         public HookM.DataExtractionHook? DataExtractionHook { get; set; }
         public List<HookM.EntryChangeLogEvent> PendingChangeLogEvents { get; } = new();
         public StagingEvidencePreview? EvidencePreview { get; set; }
+
+        public bool CommitMetadataOnly { get; set; }
     }
 }

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/DataExtractionCommitBuilder.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/DataExtractionCommitBuilder.cs
@@ -1,0 +1,138 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LM.App.Wpf.ViewModels;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Staging
+{
+    internal interface IDataExtractionCommitBuilder
+    {
+        HookM.DataExtractionHook? Build(StagingItem item,
+                                        IEnumerable<StagingTableRowViewModel>? tables,
+                                        IEnumerable<StagingEndpointViewModel>? endpoints);
+    }
+
+    internal sealed class DataExtractionCommitBuilder : IDataExtractionCommitBuilder
+    {
+        public HookM.DataExtractionHook? Build(StagingItem item,
+                                               IEnumerable<StagingTableRowViewModel>? tables,
+                                               IEnumerable<StagingEndpointViewModel>? endpoints)
+        {
+            if (item is null)
+                throw new ArgumentNullException(nameof(item));
+
+            var source = item.DataExtractionHook;
+            if (source is null)
+                return null;
+
+            var tableSnapshots = tables?.Select(static t => t?.Snapshot)
+                                       .Where(static t => t is not null)
+                                       .Cast<HookM.DataExtractionTable>()
+                                       .Select(CloneTable)
+                                       .ToList()
+                                ?? new List<HookM.DataExtractionTable>();
+
+            if (tableSnapshots.Count == 0 && source.Tables is { Count: > 0 })
+                tableSnapshots = source.Tables.Select(CloneTable).ToList();
+
+            var endpointSnapshots = endpoints?.Select(static e => e?.Endpoint)
+                                              .Where(static e => e is not null)
+                                              .Cast<HookM.DataExtractionEndpoint>()
+                                              .Select(CloneEndpoint)
+                                              .ToList()
+                                   ?? new List<HookM.DataExtractionEndpoint>();
+
+            if (endpointSnapshots.Count == 0 && source.Endpoints is { Count: > 0 })
+                endpointSnapshots = source.Endpoints.Select(CloneEndpoint).ToList();
+
+            return new HookM.DataExtractionHook
+            {
+                SchemaVersion = source.SchemaVersion,
+                ExtractedAtUtc = DateTime.UtcNow,
+                ExtractedBy = GetCurrentUserName(),
+                Populations = source.Populations.Select(ClonePopulation).ToList(),
+                Interventions = source.Interventions.Select(CloneIntervention).ToList(),
+                Endpoints = endpointSnapshots,
+                Figures = source.Figures.Select(CloneFigure).ToList(),
+                Tables = tableSnapshots,
+                Notes = source.Notes
+            };
+        }
+
+        private static HookM.DataExtractionPopulation ClonePopulation(HookM.DataExtractionPopulation population)
+            => new()
+            {
+                Id = population.Id,
+                Label = population.Label,
+                SampleSize = population.SampleSize,
+                InclusionCriteria = population.InclusionCriteria,
+                ExclusionCriteria = population.ExclusionCriteria,
+                Notes = population.Notes
+            };
+
+        private static HookM.DataExtractionIntervention CloneIntervention(HookM.DataExtractionIntervention intervention)
+            => new()
+            {
+                Id = intervention.Id,
+                Name = intervention.Name,
+                PopulationIds = new List<string>(intervention.PopulationIds),
+                Dosage = intervention.Dosage,
+                Comparator = intervention.Comparator,
+                Notes = intervention.Notes
+            };
+
+        private static HookM.DataExtractionEndpoint CloneEndpoint(HookM.DataExtractionEndpoint endpoint)
+            => new()
+            {
+                Id = endpoint.Id,
+                Name = endpoint.Name,
+                Description = endpoint.Description,
+                Timepoint = endpoint.Timepoint,
+                Measure = endpoint.Measure,
+                PopulationIds = new List<string>(endpoint.PopulationIds),
+                InterventionIds = new List<string>(endpoint.InterventionIds),
+                ResultSummary = endpoint.ResultSummary,
+                EffectSize = endpoint.EffectSize,
+                Notes = endpoint.Notes,
+                Confirmed = endpoint.Confirmed
+            };
+
+        private static HookM.DataExtractionTable CloneTable(HookM.DataExtractionTable table)
+            => new()
+            {
+                Id = table.Id,
+                Title = table.Title,
+                Caption = table.Caption,
+                SourcePath = table.SourcePath,
+                Pages = new List<string>(table.Pages),
+                LinkedEndpointIds = new List<string>(table.LinkedEndpointIds),
+                LinkedInterventionIds = new List<string>(table.LinkedInterventionIds),
+                ProvenanceHash = table.ProvenanceHash,
+                Notes = table.Notes,
+                TableLabel = table.TableLabel,
+                Summary = table.Summary
+            };
+
+        private static HookM.DataExtractionFigure CloneFigure(HookM.DataExtractionFigure figure)
+            => new()
+            {
+                Id = figure.Id,
+                Title = figure.Title,
+                Caption = figure.Caption,
+                SourcePath = figure.SourcePath,
+                Pages = new List<string>(figure.Pages),
+                ProvenanceHash = figure.ProvenanceHash,
+                Notes = figure.Notes,
+                ThumbnailPath = figure.ThumbnailPath
+            };
+
+        private static string GetCurrentUserName()
+        {
+            var user = Environment.UserName;
+            return string.IsNullOrWhiteSpace(user) ? "unknown" : user;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/Templates/Staging/StagingReviewTemplates.xaml
+++ b/src/LM.App.Wpf/Views/Templates/Staging/StagingReviewTemplates.xaml
@@ -20,6 +20,16 @@
         </swc:ItemsControl.ItemTemplate>
       </swc:ItemsControl>
 
+      <swc:StackPanel Orientation="Horizontal" Margin="0,12,0,0">
+        <swc:Button Content="Commit Extraction"
+                    Command="{Binding CommitExtractionCommand}"
+                    Margin="0,0,8,0"
+                    Padding="12,4" />
+        <swc:Button Content="Commit Metadata Only"
+                    Command="{Binding CommitMetadataOnlyCommand}"
+                    Padding="12,4" />
+      </swc:StackPanel>
+
       <swc:TextBlock Margin="0,12,0,0"
                      Text="All validations passed. You can proceed to commit."
                      Foreground="Green"


### PR DESCRIPTION
## Summary
- add a dedicated data-extraction commit builder and expose review-tab commands for committing extraction data or metadata only
- update the staging pipeline to attach extraction hooks conditionally and append new change-log events for committed or skipped extraction payloads
- cover the extraction and metadata-only flows with unit tests that assert data files and change-log output

## Testing
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: installed .NET SDK 8.0.414 cannot target the solution's net9.0 projects)*

------
https://chatgpt.com/codex/tasks/task_e_68d6890ddad8832b95eea3dea9b46117