### PR TITLE
Implement KnowledgeGraphHub for data extraction insights

### DIFF
--- a/docs/knowledge-graph-hub.md
+++ b/docs/knowledge-graph-hub.md
@@ -1,0 +1,29 @@
+# Knowledge Graph Hub
+
+The knowledge graph hub materializes structured data captured in `DataExtraction` hooks into a SQLite graph that supports cross-entry insights.
+
+## Responsibilities
+
+- Load `hub.json` metadata to discover the `data_extraction` hook for each entry.
+- Parse the `DataExtractionHook` payload and project paper, population, intervention, and endpoint nodes.
+- Persist relationships such as population assignments, intervention edges, and endpoint readouts in `extraction/knowledge_graph.db`.
+- Expose query helpers for mortality comparisons, Kaplan–Meier overlays, and baseline characteristic lookups.
+
+## Query surface
+
+| Method | Description |
+| --- | --- |
+| `GetMortalityComparisonsAsync` | Returns endpoint readouts flagged as mortality along with the source and comparator interventions. |
+| `GetKaplanMeierOverlaysAsync` | Retrieves Kaplan–Meier curves for an entry (optionally filtered to a single endpoint) so callers can overlay survival estimates. |
+| `SearchBaselineCharacteristicsAsync` | Performs a case-insensitive search over stored baseline characteristics, returning the matching populations. |
+| `GetEntryOverviewAsync` | Provides a snapshot of the nodes and edges currently persisted for an entry, useful for diagnostics and visualizations. |
+
+All APIs accept a `CancellationToken` and rely on the shared workspace service for path resolution. Graph initialization creates the backing SQLite database on demand under the workspace extraction folder.
+
+## Notifications
+
+`HubSpokeStore` invokes `IKnowledgeGraphHub.RefreshEntryAsync` after every save so the graph reflects new or updated hooks immediately. When an extraction file is missing, the hub prunes existing nodes to avoid stale results.
+
+## Testing
+
+`KnowledgeGraphHubTests` covers ingestion of sample extraction hooks, query projections, and the integration point with `HubSpokeStore`. Use `dotnet test` to validate changes before committing.

--- a/src/LM.HubAndSpoke/Hubs/KnowledgeGraph/GraphRecords.cs
+++ b/src/LM.HubAndSpoke/Hubs/KnowledgeGraph/GraphRecords.cs
@@ -1,0 +1,214 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace LM.HubSpoke.Hubs.KnowledgeGraph
+{
+    public sealed class MortalityComparison
+    {
+        public MortalityComparison(
+            string entryId,
+            string entryTitle,
+            string endpointId,
+            string endpointName,
+            string? populationId,
+            string? interventionId,
+            string? interventionName,
+            string? comparatorInterventionId,
+            string? comparatorName,
+            double? value,
+            string? unit,
+            string? metric,
+            string? timepoint)
+        {
+            EntryId = entryId;
+            EntryTitle = entryTitle;
+            EndpointId = endpointId;
+            EndpointName = endpointName;
+            PopulationId = populationId;
+            InterventionId = interventionId;
+            InterventionName = interventionName;
+            ComparatorInterventionId = comparatorInterventionId;
+            ComparatorName = comparatorName;
+            Value = value;
+            Unit = unit;
+            Metric = metric;
+            Timepoint = timepoint;
+        }
+
+        public string EntryId { get; }
+        public string EntryTitle { get; }
+        public string EndpointId { get; }
+        public string EndpointName { get; }
+        public string? PopulationId { get; }
+        public string? InterventionId { get; }
+        public string? InterventionName { get; }
+        public string? ComparatorInterventionId { get; }
+        public string? ComparatorName { get; }
+        public double? Value { get; }
+        public string? Unit { get; }
+        public string? Metric { get; }
+        public string? Timepoint { get; }
+    }
+
+    public sealed class KaplanMeierOverlay
+    {
+        public KaplanMeierOverlay(
+            string entryId,
+            string entryTitle,
+            string endpointId,
+            string endpointName,
+            string? populationId,
+            string? interventionId,
+            string? interventionName,
+            IReadOnlyList<KaplanMeierPointDto> curve)
+        {
+            EntryId = entryId;
+            EntryTitle = entryTitle;
+            EndpointId = endpointId;
+            EndpointName = endpointName;
+            PopulationId = populationId;
+            InterventionId = interventionId;
+            InterventionName = interventionName;
+            Curve = curve;
+        }
+
+        public string EntryId { get; }
+        public string EntryTitle { get; }
+        public string EndpointId { get; }
+        public string EndpointName { get; }
+        public string? PopulationId { get; }
+        public string? InterventionId { get; }
+        public string? InterventionName { get; }
+        public IReadOnlyList<KaplanMeierPointDto> Curve { get; }
+    }
+
+    public sealed class KaplanMeierPointDto
+    {
+        public KaplanMeierPointDto(double time, double survivalProbability)
+        {
+            Time = time;
+            SurvivalProbability = survivalProbability;
+        }
+
+        public double Time { get; }
+        public double SurvivalProbability { get; }
+    }
+
+    public sealed class BaselineCharacteristicHit
+    {
+        public BaselineCharacteristicHit(
+            string entryId,
+            string entryTitle,
+            string populationId,
+            string populationName,
+            string characteristic,
+            string value)
+        {
+            EntryId = entryId;
+            EntryTitle = entryTitle;
+            PopulationId = populationId;
+            PopulationName = populationName;
+            Characteristic = characteristic;
+            Value = value;
+        }
+
+        public string EntryId { get; }
+        public string EntryTitle { get; }
+        public string PopulationId { get; }
+        public string PopulationName { get; }
+        public string Characteristic { get; }
+        public string Value { get; }
+    }
+
+    public sealed class GraphPopulationNode
+    {
+        public GraphPopulationNode(string populationId, string name, string? description)
+        {
+            PopulationId = populationId;
+            Name = name;
+            Description = description;
+        }
+
+        public string PopulationId { get; }
+        public string Name { get; }
+        public string? Description { get; }
+    }
+
+    public sealed class GraphInterventionNode
+    {
+        public GraphInterventionNode(string interventionId, string name, string? type, string? description)
+        {
+            InterventionId = interventionId;
+            Name = name;
+            Type = type;
+            Description = description;
+        }
+
+        public string InterventionId { get; }
+        public string Name { get; }
+        public string? Type { get; }
+        public string? Description { get; }
+    }
+
+    public sealed class GraphEndpointNode
+    {
+        public GraphEndpointNode(string endpointId, string name, string category, string? description)
+        {
+            EndpointId = endpointId;
+            Name = name;
+            Category = category;
+            Description = description;
+        }
+
+        public string EndpointId { get; }
+        public string Name { get; }
+        public string Category { get; }
+        public string? Description { get; }
+    }
+
+    public sealed class GraphEdge
+    {
+        public GraphEdge(string sourceType, string sourceId, string targetType, string targetId, string relationship, string? payloadJson)
+        {
+            SourceType = sourceType;
+            SourceId = sourceId;
+            TargetType = targetType;
+            TargetId = targetId;
+            Relationship = relationship;
+            PayloadJson = payloadJson;
+        }
+
+        public string SourceType { get; }
+        public string SourceId { get; }
+        public string TargetType { get; }
+        public string TargetId { get; }
+        public string Relationship { get; }
+        public string? PayloadJson { get; }
+    }
+
+    public sealed class GraphEntryOverview
+    {
+        public GraphEntryOverview(
+            string entryId,
+            string title,
+            IReadOnlyList<GraphPopulationNode> populations,
+            IReadOnlyList<GraphInterventionNode> interventions,
+            IReadOnlyList<GraphEndpointNode> endpoints,
+            IReadOnlyList<GraphEdge> edges)
+        {
+            EntryId = entryId;
+            Title = title;
+            Populations = populations;
+            Interventions = interventions;
+            Endpoints = endpoints;
+            Edges = edges;
+        }
+
+        public string EntryId { get; }
+        public string Title { get; }
+        public IReadOnlyList<GraphPopulationNode> Populations { get; }
+        public IReadOnlyList<GraphInterventionNode> Interventions { get; }
+        public IReadOnlyList<GraphEndpointNode> Endpoints { get; }
+        public IReadOnlyList<GraphEdge> Edges { get; }
+    }
+}

