### PR TITLE
Add review analytics aggregation service and metrics DTOs

### DIFF
--- a/src/LM.Review.Core.Tests/Services/ReviewAnalyticsServiceTests.cs
+++ b/src/LM.Review.Core.Tests/Services/ReviewAnalyticsServiceTests.cs
@@ -1,0 +1,388 @@
+using System;
+using System.Collections.Generic;
+using LM.Review.Core.Models;
+using LM.Review.Core.Models.Analytics;
+using LM.Review.Core.Services;
+using Xunit;
+
+namespace LM.Review.Core.Tests.Services;
+
+public sealed class ReviewAnalyticsServiceTests
+{
+    [Fact]
+    public void CreateSnapshot_ComputesAggregateMetrics()
+    {
+        var reference = new DateTimeOffset(2024, 10, 10, 12, 0, 0, TimeSpan.Zero);
+        var titleDefinition = CreateStageDefinition(
+            "title-stage",
+            "Title Screening",
+            ReviewStageType.TitleScreening,
+            ReviewerRequirement.Create(new[]
+            {
+                new KeyValuePair<ReviewerRole, int>(ReviewerRole.Primary, 1),
+                new KeyValuePair<ReviewerRole, int>(ReviewerRole.Secondary, 1)
+            }),
+            StageConsensusPolicy.RequireAgreement(2, escalateOnDisagreement: true, arbitrationRole: null));
+
+        var fullTextDefinition = CreateStageDefinition(
+            "full-text-stage",
+            "Full Text",
+            ReviewStageType.FullTextReview,
+            ReviewerRequirement.Create(new[]
+            {
+                new KeyValuePair<ReviewerRole, int>(ReviewerRole.Primary, 1)
+            }),
+            StageConsensusPolicy.Disabled());
+
+        var project = ReviewProject.Create(
+            "proj-analytics",
+            "Systematic Review",
+            reference.AddDays(-30),
+            new[] { titleDefinition, fullTextDefinition });
+
+        var stage1 = CreateStage(
+            project.Id,
+            "stage-1",
+            titleDefinition,
+            reference.AddDays(-9),
+            reference.AddDays(-9).AddHours(3),
+            ConflictState.None,
+            new[]
+            {
+                CreateAssignment(
+                    "assign-1",
+                    "stage-1",
+                    "alice",
+                    ReviewerRole.Primary,
+                    ScreeningStatus.Included,
+                    reference.AddDays(-9),
+                    reference.AddDays(-9).AddHours(1)),
+                CreateAssignment(
+                    "assign-2",
+                    "stage-1",
+                    "bob",
+                    ReviewerRole.Secondary,
+                    ScreeningStatus.Included,
+                    reference.AddDays(-9),
+                    reference.AddDays(-9).AddHours(1.5))
+            });
+
+        var stage2 = CreateStage(
+            project.Id,
+            "stage-2",
+            titleDefinition,
+            reference.AddDays(-8),
+            completedAt: null,
+            ConflictState.Escalated,
+            new[]
+            {
+                CreateAssignment(
+                    "assign-3",
+                    "stage-2",
+                    "alice",
+                    ReviewerRole.Primary,
+                    ScreeningStatus.Included,
+                    reference.AddDays(-8),
+                    reference.AddDays(-8).AddHours(1)),
+                CreateAssignment(
+                    "assign-4",
+                    "stage-2",
+                    "bob",
+                    ReviewerRole.Secondary,
+                    ScreeningStatus.Excluded,
+                    reference.AddDays(-8),
+                    reference.AddDays(-8).AddHours(2))
+            });
+
+        var consensus = ConsensusOutcome.Create(
+            "stage-3",
+            approved: false,
+            resultingState: ConflictState.Resolved,
+            resolvedAtUtc: reference.AddDays(-7).AddHours(5));
+
+        var stage3 = CreateStage(
+            project.Id,
+            "stage-3",
+            titleDefinition,
+            reference.AddDays(-7),
+            reference.AddDays(-7).AddHours(6),
+            ConflictState.Resolved,
+            new[]
+            {
+                CreateAssignment(
+                    "assign-5",
+                    "stage-3",
+                    "alice",
+                    ReviewerRole.Primary,
+                    ScreeningStatus.Excluded,
+                    reference.AddDays(-7),
+                    reference.AddDays(-7).AddHours(2)),
+                CreateAssignment(
+                    "assign-6",
+                    "stage-3",
+                    "bob",
+                    ReviewerRole.Secondary,
+                    ScreeningStatus.Excluded,
+                    reference.AddDays(-7),
+                    reference.AddDays(-7).AddHours(2.5))
+            },
+            consensus);
+
+        var stage4 = CreateStage(
+            project.Id,
+            "stage-4",
+            fullTextDefinition,
+            reference.AddDays(-5),
+            reference.AddDays(-5).AddHours(2),
+            ConflictState.None,
+            new[]
+            {
+                CreateAssignment(
+                    "assign-7",
+                    "stage-4",
+                    "carol",
+                    ReviewerRole.Primary,
+                    ScreeningStatus.Included,
+                    reference.AddDays(-5),
+                    reference.AddDays(-5).AddHours(2))
+            });
+
+        var service = new ReviewAnalyticsService();
+        var snapshot = service.CreateSnapshot(
+            project,
+            new[] { stage1, stage2, stage3, stage4 },
+            new ReviewAnalyticsQueryOptions(reference));
+
+        Assert.Equal(project.Id, snapshot.ProjectId);
+        Assert.Equal(reference, snapshot.GeneratedAt);
+
+        Assert.Collection(
+            snapshot.StageProgress,
+            titleSnapshot =>
+            {
+                Assert.Equal(titleDefinition.Id, titleSnapshot.StageDefinitionId);
+                Assert.Equal(3, titleSnapshot.TotalInstances);
+                Assert.Equal(2, titleSnapshot.CompletedInstances);
+                Assert.Equal(ReviewStageType.TitleScreening, titleSnapshot.StageType);
+                Assert.Equal(2d / 3d, titleSnapshot.CompletionRate, 5);
+                Assert.Equal(1d, titleSnapshot.AverageReviewerCompletion, 5);
+            },
+            fullTextSnapshot =>
+            {
+                Assert.Equal(fullTextDefinition.Id, fullTextSnapshot.StageDefinitionId);
+                Assert.Equal(1, fullTextSnapshot.TotalInstances);
+                Assert.Equal(1, fullTextSnapshot.CompletedInstances);
+                Assert.Equal(ReviewStageType.FullTextReview, fullTextSnapshot.StageType);
+                Assert.Equal(1d, fullTextSnapshot.CompletionRate, 5);
+                Assert.Equal(1d, fullTextSnapshot.AverageReviewerCompletion, 5);
+            });
+
+        Assert.Collection(
+            snapshot.ReviewerLoads,
+            alice =>
+            {
+                Assert.Equal("alice", alice.ReviewerId);
+                Assert.Equal(0, alice.ActiveAssignments);
+                Assert.Equal(3, alice.CompletedAssignments);
+                Assert.Equal(1.33, alice.AverageDecisionLatencyHours, 2);
+                Assert.Equal(0.33, alice.ThroughputPerDay, 2);
+            },
+            bob =>
+            {
+                Assert.Equal("bob", bob.ReviewerId);
+                Assert.Equal(0, bob.ActiveAssignments);
+                Assert.Equal(3, bob.CompletedAssignments);
+                Assert.Equal(2d, bob.AverageDecisionLatencyHours, 2);
+                Assert.Equal(0.33, bob.ThroughputPerDay, 2);
+            },
+            carol =>
+            {
+                Assert.Equal("carol", carol.ReviewerId);
+                Assert.Equal(0, carol.ActiveAssignments);
+                Assert.Equal(1, carol.CompletedAssignments);
+                Assert.Equal(2d, carol.AverageDecisionLatencyHours, 2);
+                Assert.Equal(0.2, carol.ThroughputPerDay, 2);
+            });
+
+        Assert.Equal(4, snapshot.ConflictRates.TotalStages);
+        Assert.Equal(2, snapshot.ConflictRates.ConflictCount);
+        Assert.Equal(1, snapshot.ConflictRates.EscalatedCount);
+        Assert.Equal(1, snapshot.ConflictRates.ResolvedCount);
+        Assert.Equal(1, snapshot.ConflictRates.OpenConflicts);
+        Assert.Equal(0.5, snapshot.ConflictRates.ConflictRate, 5);
+        Assert.Equal(0.25, snapshot.ConflictRates.EscalationRate, 5);
+        Assert.Equal(0.5, snapshot.ConflictRates.ResolutionRate, 5);
+
+        Assert.Equal(4, snapshot.PrismaFlow.RecordsIdentified);
+        Assert.Equal(4, snapshot.PrismaFlow.RecordsScreened);
+        Assert.Equal(2, snapshot.PrismaFlow.RecordsIncluded);
+        Assert.Equal(1, snapshot.PrismaFlow.RecordsExcluded);
+        Assert.Equal(1, snapshot.PrismaFlow.RecordsEscalated);
+        Assert.Equal(0, snapshot.PrismaFlow.PendingDecisions);
+    }
+
+    [Fact]
+    public void CreateSnapshot_WithTimelineFilter_UsesFilteredAssignments()
+    {
+        var reference = new DateTimeOffset(2024, 11, 15, 9, 0, 0, TimeSpan.Zero);
+        var titleDefinition = CreateStageDefinition(
+            "title-stage",
+            "Title Screening",
+            ReviewStageType.TitleScreening,
+            ReviewerRequirement.Create(new[]
+            {
+                new KeyValuePair<ReviewerRole, int>(ReviewerRole.Primary, 1),
+                new KeyValuePair<ReviewerRole, int>(ReviewerRole.Secondary, 1)
+            }),
+            StageConsensusPolicy.Disabled());
+
+        var project = ReviewProject.Create(
+            "proj-window",
+            "Windowed Review",
+            reference.AddDays(-60),
+            new[] { titleDefinition });
+
+        var oldStage = CreateStage(
+            project.Id,
+            "stage-old",
+            titleDefinition,
+            reference.AddDays(-20),
+            reference.AddDays(-20).AddHours(2),
+            ConflictState.None,
+            new[]
+            {
+                CreateAssignment(
+                    "assign-old-1",
+                    "stage-old",
+                    "alice",
+                    ReviewerRole.Primary,
+                    ScreeningStatus.Included,
+                    reference.AddDays(-20),
+                    reference.AddDays(-20).AddHours(1)),
+                CreateAssignment(
+                    "assign-old-2",
+                    "stage-old",
+                    "bob",
+                    ReviewerRole.Secondary,
+                    ScreeningStatus.Excluded,
+                    reference.AddDays(-20),
+                    reference.AddDays(-20).AddHours(1.5))
+            });
+
+        var recentStage = CreateStage(
+            project.Id,
+            "stage-recent",
+            titleDefinition,
+            reference.AddDays(-3),
+            reference.AddDays(-3).AddHours(3),
+            ConflictState.None,
+            new[]
+            {
+                CreateAssignment(
+                    "assign-new-1",
+                    "stage-recent",
+                    "alice",
+                    ReviewerRole.Primary,
+                    ScreeningStatus.Included,
+                    reference.AddDays(-3),
+                    reference.AddDays(-3).AddHours(1)),
+                CreateAssignment(
+                    "assign-new-2",
+                    "stage-recent",
+                    "bob",
+                    ReviewerRole.Secondary,
+                    ScreeningStatus.Excluded,
+                    reference.AddDays(-3),
+                    reference.AddDays(-3).AddHours(1.5))
+            });
+
+        var filter = ReviewAnalyticsQuery.LastDays(7, reference);
+        var options = new ReviewAnalyticsQueryOptions(
+            reference,
+            filter,
+            ReviewAnalyticsQuery.ActivatedWithin(filter),
+            ReviewAnalyticsQuery.CompletedWithin(filter));
+
+        var service = new ReviewAnalyticsService();
+        var snapshot = service.CreateSnapshot(project, new[] { oldStage, recentStage }, options);
+
+        Assert.Single(snapshot.StageProgress);
+        var progress = Assert.Single(snapshot.StageProgress);
+        Assert.Equal(1, progress.TotalInstances);
+        Assert.Equal(1, progress.CompletedInstances);
+        Assert.Equal(1d, progress.AverageReviewerCompletion, 5);
+
+        Assert.Collection(
+            snapshot.ReviewerLoads,
+            alice =>
+            {
+                Assert.Equal("alice", alice.ReviewerId);
+                Assert.Equal(0, alice.ActiveAssignments);
+                Assert.Equal(1, alice.CompletedAssignments);
+                Assert.Equal(1d, alice.AverageDecisionLatencyHours, 2);
+                Assert.Equal(0.14, alice.ThroughputPerDay, 2);
+            },
+            bob =>
+            {
+                Assert.Equal("bob", bob.ReviewerId);
+                Assert.Equal(0, bob.ActiveAssignments);
+                Assert.Equal(1, bob.CompletedAssignments);
+                Assert.Equal(1.5, bob.AverageDecisionLatencyHours, 2);
+                Assert.Equal(0.14, bob.ThroughputPerDay, 2);
+            });
+
+        Assert.Equal(1, snapshot.ConflictRates.TotalStages);
+        Assert.Equal(0, snapshot.ConflictRates.ConflictCount);
+        Assert.Equal(1, snapshot.PrismaFlow.RecordsIdentified);
+        Assert.Equal(1, snapshot.PrismaFlow.RecordsScreened);
+        Assert.Equal(0, snapshot.PrismaFlow.RecordsIncluded);
+        Assert.Equal(0, snapshot.PrismaFlow.RecordsExcluded);
+        Assert.Equal(0, snapshot.PrismaFlow.RecordsEscalated);
+        Assert.Equal(0, snapshot.PrismaFlow.PendingDecisions);
+    }
+
+    private static StageDefinition CreateStageDefinition(
+        string id,
+        string name,
+        ReviewStageType stageType,
+        ReviewerRequirement requirement,
+        StageConsensusPolicy policy) =>
+        StageDefinition.Create(id, name, stageType, requirement, policy);
+
+    private static ReviewStage CreateStage(
+        string projectId,
+        string stageId,
+        StageDefinition definition,
+        DateTimeOffset activatedAt,
+        DateTimeOffset? completedAt,
+        ConflictState conflictState,
+        IEnumerable<ScreeningAssignment> assignments,
+        ConsensusOutcome? consensus = null) =>
+        ReviewStage.Create(stageId, projectId, definition, assignments, conflictState, activatedAt, completedAt, consensus);
+
+    private static ScreeningAssignment CreateAssignment(
+        string assignmentId,
+        string stageId,
+        string reviewerId,
+        ReviewerRole role,
+        ScreeningStatus status,
+        DateTimeOffset assignedAt,
+        DateTimeOffset? completedAt)
+    {
+        ReviewerDecision? decision = null;
+        if (status is ScreeningStatus.Included or ScreeningStatus.Excluded)
+        {
+            decision = ReviewerDecision.Create(assignmentId, reviewerId, status, completedAt!.Value);
+        }
+
+        return ScreeningAssignment.Create(
+            assignmentId,
+            stageId,
+            reviewerId,
+            role,
+            status,
+            assignedAt,
+            completedAt,
+            decision);
+    }
+}

