### PR TITLE
Add data extraction stage type to review workflow

### DIFF
--- a/src/LM.Review.Core.Tests/Models/StageDefinitionTests.cs
+++ b/src/LM.Review.Core.Tests/Models/StageDefinitionTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using LM.Review.Core.Models;
+using Xunit;
+
+namespace LM.Review.Core.Tests.Models;
+
+public sealed class StageDefinitionTests
+{
+    [Fact]
+    public void Create_WithDataExtractionStage_PreservesStageType()
+    {
+        var requirement = ReviewerRequirement.Create(new[]
+        {
+            new KeyValuePair<ReviewerRole, int>(ReviewerRole.Primary, 1)
+        });
+        var consensus = StageConsensusPolicy.Disabled();
+
+        var definition = StageDefinition.Create(
+            id: "extract-1",
+            name: "Data Extraction",
+            stageType: ReviewStageType.DataExtraction,
+            reviewerRequirement: requirement,
+            consensusPolicy: consensus);
+
+        Assert.Equal(ReviewStageType.DataExtraction, definition.StageType);
+    }
+}

--- a/src/LM.Review.Core/Models/ReviewStageType.cs
+++ b/src/LM.Review.Core/Models/ReviewStageType.cs
@@ -5,5 +5,6 @@ public enum ReviewStageType
     TitleScreening = 0,
     FullTextReview = 1,
     ConsensusMeeting = 2,
-    QualityAssurance = 3
+    QualityAssurance = 3,
+    DataExtraction = 4
 }

--- a/src/LM.Review.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Review.Core/PublicAPI.Unshipped.txt
@@ -27,3 +27,4 @@ LM.Review.Core.Services.ReviewerAssignmentRequest.ReviewerId.get -> string!
 LM.Review.Core.Services.ReviewerAssignmentRequest.ReviewerId.init -> void
 LM.Review.Core.Services.ReviewerAssignmentRequest.Role.get -> LM.Review.Core.Models.ReviewerRole
 LM.Review.Core.Services.ReviewerAssignmentRequest.Role.init -> void
+LM.Review.Core.Models.ReviewStageType.DataExtraction = 4 -> LM.Review.Core.Models.ReviewStageType


### PR DESCRIPTION
## Summary
- add a DataExtraction value to `ReviewStageType` so downstream code can target the extraction workflow
- cover the new stage type through a focused `StageDefinition` unit test
- record the enum expansion in the public API tracking file

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug`
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: `LM.HubSpoke.Tests.SqliteSearchIndexFullTextTests.FullTextSearch_ReturnsMatchesWithScoreAndSnippet` expected highlight substring)*

------
https://chatgpt.com/codex/tasks/task_e_68d68e5f6d74832b9d663de156d031a2