--- a/src/LM.HubAndSpoke/Hubs/KnowledgeGraph/IKnowledgeGraphHub.cs
+++ b/src/LM.HubAndSpoke/Hubs/KnowledgeGraph/IKnowledgeGraphHub.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LM.HubSpoke.Hubs.KnowledgeGraph
+{
+    public interface IKnowledgeGraphHub
+    {
+        Task InitializeAsync(CancellationToken ct = default);
+
+        Task RefreshEntryAsync(string entryId, CancellationToken ct = default);
+
+        Task<IReadOnlyList<MortalityComparison>> GetMortalityComparisonsAsync(string? entryId = null, CancellationToken ct = default);
+
+        Task<IReadOnlyList<KaplanMeierOverlay>> GetKaplanMeierOverlaysAsync(string entryId, string? endpointId = null, CancellationToken ct = default);
+
+        Task<IReadOnlyList<BaselineCharacteristicHit>> SearchBaselineCharacteristicsAsync(
+            string characteristicSearchTerm,
+            string? valueContains = null,
+            CancellationToken ct = default);
+
+        Task<GraphEntryOverview?> GetEntryOverviewAsync(string entryId, CancellationToken ct = default);
+    }
+}

--- a/src/LM.HubAndSpoke/Hubs/KnowledgeGraph/KnowledgeGraphHub.cs
+++ b/src/LM.HubAndSpoke/Hubs/KnowledgeGraph/KnowledgeGraphHub.cs
@@ -1,0 +1,137 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Abstractions;
+using LM.HubSpoke.Models;
+
+namespace LM.HubSpoke.Hubs.KnowledgeGraph
+{
+    public sealed class KnowledgeGraphHub : IKnowledgeGraphHub
+    {
+        private readonly IWorkSpaceService _workspace;
+        private readonly KnowledgeGraphStore _store;
+        private readonly SemaphoreSlim _initLock = new(1, 1);
+        private volatile bool _initialized;
+
+        public KnowledgeGraphHub(IWorkSpaceService workspace)
+        {
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+            _store = new KnowledgeGraphStore(workspace);
+        }
+
+        public async Task InitializeAsync(CancellationToken ct = default)
+        {
+            if (_initialized)
+                return;
+
+            await _initLock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (_initialized)
+                    return;
+
+                await _store.InitializeAsync(ct).ConfigureAwait(false);
+                _initialized = true;
+            }
+            finally
+            {
+                _initLock.Release();
+            }
+        }
+
+        public async Task RefreshEntryAsync(string entryId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(entryId))
+                throw new ArgumentException("Entry id must be provided.", nameof(entryId));
+
+            await EnsureInitializedAsync(ct).ConfigureAwait(false);
+
+            var hub = await HubJsonStore.LoadAsync(_workspace, entryId, ct).ConfigureAwait(false);
+            if (hub is null)
+            {
+                await _store.DeleteEntryAsync(entryId, ct).ConfigureAwait(false);
+                return;
+            }
+
+            var relPath = hub.Hooks?.DataExtraction;
+            if (string.IsNullOrWhiteSpace(relPath))
+            {
+                await _store.DeleteEntryAsync(entryId, ct).ConfigureAwait(false);
+                return;
+            }
+
+            var absPath = Path.IsPathRooted(relPath)
+                ? relPath
+                : _workspace.GetAbsolutePath(relPath);
+            if (!File.Exists(absPath))
+            {
+                await _store.DeleteEntryAsync(entryId, ct).ConfigureAwait(false);
+                return;
+            }
+
+            DataExtractionHook? hook;
+            try
+            {
+                var json = await File.ReadAllTextAsync(absPath, ct).ConfigureAwait(false);
+                hook = JsonSerializer.Deserialize<DataExtractionHook>(json, JsonStd.Options);
+            }
+            catch
+            {
+                hook = null;
+            }
+
+            if (hook is null)
+            {
+                await _store.DeleteEntryAsync(entryId, ct).ConfigureAwait(false);
+                return;
+            }
+
+            await _store.ReplaceEntryAsync(hub, hook, ct).ConfigureAwait(false);
+        }
+
+        public async Task<IReadOnlyList<MortalityComparison>> GetMortalityComparisonsAsync(string? entryId = null, CancellationToken ct = default)
+        {
+            await EnsureInitializedAsync(ct).ConfigureAwait(false);
+            return await _store.QueryMortalityComparisonsAsync(entryId, ct).ConfigureAwait(false);
+        }
+
+        public async Task<IReadOnlyList<KaplanMeierOverlay>> GetKaplanMeierOverlaysAsync(string entryId, string? endpointId = null, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(entryId))
+                throw new ArgumentException("Entry id must be provided.", nameof(entryId));
+
+            await EnsureInitializedAsync(ct).ConfigureAwait(false);
+            return await _store.QueryKaplanMeierAsync(entryId, endpointId, ct).ConfigureAwait(false);
+        }
+
+        public async Task<IReadOnlyList<BaselineCharacteristicHit>> SearchBaselineCharacteristicsAsync(string characteristicSearchTerm, string? valueContains = null, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(characteristicSearchTerm))
+                throw new ArgumentException("Characteristic search term must be provided.", nameof(characteristicSearchTerm));
+
+            await EnsureInitializedAsync(ct).ConfigureAwait(false);
+            return await _store.QueryBaselineAsync(characteristicSearchTerm, valueContains, ct).ConfigureAwait(false);
+        }
+
+        public async Task<GraphEntryOverview?> GetEntryOverviewAsync(string entryId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(entryId))
+                throw new ArgumentException("Entry id must be provided.", nameof(entryId));
+
+            await EnsureInitializedAsync(ct).ConfigureAwait(false);
+            return await _store.LoadEntryOverviewAsync(entryId, ct).ConfigureAwait(false);
+        }
+
+        private async Task EnsureInitializedAsync(CancellationToken ct)
+        {
+            if (_initialized)
+                return;
+
+            await InitializeAsync(ct).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/LM.HubAndSpoke/Hubs/KnowledgeGraph/KnowledgeGraphStore.cs
+++ b/src/LM.HubAndSpoke/Hubs/KnowledgeGraph/KnowledgeGraphStore.cs
@@ -1,0 +1,551 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Abstractions;
+using LM.HubSpoke.Models;
+using Microsoft.Data.Sqlite;
+
+namespace LM.HubSpoke.Hubs.KnowledgeGraph
+{
+    internal sealed class KnowledgeGraphStore
+    {
+        private const string PaperNodeType = "Paper";
+        private const string PopulationNodeType = "Population";
+        private const string InterventionNodeType = "Intervention";
+        private const string EndpointNodeType = "Endpoint";
+
+        private const string PaperHasPopulation = "HAS_POPULATION";
+        private const string PopulationHasIntervention = "HAS_INTERVENTION";
+        private const string InterventionReportsEndpoint = "REPORTS_ENDPOINT";
+        private const string InterventionComparedWith = "COMPARED_WITH";
+
+        private readonly IWorkSpaceService _workspace;
+        private readonly string _databasePath;
+
+        public KnowledgeGraphStore(IWorkSpaceService workspace)
+        {
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+            var root = WorkspaceRoot();
+            Directory.CreateDirectory(root);
+            _databasePath = Path.Combine(root, "knowledge_graph.db");
+        }
+
+        public async Task InitializeAsync(CancellationToken ct)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_databasePath)!);
+            await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+            var statements = new[]
+            {
+                "CREATE TABLE IF NOT EXISTS Papers (EntryId TEXT PRIMARY KEY, Title TEXT NOT NULL, Year INTEGER NULL, Source TEXT NULL)",
+                "CREATE TABLE IF NOT EXISTS Populations (EntryId TEXT NOT NULL, PopulationId TEXT NOT NULL, Name TEXT NOT NULL, Description TEXT NULL, PRIMARY KEY (EntryId, PopulationId))",
+                "CREATE TABLE IF NOT EXISTS BaselineCharacteristics (EntryId TEXT NOT NULL, PopulationId TEXT NOT NULL, Characteristic TEXT NOT NULL, Value TEXT NULL, PRIMARY KEY (EntryId, PopulationId, Characteristic))",
+                "CREATE TABLE IF NOT EXISTS Interventions (EntryId TEXT NOT NULL, InterventionId TEXT NOT NULL, Name TEXT NOT NULL, Type TEXT NULL, Description TEXT NULL, PRIMARY KEY (EntryId, InterventionId))",
+                "CREATE TABLE IF NOT EXISTS Endpoints (EntryId TEXT NOT NULL, EndpointId TEXT NOT NULL, Name TEXT NOT NULL, Category TEXT NOT NULL, Description TEXT NULL, PRIMARY KEY (EntryId, EndpointId))",
+                "CREATE TABLE IF NOT EXISTS EndpointReadouts (EntryId TEXT NOT NULL, EndpointId TEXT NOT NULL, InterventionId TEXT NULL, ComparatorInterventionId TEXT NULL, PopulationId TEXT NULL, Metric TEXT NULL, Value REAL NULL, Unit TEXT NULL, Timepoint TEXT NULL, CurveJson TEXT NULL, PRIMARY KEY (EntryId, EndpointId, InterventionId, ComparatorInterventionId, PopulationId, Metric, Timepoint))",
+                "CREATE TABLE IF NOT EXISTS GraphEdges (EntryId TEXT NOT NULL, SourceType TEXT NOT NULL, SourceId TEXT NOT NULL, TargetType TEXT NOT NULL, TargetId TEXT NOT NULL, Relationship TEXT NOT NULL, PayloadJson TEXT NULL, PRIMARY KEY (EntryId, SourceType, SourceId, TargetType, TargetId, Relationship))",
+                "CREATE INDEX IF NOT EXISTS IX_Baseline_Search ON BaselineCharacteristics (Characteristic, Value)",
+                "CREATE INDEX IF NOT EXISTS IX_EndPoint_Category ON Endpoints (Category)",
+                "CREATE INDEX IF NOT EXISTS IX_Readouts_Category ON EndpointReadouts (EntryId, EndpointId)"
+            };
+
+            foreach (var sql in statements)
+            {
+                await using var command = connection.CreateCommand();
+                command.CommandText = sql;
+                await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            }
+        }
+
+        public async Task ReplaceEntryAsync(EntryHub hub, DataExtractionHook hook, CancellationToken ct)
+        {
+            ArgumentNullException.ThrowIfNull(hub);
+            ArgumentNullException.ThrowIfNull(hook);
+
+            var entryId = hub.EntryId;
+            await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+            await using var transaction = await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
+
+            await DeleteEntryInternalAsync(connection, transaction, entryId, ct).ConfigureAwait(false);
+            await InsertPaperAsync(connection, transaction, hub, hook, ct).ConfigureAwait(false);
+            await InsertPopulationsAsync(connection, transaction, entryId, hook.Populations, ct).ConfigureAwait(false);
+            await InsertInterventionsAsync(connection, transaction, entryId, hook.Interventions, hook.Assignments, ct).ConfigureAwait(false);
+            await InsertEndpointsAsync(connection, transaction, entryId, hook.Endpoints, ct).ConfigureAwait(false);
+
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+        }
+
+        public async Task DeleteEntryAsync(string entryId, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(entryId))
+                return;
+
+            await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+            await using var transaction = await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
+            await DeleteEntryInternalAsync(connection, transaction, entryId, ct).ConfigureAwait(false);
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+        }
+
+        public async Task<IReadOnlyList<MortalityComparison>> QueryMortalityComparisonsAsync(string? entryId, CancellationToken ct)
+        {
+            await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+            const string sql = "SELECT r.EntryId, p.Title, r.EndpointId, e.Name, r.PopulationId, r.InterventionId, i.Name, r.ComparatorInterventionId, ci.Name, r.Value, r.Unit, r.Metric, r.Timepoint FROM EndpointReadouts r JOIN Endpoints e ON e.EntryId = r.EntryId AND e.EndpointId = r.EndpointId JOIN Papers p ON p.EntryId = r.EntryId LEFT JOIN Interventions i ON i.EntryId = r.EntryId AND i.InterventionId = r.InterventionId LEFT JOIN Interventions ci ON ci.EntryId = r.EntryId AND ci.InterventionId = r.ComparatorInterventionId WHERE lower(e.Category) = 'mortality' AND ($entryId IS NULL OR r.EntryId = $entryId)";
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            var param = command.CreateParameter();
+            param.ParameterName = "$entryId";
+            param.Value = entryId ?? (object)DBNull.Value;
+            command.Parameters.Add(param);
+
+            var results = new List<MortalityComparison>();
+            await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                results.Add(new MortalityComparison(
+                    reader.GetString(0),
+                    reader.GetString(1),
+                    reader.GetString(2),
+                    reader.GetString(3),
+                    reader.IsDBNull(4) ? null : reader.GetString(4),
+                    reader.IsDBNull(5) ? null : reader.GetString(5),
+                    reader.IsDBNull(6) ? null : reader.GetString(6),
+                    reader.IsDBNull(7) ? null : reader.GetString(7),
+                    reader.IsDBNull(8) ? null : reader.GetString(8),
+                    reader.IsDBNull(9) ? null : reader.GetDouble(9),
+                    reader.IsDBNull(10) ? null : reader.GetString(10),
+                    reader.IsDBNull(11) ? null : reader.GetString(11),
+                    reader.IsDBNull(12) ? null : reader.GetString(12)));
+            }
+
+            return results;
+        }
+
+        public async Task<IReadOnlyList<KaplanMeierOverlay>> QueryKaplanMeierAsync(string entryId, string? endpointId, CancellationToken ct)
+        {
+            await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+            const string sql = "SELECT r.EntryId, p.Title, r.EndpointId, e.Name, r.PopulationId, r.InterventionId, i.Name, r.CurveJson FROM EndpointReadouts r JOIN Endpoints e ON e.EntryId = r.EntryId AND e.EndpointId = r.EndpointId JOIN Papers p ON p.EntryId = r.EntryId LEFT JOIN Interventions i ON i.EntryId = r.EntryId AND i.InterventionId = r.InterventionId WHERE r.CurveJson IS NOT NULL AND r.EntryId = $entryId AND ($endpointId IS NULL OR r.EndpointId = $endpointId)";
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            var entryParam = command.CreateParameter();
+            entryParam.ParameterName = "$entryId";
+            entryParam.Value = entryId;
+            command.Parameters.Add(entryParam);
+            var endpointParam = command.CreateParameter();
+            endpointParam.ParameterName = "$endpointId";
+            endpointParam.Value = endpointId ?? (object)DBNull.Value;
+            command.Parameters.Add(endpointParam);
+
+            var overlays = new List<KaplanMeierOverlay>();
+            await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                var curveJson = reader.GetString(7);
+                var curve = JsonSerializer.Deserialize<List<KaplanMeierPointDto>>(curveJson, JsonStd.Options)
+                            ?? new List<KaplanMeierPointDto>();
+                overlays.Add(new KaplanMeierOverlay(
+                    reader.GetString(0),
+                    reader.GetString(1),
+                    reader.GetString(2),
+                    reader.GetString(3),
+                    reader.IsDBNull(4) ? null : reader.GetString(4),
+                    reader.IsDBNull(5) ? null : reader.GetString(5),
+                    reader.IsDBNull(6) ? null : reader.GetString(6),
+                    curve));
+            }
+
+            return overlays;
+        }
+
+        public async Task<IReadOnlyList<BaselineCharacteristicHit>> QueryBaselineAsync(string characteristicTerm, string? valueTerm, CancellationToken ct)
+        {
+            await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+            const string sql = "SELECT bc.EntryId, p.Title, bc.PopulationId, pop.Name, bc.Characteristic, bc.Value FROM BaselineCharacteristics bc JOIN Papers p ON p.EntryId = bc.EntryId LEFT JOIN Populations pop ON pop.EntryId = bc.EntryId AND pop.PopulationId = bc.PopulationId WHERE lower(bc.Characteristic) LIKE $char AND ($val IS NULL OR lower(IFNULL(bc.Value, '')) LIKE $val)";
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            var charParam = command.CreateParameter();
+            charParam.ParameterName = "$char";
+            charParam.Value = $"%{characteristicTerm.ToLowerInvariant()}%";
+            command.Parameters.Add(charParam);
+            var valParam = command.CreateParameter();
+            valParam.ParameterName = "$val";
+            if (string.IsNullOrWhiteSpace(valueTerm))
+            {
+                valParam.Value = DBNull.Value;
+            }
+            else
+            {
+                valParam.Value = $"%{valueTerm.ToLowerInvariant()}%";
+            }
+            command.Parameters.Add(valParam);
+
+            var hits = new List<BaselineCharacteristicHit>();
+            await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                hits.Add(new BaselineCharacteristicHit(
+                    reader.GetString(0),
+                    reader.GetString(1),
+                    reader.GetString(2),
+                    reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
+                    reader.GetString(4),
+                    reader.IsDBNull(5) ? string.Empty : reader.GetString(5)));
+            }
+
+            return hits;
+        }
+
+        public async Task<GraphEntryOverview?> LoadEntryOverviewAsync(string entryId, CancellationToken ct)
+        {
+            await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+            const string paperSql = "SELECT Title FROM Papers WHERE EntryId = $entryId";
+            await using var paperCommand = connection.CreateCommand();
+            paperCommand.CommandText = paperSql;
+            var idParam = paperCommand.CreateParameter();
+            idParam.ParameterName = "$entryId";
+            idParam.Value = entryId;
+            paperCommand.Parameters.Add(idParam);
+            var title = (string?)await paperCommand.ExecuteScalarAsync(ct).ConfigureAwait(false);
+            if (title is null)
+                return null;
+
+            var populations = await LoadPopulationsAsync(connection, entryId, ct).ConfigureAwait(false);
+            var interventions = await LoadInterventionsAsync(connection, entryId, ct).ConfigureAwait(false);
+            var endpoints = await LoadEndpointsAsync(connection, entryId, ct).ConfigureAwait(false);
+            var edges = await LoadEdgesAsync(connection, entryId, ct).ConfigureAwait(false);
+
+            return new GraphEntryOverview(entryId, title, populations, interventions, endpoints, edges);
+        }
+
+        private string WorkspaceRoot()
+        {
+            var extractionRoot = LM.HubSpoke.FileSystem.WorkspaceLayout.ExtractionRoot(_workspace);
+            Directory.CreateDirectory(extractionRoot);
+            return extractionRoot;
+        }
+
+        private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken ct)
+        {
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = _databasePath,
+                Mode = SqliteOpenMode.ReadWriteCreate,
+                Cache = SqliteCacheMode.Private
+            }.ToString();
+
+            var connection = new SqliteConnection(connectionString);
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await using var pragma = connection.CreateCommand();
+            pragma.CommandText = "PRAGMA foreign_keys = ON;";
+            await pragma.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            return connection;
+        }
+
+        private static async Task DeleteEntryInternalAsync(SqliteConnection connection, SqliteTransaction transaction, string entryId, CancellationToken ct)
+        {
+            var tables = new[]
+            {
+                "GraphEdges",
+                "EndpointReadouts",
+                "Endpoints",
+                "BaselineCharacteristics",
+                "Populations",
+                "Interventions",
+                "Papers"
+            };
+
+            foreach (var table in tables)
+            {
+                await using var command = connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = $"DELETE FROM {table} WHERE EntryId = $entryId";
+                var param = command.CreateParameter();
+                param.ParameterName = "$entryId";
+                param.Value = entryId;
+                command.Parameters.Add(param);
+                await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task InsertPaperAsync(SqliteConnection connection, SqliteTransaction transaction, EntryHub hub, DataExtractionHook hook, CancellationToken ct)
+        {
+            await using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = "INSERT INTO Papers (EntryId, Title, Year, Source) VALUES ($entryId, $title, $year, $source)";
+            AddParam(command, "$entryId", hub.EntryId);
+            AddParam(command, "$title", hook.Title ?? hub.DisplayTitle);
+            AddParam(command, "$year", hook.Year);
+            AddParam(command, "$source", hook.Source);
+            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        private async Task InsertPopulationsAsync(SqliteConnection connection, SqliteTransaction transaction, string entryId, IReadOnlyList<ExtractedPopulation> populations, CancellationToken ct)
+        {
+            foreach (var population in populations ?? Array.Empty<ExtractedPopulation>())
+            {
+                ct.ThrowIfCancellationRequested();
+                await using var command = connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = "INSERT INTO Populations (EntryId, PopulationId, Name, Description) VALUES ($entryId, $id, $name, $desc)";
+                AddParam(command, "$entryId", entryId);
+                AddParam(command, "$id", population.Id);
+                AddParam(command, "$name", population.Name);
+                AddParam(command, "$desc", population.Description);
+                await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+                await InsertEdgeAsync(connection, transaction, entryId, PaperNodeType, entryId, PopulationNodeType, population.Id, PaperHasPopulation, payload: null, ct).ConfigureAwait(false);
+
+                if (population.BaselineCharacteristics is not null)
+                {
+                    foreach (var kvp in population.BaselineCharacteristics)
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        await using var baselineCommand = connection.CreateCommand();
+                        baselineCommand.Transaction = transaction;
+                        baselineCommand.CommandText = "INSERT INTO BaselineCharacteristics (EntryId, PopulationId, Characteristic, Value) VALUES ($entryId, $popId, $char, $val)";
+                        AddParam(baselineCommand, "$entryId", entryId);
+                        AddParam(baselineCommand, "$popId", population.Id);
+                        AddParam(baselineCommand, "$char", kvp.Key);
+                        AddParam(baselineCommand, "$val", kvp.Value);
+                        await baselineCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                    }
+                }
+            }
+        }
+
+        private async Task InsertInterventionsAsync(
+            SqliteConnection connection,
+            SqliteTransaction transaction,
+            string entryId,
+            IReadOnlyList<ExtractedIntervention> interventions,
+            IReadOnlyList<PopulationInterventionAssignment> assignments,
+            CancellationToken ct)
+        {
+            var interventionSet = interventions ?? Array.Empty<ExtractedIntervention>();
+            foreach (var intervention in interventionSet)
+            {
+                ct.ThrowIfCancellationRequested();
+                await using var command = connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = "INSERT INTO Interventions (EntryId, InterventionId, Name, Type, Description) VALUES ($entryId, $id, $name, $type, $desc)";
+                AddParam(command, "$entryId", entryId);
+                AddParam(command, "$id", intervention.Id);
+                AddParam(command, "$name", intervention.Name);
+                AddParam(command, "$type", intervention.Type);
+                AddParam(command, "$desc", intervention.Description);
+                await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            }
+
+            foreach (var assignment in assignments ?? Array.Empty<PopulationInterventionAssignment>())
+            {
+                ct.ThrowIfCancellationRequested();
+                await InsertEdgeAsync(
+                    connection,
+                    transaction,
+                    entryId,
+                    PopulationNodeType,
+                    assignment.PopulationId,
+                    InterventionNodeType,
+                    assignment.InterventionId,
+                    PopulationHasIntervention,
+                    payload: assignment.ArmLabel is null ? null : JsonSerializer.Serialize(new { label = assignment.ArmLabel }, JsonStd.Options),
+                    ct).ConfigureAwait(false);
+            }
+        }
+
+        private async Task InsertEndpointsAsync(SqliteConnection connection, SqliteTransaction transaction, string entryId, IReadOnlyList<ExtractedEndpoint> endpoints, CancellationToken ct)
+        {
+            foreach (var endpoint in endpoints ?? Array.Empty<ExtractedEndpoint>())
+            {
+                ct.ThrowIfCancellationRequested();
+                await using var command = connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = "INSERT INTO Endpoints (EntryId, EndpointId, Name, Category, Description) VALUES ($entryId, $id, $name, $cat, $desc)";
+                AddParam(command, "$entryId", entryId);
+                AddParam(command, "$id", endpoint.Id);
+                AddParam(command, "$name", endpoint.Name);
+                AddParam(command, "$cat", endpoint.Category);
+                AddParam(command, "$desc", endpoint.Description);
+                await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+                foreach (var readout in endpoint.Readouts ?? Array.Empty<EndpointReadout>())
+                {
+                    ct.ThrowIfCancellationRequested();
+                    var curveJson = readout.KaplanMeierCurve is null
+                        ? null
+                        : JsonSerializer.Serialize(readout.KaplanMeierCurve.Select(p => new KaplanMeierPointDto(p.Time, p.SurvivalProbability)).ToList(), JsonStd.Options);
+
+                    await using var readoutCommand = connection.CreateCommand();
+                    readoutCommand.Transaction = transaction;
+                    readoutCommand.CommandText = "INSERT INTO EndpointReadouts (EntryId, EndpointId, InterventionId, ComparatorInterventionId, PopulationId, Metric, Value, Unit, Timepoint, CurveJson) VALUES ($entryId, $endpointId, $interventionId, $compId, $populationId, $metric, $value, $unit, $timepoint, $curve)";
+                    AddParam(readoutCommand, "$entryId", entryId);
+                    AddParam(readoutCommand, "$endpointId", endpoint.Id);
+                    AddParam(readoutCommand, "$interventionId", readout.InterventionId);
+                    AddParam(readoutCommand, "$compId", readout.ComparatorInterventionId);
+                    AddParam(readoutCommand, "$populationId", readout.PopulationId);
+                    AddParam(readoutCommand, "$metric", readout.Metric);
+                    AddParam(readoutCommand, "$value", readout.Value);
+                    AddParam(readoutCommand, "$unit", readout.Unit);
+                    AddParam(readoutCommand, "$timepoint", readout.Timepoint);
+                    AddParam(readoutCommand, "$curve", curveJson);
+                    await readoutCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+                    if (!string.IsNullOrWhiteSpace(readout.InterventionId))
+                    {
+                        await InsertEdgeAsync(
+                            connection,
+                            transaction,
+                            entryId,
+                            InterventionNodeType,
+                            readout.InterventionId!,
+                            EndpointNodeType,
+                            endpoint.Id,
+                            InterventionReportsEndpoint,
+                            payload: JsonSerializer.Serialize(new
+                            {
+                                readout.PopulationId,
+                                readout.Metric,
+                                readout.Timepoint,
+                                readout.Value,
+                                readout.Unit
+                            }, JsonStd.Options),
+                            ct).ConfigureAwait(false);
+
+                        if (!string.IsNullOrWhiteSpace(readout.ComparatorInterventionId) && !string.Equals(readout.ComparatorInterventionId, readout.InterventionId, StringComparison.Ordinal))
+                        {
+                            await InsertEdgeAsync(
+                                connection,
+                                transaction,
+                                entryId,
+                                InterventionNodeType,
+                                readout.InterventionId!,
+                                InterventionNodeType,
+                                readout.ComparatorInterventionId!,
+                                InterventionComparedWith,
+                                payload: JsonSerializer.Serialize(new
+                                {
+                                    endpointId = endpoint.Id,
+                                    readout.Timepoint,
+                                    readout.Metric
+                                }, JsonStd.Options),
+                                ct).ConfigureAwait(false);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static async Task InsertEdgeAsync(
+            SqliteConnection connection,
+            SqliteTransaction transaction,
+            string entryId,
+            string sourceType,
+            string sourceId,
+            string targetType,
+            string targetId,
+            string relationship,
+            string? payload,
+            CancellationToken ct)
+        {
+            await using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = "INSERT OR REPLACE INTO GraphEdges (EntryId, SourceType, SourceId, TargetType, TargetId, Relationship, PayloadJson) VALUES ($entryId, $sourceType, $sourceId, $targetType, $targetId, $rel, $payload)";
+            AddParam(command, "$entryId", entryId);
+            AddParam(command, "$sourceType", sourceType);
+            AddParam(command, "$sourceId", sourceId);
+            AddParam(command, "$targetType", targetType);
+            AddParam(command, "$targetId", targetId);
+            AddParam(command, "$rel", relationship);
+            AddParam(command, "$payload", payload);
+            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        private static async Task<IReadOnlyList<GraphPopulationNode>> LoadPopulationsAsync(SqliteConnection connection, string entryId, CancellationToken ct)
+        {
+            const string sql = "SELECT PopulationId, Name, Description FROM Populations WHERE EntryId = $entryId ORDER BY PopulationId";
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            AddParam(command, "$entryId", entryId);
+            var list = new List<GraphPopulationNode>();
+            await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                list.Add(new GraphPopulationNode(
+                    reader.GetString(0),
+                    reader.GetString(1),
+                    reader.IsDBNull(2) ? null : reader.GetString(2)));
+            }
+            return list;
+        }
+
+        private static async Task<IReadOnlyList<GraphInterventionNode>> LoadInterventionsAsync(SqliteConnection connection, string entryId, CancellationToken ct)
+        {
+            const string sql = "SELECT InterventionId, Name, Type, Description FROM Interventions WHERE EntryId = $entryId ORDER BY InterventionId";
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            AddParam(command, "$entryId", entryId);
+            var list = new List<GraphInterventionNode>();
+            await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                list.Add(new GraphInterventionNode(
+                    reader.GetString(0),
+                    reader.GetString(1),
+                    reader.IsDBNull(2) ? null : reader.GetString(2),
+                    reader.IsDBNull(3) ? null : reader.GetString(3)));
+            }
+            return list;
+        }
+
+        private static async Task<IReadOnlyList<GraphEndpointNode>> LoadEndpointsAsync(SqliteConnection connection, string entryId, CancellationToken ct)
+        {
+            const string sql = "SELECT EndpointId, Name, Category, Description FROM Endpoints WHERE EntryId = $entryId ORDER BY EndpointId";
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            AddParam(command, "$entryId", entryId);
+            var list = new List<GraphEndpointNode>();
+            await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                list.Add(new GraphEndpointNode(
+                    reader.GetString(0),
+                    reader.GetString(1),
+                    reader.GetString(2),
+                    reader.IsDBNull(3) ? null : reader.GetString(3)));
+            }
+            return list;
+        }
+
+        private static async Task<IReadOnlyList<GraphEdge>> LoadEdgesAsync(SqliteConnection connection, string entryId, CancellationToken ct)
+        {
+            const string sql = "SELECT SourceType, SourceId, TargetType, TargetId, Relationship, PayloadJson FROM GraphEdges WHERE EntryId = $entryId ORDER BY SourceType, SourceId";
+            await using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            AddParam(command, "$entryId", entryId);
+            var list = new List<GraphEdge>();
+            await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                list.Add(new GraphEdge(
+                    reader.GetString(0),
+                    reader.GetString(1),
+                    reader.GetString(2),
+                    reader.GetString(3),
+                    reader.GetString(4),
+                    reader.IsDBNull(5) ? null : reader.GetString(5)));
+            }
+            return list;
+        }
+
+        private static void AddParam(SqliteCommand command, string name, object? value)
+        {
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = name;
+            parameter.Value = value ?? DBNull.Value;
+            command.Parameters.Add(parameter);
+        }
+    }
+}

--- a/src/LM.HubAndSpoke/Models/DataExtractionHook.cs
+++ b/src/LM.HubAndSpoke/Models/DataExtractionHook.cs
@@ -1,0 +1,141 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace LM.HubSpoke.Models
+{
+    /// <summary>
+    /// Structured data extracted from a study that is shared across modules via the extraction hub.
+    /// </summary>
+    public sealed class DataExtractionHook
+    {
+        [JsonPropertyName("schema_version")]
+        public string SchemaVersion { get; init; } = "1.0.0";
+
+        [JsonPropertyName("entry_id")]
+        public string EntryId { get; init; } = string.Empty;
+
+        [JsonPropertyName("title")]
+        public string? Title { get; init; }
+
+        [JsonPropertyName("year")]
+        public int? Year { get; init; }
+
+        [JsonPropertyName("source")]
+        public string? Source { get; init; }
+
+        [JsonPropertyName("populations")]
+        public IReadOnlyList<ExtractedPopulation> Populations { get; init; } = Array.Empty<ExtractedPopulation>();
+
+        [JsonPropertyName("interventions")]
+        public IReadOnlyList<ExtractedIntervention> Interventions { get; init; } = Array.Empty<ExtractedIntervention>();
+
+        [JsonPropertyName("assignments")]
+        public IReadOnlyList<PopulationInterventionAssignment> Assignments { get; init; } = Array.Empty<PopulationInterventionAssignment>();
+
+        [JsonPropertyName("endpoints")]
+        public IReadOnlyList<ExtractedEndpoint> Endpoints { get; init; } = Array.Empty<ExtractedEndpoint>();
+    }
+
+    public sealed class ExtractedPopulation
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string? Description { get; init; }
+
+        [JsonPropertyName("baseline_characteristics")]
+        public IReadOnlyDictionary<string, string> BaselineCharacteristics { get; init; }
+            = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public sealed class ExtractedIntervention
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = string.Empty;
+
+        [JsonPropertyName("type")]
+        public string? Type { get; init; }
+
+        [JsonPropertyName("description")]
+        public string? Description { get; init; }
+
+        [JsonPropertyName("attributes")]
+        public IReadOnlyDictionary<string, string>? Attributes { get; init; }
+            = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public sealed class PopulationInterventionAssignment
+    {
+        [JsonPropertyName("population_id")]
+        public string PopulationId { get; init; } = string.Empty;
+
+        [JsonPropertyName("intervention_id")]
+        public string InterventionId { get; init; } = string.Empty;
+
+        [JsonPropertyName("arm_label")]
+        public string? ArmLabel { get; init; }
+    }
+
+    public sealed class ExtractedEndpoint
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = string.Empty;
+
+        [JsonPropertyName("category")]
+        public string Category { get; init; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string? Description { get; init; }
+
+        [JsonPropertyName("readouts")]
+        public IReadOnlyList<EndpointReadout> Readouts { get; init; } = Array.Empty<EndpointReadout>();
+    }
+
+    public sealed class EndpointReadout
+    {
+        [JsonPropertyName("population_id")]
+        public string? PopulationId { get; init; }
+
+        [JsonPropertyName("intervention_id")]
+        public string? InterventionId { get; init; }
+
+        [JsonPropertyName("comparator_intervention_id")]
+        public string? ComparatorInterventionId { get; init; }
+
+        [JsonPropertyName("metric")]
+        public string? Metric { get; init; }
+
+        [JsonPropertyName("value")]
+        public double? Value { get; init; }
+
+        [JsonPropertyName("unit")]
+        public string? Unit { get; init; }
+
+        [JsonPropertyName("timepoint")]
+        public string? Timepoint { get; init; }
+
+        [JsonPropertyName("curve")]
+        public IReadOnlyList<KaplanMeierPoint>? KaplanMeierCurve { get; init; }
+    }
+
+    public sealed class KaplanMeierPoint
+    {
+        [JsonPropertyName("time")]
+        public double Time { get; init; }
+
+        [JsonPropertyName("survival_probability")]
+        public double SurvivalProbability { get; init; }
+    }
+}

--- a/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
+++ b/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
@@ -337,6 +337,177 @@ LM.HubSpoke.Models.EntryHub.Flags.get -> System.Collections.Generic.IReadOnlyLis
 LM.HubSpoke.Models.EntryHub.Flags.init -> void
 LM.HubSpoke.Models.EntryHub.Hooks.get -> LM.HubSpoke.Models.EntryHooks!
 LM.HubSpoke.Models.EntryHub.Hooks.init -> void
+LM.HubSpoke.Models.DataExtractionHook
+LM.HubSpoke.Models.DataExtractionHook.Assignments.get -> System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Models.PopulationInterventionAssignment!>!
+LM.HubSpoke.Models.DataExtractionHook.Assignments.init -> void
+LM.HubSpoke.Models.DataExtractionHook.DataExtractionHook() -> void
+LM.HubSpoke.Models.DataExtractionHook.Endpoints.get -> System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Models.ExtractedEndpoint!>!
+LM.HubSpoke.Models.DataExtractionHook.Endpoints.init -> void
+LM.HubSpoke.Models.DataExtractionHook.EntryId.get -> string!
+LM.HubSpoke.Models.DataExtractionHook.EntryId.init -> void
+LM.HubSpoke.Models.DataExtractionHook.Interventions.get -> System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Models.ExtractedIntervention!>!
+LM.HubSpoke.Models.DataExtractionHook.Interventions.init -> void
+LM.HubSpoke.Models.DataExtractionHook.Populations.get -> System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Models.ExtractedPopulation!>!
+LM.HubSpoke.Models.DataExtractionHook.Populations.init -> void
+LM.HubSpoke.Models.DataExtractionHook.SchemaVersion.get -> string!
+LM.HubSpoke.Models.DataExtractionHook.SchemaVersion.init -> void
+LM.HubSpoke.Models.DataExtractionHook.Source.get -> string?
+LM.HubSpoke.Models.DataExtractionHook.Source.init -> void
+LM.HubSpoke.Models.DataExtractionHook.Title.get -> string?
+LM.HubSpoke.Models.DataExtractionHook.Title.init -> void
+LM.HubSpoke.Models.DataExtractionHook.Year.get -> int?
+LM.HubSpoke.Models.DataExtractionHook.Year.init -> void
+LM.HubSpoke.Models.ExtractedEndpoint
+LM.HubSpoke.Models.ExtractedEndpoint.Category.get -> string!
+LM.HubSpoke.Models.ExtractedEndpoint.Category.init -> void
+LM.HubSpoke.Models.ExtractedEndpoint.Description.get -> string?
+LM.HubSpoke.Models.ExtractedEndpoint.Description.init -> void
+LM.HubSpoke.Models.ExtractedEndpoint.ExtractedEndpoint() -> void
+LM.HubSpoke.Models.ExtractedEndpoint.Id.get -> string!
+LM.HubSpoke.Models.ExtractedEndpoint.Id.init -> void
+LM.HubSpoke.Models.ExtractedEndpoint.Name.get -> string!
+LM.HubSpoke.Models.ExtractedEndpoint.Name.init -> void
+LM.HubSpoke.Models.ExtractedEndpoint.Readouts.get -> System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Models.EndpointReadout!>!
+LM.HubSpoke.Models.ExtractedEndpoint.Readouts.init -> void
+LM.HubSpoke.Models.ExtractedIntervention
+LM.HubSpoke.Models.ExtractedIntervention.Attributes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>?
+LM.HubSpoke.Models.ExtractedIntervention.Attributes.init -> void
+LM.HubSpoke.Models.ExtractedIntervention.Description.get -> string?
+LM.HubSpoke.Models.ExtractedIntervention.Description.init -> void
+LM.HubSpoke.Models.ExtractedIntervention.ExtractedIntervention() -> void
+LM.HubSpoke.Models.ExtractedIntervention.Id.get -> string!
+LM.HubSpoke.Models.ExtractedIntervention.Id.init -> void
+LM.HubSpoke.Models.ExtractedIntervention.Name.get -> string!
+LM.HubSpoke.Models.ExtractedIntervention.Name.init -> void
+LM.HubSpoke.Models.ExtractedIntervention.Type.get -> string?
+LM.HubSpoke.Models.ExtractedIntervention.Type.init -> void
+LM.HubSpoke.Models.ExtractedPopulation
+LM.HubSpoke.Models.ExtractedPopulation.BaselineCharacteristics.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+LM.HubSpoke.Models.ExtractedPopulation.BaselineCharacteristics.init -> void
+LM.HubSpoke.Models.ExtractedPopulation.Description.get -> string?
+LM.HubSpoke.Models.ExtractedPopulation.Description.init -> void
+LM.HubSpoke.Models.ExtractedPopulation.ExtractedPopulation() -> void
+LM.HubSpoke.Models.ExtractedPopulation.Id.get -> string!
+LM.HubSpoke.Models.ExtractedPopulation.Id.init -> void
+LM.HubSpoke.Models.ExtractedPopulation.Name.get -> string!
+LM.HubSpoke.Models.ExtractedPopulation.Name.init -> void
+LM.HubSpoke.Models.EndpointReadout
+LM.HubSpoke.Models.EndpointReadout.ComparatorInterventionId.get -> string?
+LM.HubSpoke.Models.EndpointReadout.ComparatorInterventionId.init -> void
+LM.HubSpoke.Models.EndpointReadout.EndpointReadout() -> void
+LM.HubSpoke.Models.EndpointReadout.InterventionId.get -> string?
+LM.HubSpoke.Models.EndpointReadout.InterventionId.init -> void
+LM.HubSpoke.Models.EndpointReadout.KaplanMeierCurve.get -> System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Models.KaplanMeierPoint!>?
+LM.HubSpoke.Models.EndpointReadout.KaplanMeierCurve.init -> void
+LM.HubSpoke.Models.EndpointReadout.Metric.get -> string?
+LM.HubSpoke.Models.EndpointReadout.Metric.init -> void
+LM.HubSpoke.Models.EndpointReadout.PopulationId.get -> string?
+LM.HubSpoke.Models.EndpointReadout.PopulationId.init -> void
+LM.HubSpoke.Models.EndpointReadout.Timepoint.get -> string?
+LM.HubSpoke.Models.EndpointReadout.Timepoint.init -> void
+LM.HubSpoke.Models.EndpointReadout.Unit.get -> string?
+LM.HubSpoke.Models.EndpointReadout.Unit.init -> void
+LM.HubSpoke.Models.EndpointReadout.Value.get -> double?
+LM.HubSpoke.Models.EndpointReadout.Value.init -> void
+LM.HubSpoke.Models.KaplanMeierPoint
+LM.HubSpoke.Models.KaplanMeierPoint.KaplanMeierPoint() -> void
+LM.HubSpoke.Models.KaplanMeierPoint.SurvivalProbability.get -> double
+LM.HubSpoke.Models.KaplanMeierPoint.SurvivalProbability.init -> void
+LM.HubSpoke.Models.KaplanMeierPoint.Time.get -> double
+LM.HubSpoke.Models.KaplanMeierPoint.Time.init -> void
+LM.HubSpoke.Models.PopulationInterventionAssignment
+LM.HubSpoke.Models.PopulationInterventionAssignment.ArmLabel.get -> string?
+LM.HubSpoke.Models.PopulationInterventionAssignment.ArmLabel.init -> void
+LM.HubSpoke.Models.PopulationInterventionAssignment.PopulationId.get -> string!
+LM.HubSpoke.Models.PopulationInterventionAssignment.PopulationId.init -> void
+LM.HubSpoke.Models.PopulationInterventionAssignment.InterventionId.get -> string!
+LM.HubSpoke.Models.PopulationInterventionAssignment.InterventionId.init -> void
+LM.HubSpoke.Models.PopulationInterventionAssignment.PopulationInterventionAssignment() -> void
+LM.HubSpoke.Hubs.KnowledgeGraph.IKnowledgeGraphHub
+LM.HubSpoke.Hubs.KnowledgeGraph.IKnowledgeGraphHub.GetEntryOverviewAsync(string! entryId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.HubSpoke.Hubs.KnowledgeGraph.GraphEntryOverview?>!
+LM.HubSpoke.Hubs.KnowledgeGraph.IKnowledgeGraphHub.GetKaplanMeierOverlaysAsync(string! entryId, string? endpointId = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierOverlay!>!>!
+LM.HubSpoke.Hubs.KnowledgeGraph.IKnowledgeGraphHub.GetMortalityComparisonsAsync(string? entryId = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison!>!>!
+LM.HubSpoke.Hubs.KnowledgeGraph.IKnowledgeGraphHub.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.HubSpoke.Hubs.KnowledgeGraph.IKnowledgeGraphHub.RefreshEntryAsync(string! entryId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.HubSpoke.Hubs.KnowledgeGraph.IKnowledgeGraphHub.SearchBaselineCharacteristicsAsync(string! characteristicSearchTerm, string? valueContains = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.BaselineCharacteristicHit!>!>!
+LM.HubSpoke.Hubs.KnowledgeGraph.KnowledgeGraphHub
+LM.HubSpoke.Hubs.KnowledgeGraph.KnowledgeGraphHub.KnowledgeGraphHub(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.HubSpoke.Hubs.KnowledgeGraph.KnowledgeGraphHub.GetEntryOverviewAsync(string! entryId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.HubSpoke.Hubs.KnowledgeGraph.GraphEntryOverview?>!
+LM.HubSpoke.Hubs.KnowledgeGraph.KnowledgeGraphHub.GetKaplanMeierOverlaysAsync(string! entryId, string? endpointId = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierOverlay!>!>!
+LM.HubSpoke.Hubs.KnowledgeGraph.KnowledgeGraphHub.GetMortalityComparisonsAsync(string? entryId = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison!>!>!
+LM.HubSpoke.Hubs.KnowledgeGraph.KnowledgeGraphHub.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.HubSpoke.Hubs.KnowledgeGraph.KnowledgeGraphHub.RefreshEntryAsync(string! entryId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.HubSpoke.Hubs.KnowledgeGraph.KnowledgeGraphHub.SearchBaselineCharacteristicsAsync(string! characteristicSearchTerm, string? valueContains = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.BaselineCharacteristicHit!>!>!
+LM.HubSpoke.Hubs.KnowledgeGraph.BaselineCharacteristicHit
+LM.HubSpoke.Hubs.KnowledgeGraph.BaselineCharacteristicHit.BaselineCharacteristicHit(string! entryId, string! entryTitle, string! populationId, string! populationName, string! characteristic, string! value) -> void
+LM.HubSpoke.Hubs.KnowledgeGraph.BaselineCharacteristicHit.Characteristic.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.BaselineCharacteristicHit.EntryId.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.BaselineCharacteristicHit.EntryTitle.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.BaselineCharacteristicHit.PopulationId.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.BaselineCharacteristicHit.PopulationName.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.BaselineCharacteristicHit.Value.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEdge
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEdge.GraphEdge(string! sourceType, string! sourceId, string! targetType, string! targetId, string! relationship, string? payloadJson) -> void
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEdge.PayloadJson.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEdge.Relationship.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEdge.SourceId.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEdge.SourceType.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEdge.TargetId.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEdge.TargetType.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEntryOverview
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEntryOverview.Edges.get -> System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.GraphEdge!>!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEntryOverview.GraphEntryOverview(string! entryId, string! title, System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.GraphPopulationNode!>! populations, System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.GraphInterventionNode!>! interventions, System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.GraphEndpointNode!>! endpoints, System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.GraphEdge!>! edges) -> void
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEntryOverview.EntryId.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEntryOverview.Endpoints.get -> System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.GraphEndpointNode!>!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEntryOverview.Interventions.get -> System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.GraphInterventionNode!>!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEntryOverview.Populations.get -> System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.GraphPopulationNode!>!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEntryOverview.Title.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEndpointNode
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEndpointNode.Category.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEndpointNode.Description.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEndpointNode.EndpointId.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEndpointNode.GraphEndpointNode(string! endpointId, string! name, string! category, string? description) -> void
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphEndpointNode.Name.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphInterventionNode
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphInterventionNode.Description.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphInterventionNode.GraphInterventionNode(string! interventionId, string! name, string? type, string? description) -> void
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphInterventionNode.InterventionId.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphInterventionNode.Name.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphInterventionNode.Type.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphPopulationNode
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphPopulationNode.Description.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphPopulationNode.GraphPopulationNode(string! populationId, string! name, string? description) -> void
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphPopulationNode.Name.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.GraphPopulationNode.PopulationId.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierOverlay
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierOverlay.Curve.get -> System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierPointDto!>!
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierOverlay.EndpointId.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierOverlay.EndpointName.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierOverlay.EntryId.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierOverlay.EntryTitle.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierOverlay.InterventionId.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierOverlay.InterventionName.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierOverlay.KaplanMeierOverlay(string! entryId, string! entryTitle, string! endpointId, string! endpointName, string? populationId, string? interventionId, string? interventionName, System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierPointDto!>! curve) -> void
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierOverlay.PopulationId.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierPointDto
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierPointDto.KaplanMeierPointDto(double time, double survivalProbability) -> void
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierPointDto.SurvivalProbability.get -> double
+LM.HubSpoke.Hubs.KnowledgeGraph.KaplanMeierPointDto.Time.get -> double
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.ComparatorInterventionId.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.ComparatorName.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.EndpointId.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.EndpointName.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.EntryId.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.EntryTitle.get -> string!
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.InterventionId.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.InterventionName.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.Metric.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.MortalityComparison(string! entryId, string! entryTitle, string! endpointId, string! endpointName, string? populationId, string? interventionId, string? interventionName, string? comparatorInterventionId, string? comparatorName, double? value, string? unit, string? metric, string? timepoint) -> void
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.PopulationId.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.Timepoint.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.Unit.get -> string?
+LM.HubSpoke.Hubs.KnowledgeGraph.MortalityComparison.Value.get -> double?
 LM.HubSpoke.Models.EntryHub.LastActivityUtc.get -> System.DateTime?
 LM.HubSpoke.Models.EntryHub.LastActivityUtc.init -> void
 LM.HubSpoke.Models.EntryHub.Origin.get -> LM.HubSpoke.Models.EntryOrigin

--- a/src/LM.HubSpoke.Tests/KnowledgeGraphHubTests.cs
+++ b/src/LM.HubSpoke.Tests/KnowledgeGraphHubTests.cs
@@ -1,0 +1,327 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Abstractions;
+using LM.Core.Models;
+using LM.HubSpoke.Hubs.KnowledgeGraph;
+using LM.HubSpoke.Models;
+using LM.HubSpoke.Spokes;
+using Xunit;
+
+namespace LM.HubSpoke.Tests
+{
+    public sealed class KnowledgeGraphHubTests
+    {
+        [Fact]
+        public async Task RefreshEntryAsync_BuildsGraphAndSupportsQueries()
+        {
+            using var temp = new TempWorkspace();
+            var workspace = new TestWorkspaceService(temp.RootPath);
+            var entryId = "01HXGRAPH0001";
+            var extractionRelPath = Path.Combine("extraction", "00", "11", "sample.json");
+
+            await WriteHubAsync(temp.RootPath, entryId, extractionRelPath);
+            await WriteExtractionAsync(temp.RootPath, extractionRelPath, entryId);
+
+            var graph = new KnowledgeGraphHub(workspace);
+            await graph.InitializeAsync();
+            await graph.RefreshEntryAsync(entryId);
+
+            var overview = await graph.GetEntryOverviewAsync(entryId);
+            Assert.NotNull(overview);
+            Assert.Equal(entryId, overview!.EntryId);
+            Assert.Single(overview.Populations);
+            Assert.Equal("pop-itt", overview.Populations[0].PopulationId);
+            Assert.Equal("Drug A", overview.Interventions[0].Name);
+            Assert.Equal(2, overview.Interventions.Count);
+            Assert.Equal(2, overview.Endpoints.Count);
+            Assert.Contains(overview.Edges, e => e.Relationship == "HAS_POPULATION");
+
+            var mortality = await graph.GetMortalityComparisonsAsync(entryId);
+            Assert.Single(mortality);
+            var mortalityResult = mortality[0];
+            Assert.Equal(-0.05, mortalityResult.Value);
+            Assert.Equal("arm-drug", mortalityResult.InterventionId);
+            Assert.Equal("arm-control", mortalityResult.ComparatorInterventionId);
+
+            var km = await graph.GetKaplanMeierOverlaysAsync(entryId, "km-overall");
+            Assert.Equal(2, km.Count);
+            Assert.All(km, overlay => Assert.NotEmpty(overlay.Curve));
+
+            var baseline = await graph.SearchBaselineCharacteristicsAsync("age", valueContains: "62");
+            Assert.Single(baseline);
+            Assert.Equal("Age, mean", baseline[0].Characteristic);
+        }
+
+        [Fact]
+        public async Task RefreshEntryAsync_PrunesMissingExtraction()
+        {
+            using var temp = new TempWorkspace();
+            var workspace = new TestWorkspaceService(temp.RootPath);
+            var entryId = "01HXGRAPH0002";
+            var extractionRelPath = Path.Combine("extraction", "ab", "cd", "missing.json");
+
+            await WriteHubAsync(temp.RootPath, entryId, extractionRelPath);
+            await WriteExtractionAsync(temp.RootPath, extractionRelPath, entryId);
+
+            var graph = new KnowledgeGraphHub(workspace);
+            await graph.RefreshEntryAsync(entryId);
+            Assert.NotNull(await graph.GetEntryOverviewAsync(entryId));
+
+            var extractionPath = Path.Combine(temp.RootPath, extractionRelPath);
+            File.Delete(extractionPath);
+
+            await graph.RefreshEntryAsync(entryId);
+            Assert.Null(await graph.GetEntryOverviewAsync(entryId));
+            Assert.Empty(await graph.GetMortalityComparisonsAsync(entryId));
+        }
+
+        [Fact]
+        public async Task HubSpokeStore_NotifiesGraphOnSave()
+        {
+            using var temp = new TempWorkspace();
+            var workspace = new TestWorkspaceService(temp.RootPath);
+            var graph = new RecordingGraphHub();
+            var store = new HubSpokeStore(
+                workspace,
+                new NoopHasher(),
+                new ISpokeHandler[] { new LitSearchSpokeHandler(workspace) },
+                contentExtractor: null,
+                graphHub: graph);
+
+            await store.InitializeAsync();
+
+            var entry = new Entry
+            {
+                Title = "Lit search",
+                Type = EntryType.LitSearch,
+                AddedBy = "CONTOSO\\UserA"
+            };
+
+            await store.SaveAsync(entry);
+
+            Assert.Single(graph.RefreshedIds);
+            Assert.Equal(entry.Id, graph.RefreshedIds[0]);
+        }
+
+        private static async Task WriteHubAsync(string root, string entryId, string extractionRelPath)
+        {
+            var hub = new EntryHub
+            {
+                EntryId = entryId,
+                DisplayTitle = "Graph Trial",
+                CreatedUtc = DateTime.UtcNow,
+                UpdatedUtc = DateTime.UtcNow,
+                CreatedBy = new PersonRef("user", "user"),
+                UpdatedBy = new PersonRef("user", "user"),
+                Hooks = new EntryHooks
+                {
+                    DataExtraction = extractionRelPath
+                }
+            };
+
+            var entryDir = Path.Combine(root, "entries", entryId);
+            Directory.CreateDirectory(entryDir);
+            var json = JsonSerializer.Serialize(hub, JsonStd.Options);
+            await File.WriteAllTextAsync(Path.Combine(entryDir, "hub.json"), json);
+        }
+
+        private static async Task WriteExtractionAsync(string root, string relativePath, string entryId)
+        {
+            var hook = new DataExtractionHook
+            {
+                EntryId = entryId,
+                Title = "Graph Trial",
+                Year = 2024,
+                Source = "JAMA",
+                Populations = new List<ExtractedPopulation>
+                {
+                    new()
+                    {
+                        Id = "pop-itt",
+                        Name = "Intent-to-treat",
+                        BaselineCharacteristics = new Dictionary<string, string>
+                        {
+                            ["Age, mean"] = "62.1 years",
+                            ["Male (%)"] = "58"
+                        }
+                    }
+                },
+                Interventions = new List<ExtractedIntervention>
+                {
+                    new()
+                    {
+                        Id = "arm-drug",
+                        Name = "Drug A",
+                        Type = "Active"
+                    },
+                    new()
+                    {
+                        Id = "arm-control",
+                        Name = "Standard of care",
+                        Type = "Control"
+                    }
+                },
+                Assignments = new List<PopulationInterventionAssignment>
+                {
+                    new()
+                    {
+                        PopulationId = "pop-itt",
+                        InterventionId = "arm-drug",
+                        ArmLabel = "Drug A"
+                    },
+                    new()
+                    {
+                        PopulationId = "pop-itt",
+                        InterventionId = "arm-control",
+                        ArmLabel = "Control"
+                    }
+                },
+                Endpoints = new List<ExtractedEndpoint>
+                {
+                    new()
+                    {
+                        Id = "mortality-30d",
+                        Name = "30-day mortality",
+                        Category = "mortality",
+                        Readouts = new List<EndpointReadout>
+                        {
+                            new()
+                            {
+                                PopulationId = "pop-itt",
+                                InterventionId = "arm-drug",
+                                ComparatorInterventionId = "arm-control",
+                                Metric = "RiskDifference",
+                                Value = -0.05,
+                                Unit = "absolute",
+                                Timepoint = "30 days"
+                            }
+                        }
+                    },
+                    new()
+                    {
+                        Id = "km-overall",
+                        Name = "Overall survival",
+                        Category = "kaplan_meier",
+                        Readouts = new List<EndpointReadout>
+                        {
+                            new()
+                            {
+                                PopulationId = "pop-itt",
+                                InterventionId = "arm-drug",
+                                Metric = "KM",
+                                KaplanMeierCurve = new List<KaplanMeierPoint>
+                                {
+                                    new() { Time = 0, SurvivalProbability = 1.0 },
+                                    new() { Time = 30, SurvivalProbability = 0.9 }
+                                }
+                            },
+                            new()
+                            {
+                                PopulationId = "pop-itt",
+                                InterventionId = "arm-control",
+                                Metric = "KM",
+                                KaplanMeierCurve = new List<KaplanMeierPoint>
+                                {
+                                    new() { Time = 0, SurvivalProbability = 1.0 },
+                                    new() { Time = 30, SurvivalProbability = 0.85 }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var absPath = Path.Combine(root, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(absPath)!);
+            var json = JsonSerializer.Serialize(hook, JsonStd.Options);
+            await File.WriteAllTextAsync(absPath, json);
+        }
+
+        private sealed class RecordingGraphHub : IKnowledgeGraphHub
+        {
+            public List<string> RefreshedIds { get; } = new();
+
+            public Task InitializeAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+            public Task RefreshEntryAsync(string entryId, CancellationToken ct = default)
+            {
+                RefreshedIds.Add(entryId);
+                return Task.CompletedTask;
+            }
+
+            public Task<IReadOnlyList<MortalityComparison>> GetMortalityComparisonsAsync(string? entryId = null, CancellationToken ct = default)
+                => Task.FromResult<IReadOnlyList<MortalityComparison>>(Array.Empty<MortalityComparison>());
+
+            public Task<IReadOnlyList<KaplanMeierOverlay>> GetKaplanMeierOverlaysAsync(string entryId, string? endpointId = null, CancellationToken ct = default)
+                => Task.FromResult<IReadOnlyList<KaplanMeierOverlay>>(Array.Empty<KaplanMeierOverlay>());
+
+            public Task<IReadOnlyList<BaselineCharacteristicHit>> SearchBaselineCharacteristicsAsync(string characteristicSearchTerm, string? valueContains = null, CancellationToken ct = default)
+                => Task.FromResult<IReadOnlyList<BaselineCharacteristicHit>>(Array.Empty<BaselineCharacteristicHit>());
+
+            public Task<GraphEntryOverview?> GetEntryOverviewAsync(string entryId, CancellationToken ct = default)
+                => Task.FromResult<GraphEntryOverview?>(null);
+        }
+
+        private sealed class NoopHasher : IHasher
+        {
+            public Task<string> ComputeSha256Async(string filePath, CancellationToken ct = default)
+                => Task.FromResult("hash");
+        }
+
+        private sealed class TestWorkspaceService : IWorkSpaceService
+        {
+            public TestWorkspaceService(string root)
+            {
+                WorkspacePath = root;
+                Directory.CreateDirectory(root);
+            }
+
+            public string? WorkspacePath { get; private set; }
+
+            public Task EnsureWorkspaceAsync(string absoluteWorkspacePath, CancellationToken ct = default)
+            {
+                WorkspacePath = absoluteWorkspacePath;
+                Directory.CreateDirectory(absoluteWorkspacePath);
+                return Task.CompletedTask;
+            }
+
+            public string GetAbsolutePath(string relativePath)
+            {
+                relativePath ??= string.Empty;
+                return Path.Combine(WorkspacePath ?? string.Empty, relativePath);
+            }
+
+            public string GetLocalDbPath() => Path.Combine(WorkspacePath ?? string.Empty, "metadata.db");
+
+            public string GetWorkspaceRoot() => WorkspacePath ?? throw new InvalidOperationException("WorkspacePath not set");
+        }
+
+        private sealed class TempWorkspace : IDisposable
+        {
+            public TempWorkspace()
+            {
+                RootPath = Path.Combine(Path.GetTempPath(), "kw-graph-tests", Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(RootPath);
+            }
+
+            public string RootPath { get; }
+
+            public void Dispose()
+            {
+                try
+                {
+                    if (Directory.Exists(RootPath))
+                        Directory.Delete(RootPath, recursive: true);
+                }
+                catch
+                {
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a DataExtractionHook model and a KnowledgeGraphHub service that stores graph nodes and relationships in SQLite with query helpers
- teach HubSpokeStore to preserve existing data extraction pointers and notify the knowledge graph hub after saves
- introduce integration tests exercising graph ingestion and documentation for the new module

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: .NET 8 SDK cannot target net9.0 in this environment)*
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: .NET 8 SDK cannot target net9.0 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d68bfb897c832b8330a0e7d0c08b92