--- a/src/LM.Review.Core/Models/Analytics/AnalyticsTimelineFilter.cs
+++ b/src/LM.Review.Core/Models/Analytics/AnalyticsTimelineFilter.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace LM.Review.Core.Models.Analytics;
+
+public readonly struct AnalyticsTimelineFilter
+{
+    public AnalyticsTimelineFilter(DateTimeOffset from, DateTimeOffset to)
+    {
+        if (to < from)
+        {
+            throw new ArgumentException("The end of a timeline filter must be greater than or equal to the start.", nameof(to));
+        }
+
+        From = from;
+        To = to;
+    }
+
+    public DateTimeOffset From { get; }
+
+    public DateTimeOffset To { get; }
+
+    public TimeSpan Duration => To - From;
+
+    public bool Contains(DateTimeOffset timestamp) => timestamp >= From && timestamp <= To;
+
+    public bool Overlaps(DateTimeOffset start, DateTimeOffset? end = null)
+    {
+        var effectiveEnd = end ?? To;
+        return start <= To && effectiveEnd >= From;
+    }
+}

--- a/src/LM.Review.Core/Models/Analytics/ConflictRateSnapshot.cs
+++ b/src/LM.Review.Core/Models/Analytics/ConflictRateSnapshot.cs
@@ -1,0 +1,40 @@
+namespace LM.Review.Core.Models.Analytics;
+
+public sealed record ConflictRateSnapshot
+{
+    public ConflictRateSnapshot(
+        int totalStages,
+        int conflictCount,
+        int escalatedCount,
+        int resolvedCount,
+        int openConflicts,
+        double conflictRate,
+        double escalationRate,
+        double resolutionRate)
+    {
+        TotalStages = totalStages;
+        ConflictCount = conflictCount;
+        EscalatedCount = escalatedCount;
+        ResolvedCount = resolvedCount;
+        OpenConflicts = openConflicts;
+        ConflictRate = conflictRate;
+        EscalationRate = escalationRate;
+        ResolutionRate = resolutionRate;
+    }
+
+    public int TotalStages { get; }
+
+    public int ConflictCount { get; }
+
+    public int EscalatedCount { get; }
+
+    public int ResolvedCount { get; }
+
+    public int OpenConflicts { get; }
+
+    public double ConflictRate { get; }
+
+    public double EscalationRate { get; }
+
+    public double ResolutionRate { get; }
+}

--- a/src/LM.Review.Core/Models/Analytics/PrismaFlowSnapshot.cs
+++ b/src/LM.Review.Core/Models/Analytics/PrismaFlowSnapshot.cs
@@ -1,0 +1,32 @@
+namespace LM.Review.Core.Models.Analytics;
+
+public sealed record PrismaFlowSnapshot
+{
+    public PrismaFlowSnapshot(
+        int recordsIdentified,
+        int recordsScreened,
+        int recordsIncluded,
+        int recordsExcluded,
+        int recordsEscalated,
+        int pendingDecisions)
+    {
+        RecordsIdentified = recordsIdentified;
+        RecordsScreened = recordsScreened;
+        RecordsIncluded = recordsIncluded;
+        RecordsExcluded = recordsExcluded;
+        RecordsEscalated = recordsEscalated;
+        PendingDecisions = pendingDecisions;
+    }
+
+    public int RecordsIdentified { get; }
+
+    public int RecordsScreened { get; }
+
+    public int RecordsIncluded { get; }
+
+    public int RecordsExcluded { get; }
+
+    public int RecordsEscalated { get; }
+
+    public int PendingDecisions { get; }
+}

--- a/src/LM.Review.Core/Models/Analytics/ProjectAnalyticsSnapshot.cs
+++ b/src/LM.Review.Core/Models/Analytics/ProjectAnalyticsSnapshot.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace LM.Review.Core.Models.Analytics;
+
+public sealed class ProjectAnalyticsSnapshot
+{
+    public ProjectAnalyticsSnapshot(
+        string projectId,
+        DateTimeOffset generatedAt,
+        IEnumerable<StageProgressSnapshot> stageProgress,
+        IEnumerable<ReviewerLoadBreakdown> reviewerLoads,
+        ConflictRateSnapshot conflictRates,
+        PrismaFlowSnapshot prismaFlow)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+        ArgumentNullException.ThrowIfNull(stageProgress);
+        ArgumentNullException.ThrowIfNull(reviewerLoads);
+        ArgumentNullException.ThrowIfNull(conflictRates);
+        ArgumentNullException.ThrowIfNull(prismaFlow);
+
+        ProjectId = projectId;
+        GeneratedAt = generatedAt;
+        StageProgress = new ReadOnlyCollection<StageProgressSnapshot>(stageProgress.ToList());
+        ReviewerLoads = new ReadOnlyCollection<ReviewerLoadBreakdown>(reviewerLoads.ToList());
+        ConflictRates = conflictRates;
+        PrismaFlow = prismaFlow;
+    }
+
+    public string ProjectId { get; }
+
+    public DateTimeOffset GeneratedAt { get; }
+
+    public IReadOnlyList<StageProgressSnapshot> StageProgress { get; }
+
+    public IReadOnlyList<ReviewerLoadBreakdown> ReviewerLoads { get; }
+
+    public ConflictRateSnapshot ConflictRates { get; }
+
+    public PrismaFlowSnapshot PrismaFlow { get; }
+}

--- a/src/LM.Review.Core/Models/Analytics/ReviewerLoadBreakdown.cs
+++ b/src/LM.Review.Core/Models/Analytics/ReviewerLoadBreakdown.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace LM.Review.Core.Models.Analytics;
+
+public sealed record ReviewerLoadBreakdown
+{
+    public ReviewerLoadBreakdown(
+        string reviewerId,
+        int activeAssignments,
+        int completedAssignments,
+        double averageDecisionLatencyHours,
+        double throughputPerDay)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reviewerId);
+
+        ReviewerId = reviewerId;
+        ActiveAssignments = activeAssignments;
+        CompletedAssignments = completedAssignments;
+        AverageDecisionLatencyHours = averageDecisionLatencyHours;
+        ThroughputPerDay = throughputPerDay;
+    }
+
+    public string ReviewerId { get; }
+
+    public int ActiveAssignments { get; }
+
+    public int CompletedAssignments { get; }
+
+    public double AverageDecisionLatencyHours { get; }
+
+    public double ThroughputPerDay { get; }
+}

--- a/src/LM.Review.Core/Models/Analytics/StageProgressSnapshot.cs
+++ b/src/LM.Review.Core/Models/Analytics/StageProgressSnapshot.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace LM.Review.Core.Models.Analytics;
+
+public sealed record StageProgressSnapshot
+{
+    public StageProgressSnapshot(
+        string stageDefinitionId,
+        string stageName,
+        ReviewStageType stageType,
+        int totalInstances,
+        int completedInstances,
+        double completionRate,
+        double averageReviewerCompletion)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stageDefinitionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(stageName);
+
+        StageDefinitionId = stageDefinitionId;
+        StageName = stageName;
+        StageType = stageType;
+        TotalInstances = totalInstances;
+        CompletedInstances = completedInstances;
+        CompletionRate = completionRate;
+        AverageReviewerCompletion = averageReviewerCompletion;
+    }
+
+    public string StageDefinitionId { get; }
+
+    public string StageName { get; }
+
+    public ReviewStageType StageType { get; }
+
+    public int TotalInstances { get; }
+
+    public int CompletedInstances { get; }
+
+    public double CompletionRate { get; }
+
+    public double AverageReviewerCompletion { get; }
+}

--- a/src/LM.Review.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Review.Core/PublicAPI.Unshipped.txt
@@ -27,3 +27,68 @@ LM.Review.Core.Services.ReviewerAssignmentRequest.ReviewerId.get -> string!
 LM.Review.Core.Services.ReviewerAssignmentRequest.ReviewerId.init -> void
 LM.Review.Core.Services.ReviewerAssignmentRequest.Role.get -> LM.Review.Core.Models.ReviewerRole
 LM.Review.Core.Services.ReviewerAssignmentRequest.Role.init -> void
+LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter
+LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter.AnalyticsTimelineFilter(System.DateTimeOffset from, System.DateTimeOffset to)
+LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter.Contains(System.DateTimeOffset timestamp) -> bool
+LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter.Duration.get -> System.TimeSpan
+LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter.From.get -> System.DateTimeOffset
+LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter.Overlaps(System.DateTimeOffset start, System.DateTimeOffset? end = null) -> bool
+LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter.To.get -> System.DateTimeOffset
+LM.Review.Core.Models.Analytics.ConflictRateSnapshot
+LM.Review.Core.Models.Analytics.ConflictRateSnapshot.ConflictRateSnapshot(int totalStages, int conflictCount, int escalatedCount, int resolvedCount, int openConflicts, double conflictRate, double escalationRate, double resolutionRate)
+LM.Review.Core.Models.Analytics.ConflictRateSnapshot.ConflictCount.get -> int
+LM.Review.Core.Models.Analytics.ConflictRateSnapshot.ConflictRate.get -> double
+LM.Review.Core.Models.Analytics.ConflictRateSnapshot.EscalatedCount.get -> int
+LM.Review.Core.Models.Analytics.ConflictRateSnapshot.EscalationRate.get -> double
+LM.Review.Core.Models.Analytics.ConflictRateSnapshot.OpenConflicts.get -> int
+LM.Review.Core.Models.Analytics.ConflictRateSnapshot.ResolutionRate.get -> double
+LM.Review.Core.Models.Analytics.ConflictRateSnapshot.ResolvedCount.get -> int
+LM.Review.Core.Models.Analytics.ConflictRateSnapshot.TotalStages.get -> int
+LM.Review.Core.Models.Analytics.PrismaFlowSnapshot
+LM.Review.Core.Models.Analytics.PrismaFlowSnapshot.PendingDecisions.get -> int
+LM.Review.Core.Models.Analytics.PrismaFlowSnapshot.PrismaFlowSnapshot(int recordsIdentified, int recordsScreened, int recordsIncluded, int recordsExcluded, int recordsEscalated, int pendingDecisions)
+LM.Review.Core.Models.Analytics.PrismaFlowSnapshot.RecordsEscalated.get -> int
+LM.Review.Core.Models.Analytics.PrismaFlowSnapshot.RecordsExcluded.get -> int
+LM.Review.Core.Models.Analytics.PrismaFlowSnapshot.RecordsIdentified.get -> int
+LM.Review.Core.Models.Analytics.PrismaFlowSnapshot.RecordsIncluded.get -> int
+LM.Review.Core.Models.Analytics.PrismaFlowSnapshot.RecordsScreened.get -> int
+LM.Review.Core.Models.Analytics.ProjectAnalyticsSnapshot
+LM.Review.Core.Models.Analytics.ProjectAnalyticsSnapshot.ConflictRates.get -> LM.Review.Core.Models.Analytics.ConflictRateSnapshot!
+LM.Review.Core.Models.Analytics.ProjectAnalyticsSnapshot.GeneratedAt.get -> System.DateTimeOffset
+LM.Review.Core.Models.Analytics.ProjectAnalyticsSnapshot.PrismaFlow.get -> LM.Review.Core.Models.Analytics.PrismaFlowSnapshot!
+LM.Review.Core.Models.Analytics.ProjectAnalyticsSnapshot.ProjectAnalyticsSnapshot(string! projectId, System.DateTimeOffset generatedAt, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Analytics.StageProgressSnapshot!>! stageProgress, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Analytics.ReviewerLoadBreakdown!>! reviewerLoads, LM.Review.Core.Models.Analytics.ConflictRateSnapshot! conflictRates, LM.Review.Core.Models.Analytics.PrismaFlowSnapshot! prismaFlow)
+LM.Review.Core.Models.Analytics.ProjectAnalyticsSnapshot.ProjectId.get -> string!
+LM.Review.Core.Models.Analytics.ProjectAnalyticsSnapshot.ReviewerLoads.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Analytics.ReviewerLoadBreakdown!>!
+LM.Review.Core.Models.Analytics.ProjectAnalyticsSnapshot.StageProgress.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Analytics.StageProgressSnapshot!>!
+LM.Review.Core.Models.Analytics.ReviewerLoadBreakdown
+LM.Review.Core.Models.Analytics.ReviewerLoadBreakdown.ActiveAssignments.get -> int
+LM.Review.Core.Models.Analytics.ReviewerLoadBreakdown.AverageDecisionLatencyHours.get -> double
+LM.Review.Core.Models.Analytics.ReviewerLoadBreakdown.CompletedAssignments.get -> int
+LM.Review.Core.Models.Analytics.ReviewerLoadBreakdown.ReviewerId.get -> string!
+LM.Review.Core.Models.Analytics.ReviewerLoadBreakdown.ReviewerLoadBreakdown(string! reviewerId, int activeAssignments, int completedAssignments, double averageDecisionLatencyHours, double throughputPerDay)
+LM.Review.Core.Models.Analytics.ReviewerLoadBreakdown.ThroughputPerDay.get -> double
+LM.Review.Core.Models.Analytics.StageProgressSnapshot
+LM.Review.Core.Models.Analytics.StageProgressSnapshot.AverageReviewerCompletion.get -> double
+LM.Review.Core.Models.Analytics.StageProgressSnapshot.CompletedInstances.get -> int
+LM.Review.Core.Models.Analytics.StageProgressSnapshot.CompletionRate.get -> double
+LM.Review.Core.Models.Analytics.StageProgressSnapshot.StageDefinitionId.get -> string!
+LM.Review.Core.Models.Analytics.StageProgressSnapshot.StageName.get -> string!
+LM.Review.Core.Models.Analytics.StageProgressSnapshot.StageProgressSnapshot(string! stageDefinitionId, string! stageName, LM.Review.Core.Models.ReviewStageType stageType, int totalInstances, int completedInstances, double completionRate, double averageReviewerCompletion)
+LM.Review.Core.Models.Analytics.StageProgressSnapshot.StageType.get -> LM.Review.Core.Models.ReviewStageType
+LM.Review.Core.Models.Analytics.StageProgressSnapshot.TotalInstances.get -> int
+LM.Review.Core.Services.IReviewAnalyticsService
+LM.Review.Core.Services.IReviewAnalyticsService.CreateSnapshot(LM.Review.Core.Models.ReviewProject! project, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.ReviewStage!>! stages, LM.Review.Core.Services.ReviewAnalyticsQueryOptions? options = null) -> LM.Review.Core.Models.Analytics.ProjectAnalyticsSnapshot!
+LM.Review.Core.Services.ReviewAnalyticsQuery
+LM.Review.Core.Services.ReviewAnalyticsQuery.ActivatedWithin(LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter filter) -> System.Func<LM.Review.Core.Models.ReviewStage!, bool!>!
+LM.Review.Core.Services.ReviewAnalyticsQuery.AssignedWithin(LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter filter) -> System.Func<LM.Review.Core.Models.ScreeningAssignment!, bool!>!
+LM.Review.Core.Services.ReviewAnalyticsQuery.CompletedWithin(LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter filter) -> System.Func<LM.Review.Core.Models.ScreeningAssignment!, bool!>!
+LM.Review.Core.Services.ReviewAnalyticsQuery.LastDays(int days, System.DateTimeOffset referenceTime) -> LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter
+LM.Review.Core.Services.ReviewAnalyticsQueryOptions
+LM.Review.Core.Services.ReviewAnalyticsQueryOptions.AssignmentFilter.get -> System.Func<LM.Review.Core.Models.ScreeningAssignment!, bool!>?
+LM.Review.Core.Services.ReviewAnalyticsQueryOptions.CreateDefault(System.DateTimeOffset referenceTime) -> LM.Review.Core.Services.ReviewAnalyticsQueryOptions!
+LM.Review.Core.Services.ReviewAnalyticsQueryOptions.ReferenceTime.get -> System.DateTimeOffset
+LM.Review.Core.Services.ReviewAnalyticsQueryOptions.ReviewAnalyticsQueryOptions(System.DateTimeOffset referenceTime, LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter? timelineFilter = null, System.Func<LM.Review.Core.Models.ReviewStage!, bool!>? stageFilter = null, System.Func<LM.Review.Core.Models.ScreeningAssignment!, bool!>? assignmentFilter = null)
+LM.Review.Core.Services.ReviewAnalyticsQueryOptions.StageFilter.get -> System.Func<LM.Review.Core.Models.ReviewStage!, bool!>?
+LM.Review.Core.Services.ReviewAnalyticsQueryOptions.TimelineFilter.get -> LM.Review.Core.Models.Analytics.AnalyticsTimelineFilter?
+LM.Review.Core.Services.ReviewAnalyticsService
+LM.Review.Core.Services.ReviewAnalyticsService.CreateSnapshot(LM.Review.Core.Models.ReviewProject! project, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.ReviewStage!>! stages, LM.Review.Core.Services.ReviewAnalyticsQueryOptions? options = null) -> LM.Review.Core.Models.Analytics.ProjectAnalyticsSnapshot!

--- a/src/LM.Review.Core/Services/IReviewAnalyticsService.cs
+++ b/src/LM.Review.Core/Services/IReviewAnalyticsService.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using LM.Review.Core.Models;
+using LM.Review.Core.Models.Analytics;
+
+namespace LM.Review.Core.Services;
+
+public interface IReviewAnalyticsService
+{
+    ProjectAnalyticsSnapshot CreateSnapshot(
+        ReviewProject project,
+        IEnumerable<ReviewStage> stages,
+        ReviewAnalyticsQueryOptions? options = null);
+}

--- a/src/LM.Review.Core/Services/ReviewAnalyticsQuery.cs
+++ b/src/LM.Review.Core/Services/ReviewAnalyticsQuery.cs
@@ -1,0 +1,33 @@
+using System;
+using LM.Review.Core.Models;
+using LM.Review.Core.Models.Analytics;
+
+namespace LM.Review.Core.Services;
+
+public static class ReviewAnalyticsQuery
+{
+    public static AnalyticsTimelineFilter LastDays(int days, DateTimeOffset referenceTime)
+    {
+        if (days <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(days), "The number of days must be greater than zero.");
+        }
+
+        return new AnalyticsTimelineFilter(referenceTime.AddDays(-days), referenceTime);
+    }
+
+    public static Func<ReviewStage, bool> ActivatedWithin(AnalyticsTimelineFilter filter)
+    {
+        return stage => filter.Overlaps(stage.ActivatedAt, stage.CompletedAt);
+    }
+
+    public static Func<ScreeningAssignment, bool> AssignedWithin(AnalyticsTimelineFilter filter)
+    {
+        return assignment => filter.Overlaps(assignment.AssignedAt, assignment.CompletedAt ?? filter.To);
+    }
+
+    public static Func<ScreeningAssignment, bool> CompletedWithin(AnalyticsTimelineFilter filter)
+    {
+        return assignment => assignment.CompletedAt is not null && filter.Contains(assignment.CompletedAt.Value);
+    }
+}

--- a/src/LM.Review.Core/Services/ReviewAnalyticsQueryOptions.cs
+++ b/src/LM.Review.Core/Services/ReviewAnalyticsQueryOptions.cs
@@ -1,0 +1,30 @@
+using System;
+using LM.Review.Core.Models;
+using LM.Review.Core.Models.Analytics;
+
+namespace LM.Review.Core.Services;
+
+public sealed record ReviewAnalyticsQueryOptions
+{
+    public ReviewAnalyticsQueryOptions(
+        DateTimeOffset referenceTime,
+        AnalyticsTimelineFilter? timelineFilter = null,
+        Func<ReviewStage, bool>? stageFilter = null,
+        Func<ScreeningAssignment, bool>? assignmentFilter = null)
+    {
+        ReferenceTime = referenceTime;
+        TimelineFilter = timelineFilter;
+        StageFilter = stageFilter;
+        AssignmentFilter = assignmentFilter;
+    }
+
+    public DateTimeOffset ReferenceTime { get; }
+
+    public AnalyticsTimelineFilter? TimelineFilter { get; }
+
+    public Func<ReviewStage, bool>? StageFilter { get; }
+
+    public Func<ScreeningAssignment, bool>? AssignmentFilter { get; }
+
+    public static ReviewAnalyticsQueryOptions CreateDefault(DateTimeOffset referenceTime) => new(referenceTime);
+}

--- a/src/LM.Review.Core/Services/ReviewAnalyticsService.cs
+++ b/src/LM.Review.Core/Services/ReviewAnalyticsService.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LM.Review.Core.Models;
+using LM.Review.Core.Models.Analytics;
+
+namespace LM.Review.Core.Services;
+
+public sealed class ReviewAnalyticsService : IReviewAnalyticsService
+{
+    public ProjectAnalyticsSnapshot CreateSnapshot(
+        ReviewProject project,
+        IEnumerable<ReviewStage> stages,
+        ReviewAnalyticsQueryOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        ArgumentNullException.ThrowIfNull(stages);
+
+        var resolvedOptions = options ?? ReviewAnalyticsQueryOptions.CreateDefault(DateTimeOffset.UtcNow);
+        var stageList = new List<ReviewStage>();
+
+        foreach (var stage in stages)
+        {
+            ArgumentNullException.ThrowIfNull(stage);
+            if (!string.Equals(stage.ProjectId, project.Id, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (resolvedOptions.StageFilter is not null && !resolvedOptions.StageFilter(stage))
+            {
+                continue;
+            }
+
+            stageList.Add(stage);
+        }
+
+        var assignmentsByStage = new Dictionary<string, IReadOnlyList<ScreeningAssignment>>(StringComparer.Ordinal);
+        var allAssignments = new List<ScreeningAssignment>();
+
+        foreach (var stage in stageList)
+        {
+            var filteredAssignments = new List<ScreeningAssignment>();
+            foreach (var assignment in stage.Assignments)
+            {
+                if (resolvedOptions.AssignmentFilter is not null && !resolvedOptions.AssignmentFilter(assignment))
+                {
+                    continue;
+                }
+
+                filteredAssignments.Add(assignment);
+                allAssignments.Add(assignment);
+            }
+
+            assignmentsByStage[stage.Id] = filteredAssignments;
+        }
+
+        var stageProgress = BuildStageProgress(project.StageDefinitions, stageList, assignmentsByStage);
+        var reviewerLoads = BuildReviewerLoads(allAssignments, resolvedOptions.ReferenceTime, resolvedOptions.TimelineFilter);
+        var conflictRates = BuildConflictRates(stageList);
+        var prismaFlow = BuildPrismaFlow(stageList, assignmentsByStage);
+
+        return new ProjectAnalyticsSnapshot(
+            project.Id,
+            resolvedOptions.ReferenceTime,
+            stageProgress,
+            reviewerLoads,
+            conflictRates,
+            prismaFlow);
+    }
+
+    private static IReadOnlyList<StageProgressSnapshot> BuildStageProgress(
+        IReadOnlyList<StageDefinition> stageDefinitions,
+        IReadOnlyList<ReviewStage> stages,
+        IReadOnlyDictionary<string, IReadOnlyList<ScreeningAssignment>> assignmentsByStage)
+    {
+        var snapshots = new List<StageProgressSnapshot>(stageDefinitions.Count);
+
+        foreach (var definition in stageDefinitions)
+        {
+            var matchingStages = stages
+                .Where(stage => string.Equals(stage.Definition.Id, definition.Id, StringComparison.Ordinal))
+                .ToList();
+
+            var totalInstances = matchingStages.Count;
+            var completedInstances = matchingStages.Count(stage => stage.IsComplete);
+            var reviewerRequirement = Math.Max(1, definition.ReviewerRequirement.TotalRequired);
+            var reviewerCompletionAccumulator = 0d;
+
+            foreach (var stage in matchingStages)
+            {
+                var stageAssignments = assignmentsByStage.TryGetValue(stage.Id, out var list)
+                    ? list
+                    : Array.Empty<ScreeningAssignment>();
+
+                var completedCount = stageAssignments.Count(assignment => IsTerminalStatus(assignment.Status));
+                reviewerCompletionAccumulator += Math.Clamp((double)completedCount / reviewerRequirement, 0d, 1d);
+            }
+
+            var completionRate = totalInstances == 0 ? 0d : (double)completedInstances / totalInstances;
+            var averageReviewerCompletion = totalInstances == 0 ? 0d : reviewerCompletionAccumulator / totalInstances;
+
+            snapshots.Add(new StageProgressSnapshot(
+                definition.Id,
+                definition.Name,
+                definition.StageType,
+                totalInstances,
+                completedInstances,
+                completionRate,
+                averageReviewerCompletion));
+        }
+
+        return snapshots;
+    }
+
+    private static IReadOnlyList<ReviewerLoadBreakdown> BuildReviewerLoads(
+        IReadOnlyList<ScreeningAssignment> assignments,
+        DateTimeOffset referenceTime,
+        AnalyticsTimelineFilter? timelineFilter)
+    {
+        if (assignments.Count == 0)
+        {
+            return Array.Empty<ReviewerLoadBreakdown>();
+        }
+
+        var groups = assignments.GroupBy(assignment => assignment.ReviewerId, StringComparer.Ordinal);
+        var results = new List<ReviewerLoadBreakdown>();
+
+        foreach (var group in groups)
+        {
+            var reviewerAssignments = group.ToList();
+            var active = reviewerAssignments.Count(assignment => IsActiveStatus(assignment.Status));
+            var completed = reviewerAssignments.Count(assignment => IsTerminalStatus(assignment.Status));
+
+            var latencyValues = reviewerAssignments
+                .Where(assignment => assignment.CompletedAt.HasValue)
+                .Select(assignment => (assignment.CompletedAt!.Value - assignment.AssignedAt).TotalHours)
+                .ToList();
+
+            var averageLatency = latencyValues.Count == 0 ? 0d : latencyValues.Average();
+
+            double measurementWindowDays;
+            if (timelineFilter.HasValue)
+            {
+                measurementWindowDays = Math.Max(1d, timelineFilter.Value.Duration.TotalDays);
+            }
+            else
+            {
+                var earliest = reviewerAssignments.Min(assignment => assignment.AssignedAt);
+                var span = (referenceTime - earliest).TotalDays;
+                measurementWindowDays = Math.Max(1d, span);
+            }
+
+            var throughput = completed / measurementWindowDays;
+
+            results.Add(new ReviewerLoadBreakdown(
+                group.Key,
+                active,
+                completed,
+                Math.Round(averageLatency, 2, MidpointRounding.AwayFromZero),
+                Math.Round(throughput, 2, MidpointRounding.AwayFromZero)));
+        }
+
+        return results
+            .OrderByDescending(result => result.ActiveAssignments)
+            .ThenBy(result => result.ReviewerId, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static ConflictRateSnapshot BuildConflictRates(IReadOnlyList<ReviewStage> stages)
+    {
+        if (stages.Count == 0)
+        {
+            return new ConflictRateSnapshot(0, 0, 0, 0, 0, 0d, 0d, 0d);
+        }
+
+        var totalStages = stages.Count;
+        var conflictCount = stages.Count(stage => stage.ConflictState != ConflictState.None);
+        var escalatedCount = stages.Count(stage => stage.ConflictState == ConflictState.Escalated);
+        var resolvedCount = stages.Count(stage => stage.ConflictState == ConflictState.Resolved);
+        var openConflicts = stages.Count(stage => stage.ConflictState is ConflictState.Conflict or ConflictState.Escalated);
+
+        var conflictRate = (double)conflictCount / totalStages;
+        var escalationRate = (double)escalatedCount / totalStages;
+        var resolutionRate = conflictCount == 0 ? 0d : (double)resolvedCount / conflictCount;
+
+        return new ConflictRateSnapshot(
+            totalStages,
+            conflictCount,
+            escalatedCount,
+            resolvedCount,
+            openConflicts,
+            conflictRate,
+            escalationRate,
+            resolutionRate);
+    }
+
+    private static PrismaFlowSnapshot BuildPrismaFlow(
+        IReadOnlyList<ReviewStage> stages,
+        IReadOnlyDictionary<string, IReadOnlyList<ScreeningAssignment>> assignmentsByStage)
+    {
+        var prismaStages = stages
+            .Where(stage => stage.Definition.StageType is ReviewStageType.TitleScreening or ReviewStageType.FullTextReview)
+            .ToList();
+
+        if (prismaStages.Count == 0)
+        {
+            return new PrismaFlowSnapshot(0, 0, 0, 0, 0, 0);
+        }
+
+        var identified = prismaStages.Count;
+        var screened = 0;
+        var included = 0;
+        var excluded = 0;
+        var escalated = 0;
+
+        foreach (var stage in prismaStages)
+        {
+            if (stage.ConflictState == ConflictState.Escalated)
+            {
+                escalated++;
+            }
+
+            var assignments = assignmentsByStage.TryGetValue(stage.Id, out var list)
+                ? list
+                : Array.Empty<ScreeningAssignment>();
+
+            var allTerminal = assignments.Count > 0 && assignments.All(assignment => IsTerminalStatus(assignment.Status));
+
+            if (stage.IsComplete || allTerminal)
+            {
+                screened++;
+            }
+
+            var consensus = stage.Consensus;
+            if (consensus is not null)
+            {
+                if (consensus.Approved)
+                {
+                    included++;
+                }
+                else
+                {
+                    excluded++;
+                }
+
+                continue;
+            }
+
+            if (!allTerminal)
+            {
+                continue;
+            }
+
+            if (assignments.All(assignment => assignment.Status == ScreeningStatus.Included))
+            {
+                included++;
+            }
+            else if (assignments.All(assignment => assignment.Status == ScreeningStatus.Excluded))
+            {
+                excluded++;
+            }
+        }
+
+        var pending = Math.Max(0, identified - screened);
+
+        return new PrismaFlowSnapshot(identified, screened, included, excluded, escalated, pending);
+    }
+
+    private static bool IsTerminalStatus(ScreeningStatus status) =>
+        status is ScreeningStatus.Included or ScreeningStatus.Excluded;
+
+    private static bool IsActiveStatus(ScreeningStatus status) =>
+        status is ScreeningStatus.Pending or ScreeningStatus.InProgress or ScreeningStatus.Escalated;
+}


### PR DESCRIPTION
## Summary
- add analytics DTOs and a review analytics service to compute stage progress, reviewer throughput, conflict rates, and PRISMA flow counts
- introduce timeline filter helpers and query options for reuse across dashboard toggles
- cover the analytics service with unit tests spanning conflict-heavy and filtered datasets

## Testing
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: .NET SDK 8.0.414 cannot build net9.0 projects)*

------
https://chatgpt.com/codex/tasks/task_e_68d68c2abe60832b9da1fc8605ebbe67