### PR TITLE
Add review module wiring and workspace store

### DIFF
--- a/src/LM.App.Wpf.Tests/AppHostBuilderTests.cs
+++ b/src/LM.App.Wpf.Tests/AppHostBuilderTests.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Threading.Tasks;
 using LM.App.Wpf.Application;
 using LM.App.Wpf.Composition.Modules;
 using LM.App.Wpf.ViewModels;
+using LM.App.Wpf.ViewModels.Review;
 using LM.Core.Abstractions;
 using LM.Infrastructure.FileSystem;
+using LM.Review.Core.Services;
 using Xunit;
 
 public class AppHostBuilderTests
@@ -19,14 +22,23 @@ public class AppHostBuilderTests
             .AddModule(new CoreModule(workspace))
             .AddModule(new AddModule())
             .AddModule(new LibraryModule())
+            .AddModule(new ReviewModule())
             .AddModule(new SearchModule())
             .Build();
 
         var entryStore = host.GetRequiredService<IEntryStore>();
         var pipeline = host.GetRequiredService<IAddPipeline>();
+        var workflowService = host.GetRequiredService<IReviewWorkflowService>();
+        var analyticsService = host.GetRequiredService<IReviewAnalyticsService>();
+        var dashboardFactory = host.GetRequiredService<Func<ReviewDashboardViewModel>>();
+        var stageFactory = host.GetRequiredService<Func<ReviewStageViewModel>>();
 
         Assert.NotNull(entryStore);
         Assert.NotNull(pipeline);
+        Assert.NotNull(workflowService);
+        Assert.NotNull(analyticsService);
+        Assert.NotNull(dashboardFactory());
+        Assert.NotNull(stageFactory());
 
         await entryStore.InitializeAsync();
     }

--- a/src/LM.App.Wpf/App.xaml.cs
+++ b/src/LM.App.Wpf/App.xaml.cs
@@ -67,6 +67,7 @@ namespace LM.App.Wpf
                                      .AddModule(new CoreModule(ws))
                                      .AddModule(new AddModule())
                                      .AddModule(new LibraryModule())
+                                     .AddModule(new ReviewModule())
                                      .AddModule(new SearchModule())
                                      .Build();
             _host = host;

--- a/src/LM.App.Wpf/Composition/Modules/ReviewModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/ReviewModule.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using System;
+using LM.App.Wpf.ViewModels.Review;
+using LM.Infrastructure.Review;
+using LM.Review.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace LM.App.Wpf.Composition.Modules;
+
+internal sealed class ReviewModule : IAppModule
+{
+    public void ConfigureServices(HostApplicationBuilder builder)
+    {
+        var services = builder.Services;
+
+        services.AddSingleton<WorkspaceReviewWorkflowStore>();
+        services.AddSingleton<IReviewWorkflowStore>(static sp => sp.GetRequiredService<WorkspaceReviewWorkflowStore>());
+        services.AddSingleton<IReviewHookContextFactory, ReviewHookContextFactory>();
+        services.AddSingleton<IReviewWorkflowService>(static sp => new ReviewWorkflowService(
+            sp.GetRequiredService<IReviewWorkflowStore>(),
+            sp.GetRequiredService<IReviewHookOrchestrator>(),
+            sp.GetRequiredService<IReviewHookContextFactory>()));
+        services.AddSingleton<IReviewAnalyticsService, ReviewAnalyticsService>();
+
+        services.AddTransient<ReviewDashboardViewModel>();
+        services.AddTransient<ReviewStageViewModel>();
+
+        services.AddTransient<Func<ReviewDashboardViewModel>>(static sp => () => sp.GetRequiredService<ReviewDashboardViewModel>());
+        services.AddTransient<Func<ReviewStageViewModel>>(static sp => () => sp.GetRequiredService<ReviewStageViewModel>());
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Review/ReviewDashboardViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Review/ReviewDashboardViewModel.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Review.Core.Models.Analytics;
+using LM.Review.Core.Services;
+
+namespace LM.App.Wpf.ViewModels.Review;
+
+internal sealed class ReviewDashboardViewModel
+{
+    private readonly IReviewWorkflowStore _store;
+    private readonly IReviewAnalyticsService _analytics;
+
+    public ReviewDashboardViewModel(IReviewWorkflowStore store, IReviewAnalyticsService analytics)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _analytics = analytics ?? throw new ArgumentNullException(nameof(analytics));
+    }
+
+    public async Task<ProjectAnalyticsSnapshot?> LoadProjectAnalyticsAsync(string projectId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectId);
+
+        var project = await _store.GetProjectAsync(projectId, cancellationToken).ConfigureAwait(false);
+        if (project is null)
+        {
+            return null;
+        }
+
+        var stages = await _store.GetStagesByProjectAsync(projectId, cancellationToken).ConfigureAwait(false);
+        return _analytics.CreateSnapshot(project, stages);
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Review/ReviewStageViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Review/ReviewStageViewModel.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Review.Core.Models;
+using LM.Review.Core.Services;
+
+namespace LM.App.Wpf.ViewModels.Review;
+
+internal sealed class ReviewStageViewModel
+{
+    private readonly IReviewWorkflowStore _store;
+    private readonly IReviewWorkflowService _workflowService;
+
+    public ReviewStageViewModel(IReviewWorkflowStore store, IReviewWorkflowService workflowService)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _workflowService = workflowService ?? throw new ArgumentNullException(nameof(workflowService));
+    }
+
+    public Task<ReviewStage?> GetStageAsync(string stageId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stageId);
+        return _store.GetStageAsync(stageId, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<ScreeningAssignment>> GetAssignmentsAsync(string stageId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stageId);
+        return _store.GetAssignmentsByStageAsync(stageId, cancellationToken);
+    }
+
+    public Task<ScreeningAssignment> SubmitDecisionAsync(string assignmentId, ScreeningStatus decision, string? notes, CancellationToken cancellationToken = default)
+        => _workflowService.SubmitDecisionAsync(assignmentId, decision, notes, cancellationToken);
+}

--- a/src/LM.Infrastructure/PublicAPI.Unshipped.txt
+++ b/src/LM.Infrastructure/PublicAPI.Unshipped.txt
@@ -111,3 +111,12 @@ LM.Infrastructure.Review.ReviewHookContextFactory.CreateConsensusResolved(LM.Rev
 LM.Infrastructure.Review.ReviewHookContextFactory.CreateReviewerDecisionRecorded(LM.Review.Core.Models.ScreeningAssignment! assignment, LM.Review.Core.Models.ReviewerDecision! decision) -> LM.Review.Core.Services.IReviewHookContext!
 LM.Infrastructure.Review.ReviewHookContextFactory.CreateStageTransition(LM.Review.Core.Models.ReviewStage! stage, LM.Review.Core.Models.ConflictState previousState, LM.Review.Core.Models.ConflictState currentState) -> LM.Review.Core.Services.IReviewHookContext!
 LM.Infrastructure.Review.ReviewHookContextFactory.ReviewHookContextFactory() -> void
+LM.Infrastructure.Review.WorkspaceReviewWorkflowStore
+LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.GetAssignmentAsync(string! assignmentId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<LM.Review.Core.Models.ScreeningAssignment?>!
+LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.GetAssignmentsByStageAsync(string! stageId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.ScreeningAssignment!>>!
+LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.GetProjectAsync(string! projectId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<LM.Review.Core.Models.ReviewProject?>!
+LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.GetStageAsync(string! stageId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<LM.Review.Core.Models.ReviewStage?>!
+LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.GetStagesByProjectAsync(string! projectId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.ReviewStage!>>!
+LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.SaveAssignmentAsync(string! projectId, LM.Review.Core.Models.ScreeningAssignment! assignment, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.SaveStageAsync(LM.Review.Core.Models.ReviewStage! stage, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.WorkspaceReviewWorkflowStore(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void

--- a/src/LM.Infrastructure/Review/WorkspaceReviewWorkflowStore.cs
+++ b/src/LM.Infrastructure/Review/WorkspaceReviewWorkflowStore.cs
@@ -1,0 +1,91 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Abstractions;
+using LM.Review.Core.Models;
+using LM.Review.Core.Services;
+
+namespace LM.Infrastructure.Review;
+
+/// <summary>
+/// Persists review workflow state in the workspace by delegating to <see cref="JsonReviewProjectStore"/>.
+/// </summary>
+public sealed class WorkspaceReviewWorkflowStore : IReviewWorkflowStore
+{
+    private readonly JsonReviewProjectStore _store;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private bool _initialized;
+
+    public WorkspaceReviewWorkflowStore(IWorkSpaceService workspace)
+    {
+        _store = new JsonReviewProjectStore(workspace ?? throw new ArgumentNullException(nameof(workspace)));
+    }
+
+    public async Task<ReviewProject?> GetProjectAsync(string projectId, CancellationToken cancellationToken)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        return await _store.GetProjectAsync(projectId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<ReviewStage?> GetStageAsync(string stageId, CancellationToken cancellationToken)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        return await _store.GetStageAsync(stageId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<ReviewStage>> GetStagesByProjectAsync(string projectId, CancellationToken cancellationToken)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        return await _store.GetStagesByProjectAsync(projectId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<ScreeningAssignment?> GetAssignmentAsync(string assignmentId, CancellationToken cancellationToken)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        return await _store.GetAssignmentAsync(assignmentId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<ScreeningAssignment>> GetAssignmentsByStageAsync(string stageId, CancellationToken cancellationToken)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        return await _store.GetAssignmentsByStageAsync(stageId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task SaveStageAsync(ReviewStage stage, CancellationToken cancellationToken)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        await _store.SaveStageAsync(stage, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task SaveAssignmentAsync(string projectId, ScreeningAssignment assignment, CancellationToken cancellationToken)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        await _store.SaveAssignmentAsync(projectId, assignment, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        await _initLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            await _store.InitializeAsync(cancellationToken).ConfigureAwait(false);
+            _initialized = true;
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a review composition module that wires the workspace-backed workflow store, review services, and factories for review view models
- expose a workspace-backed implementation of `IReviewWorkflowStore` and lightweight review view models
- load the review module in the WPF app bootstrapper and extend host builder tests to cover the new registrations

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: installed SDK 8.0.414 cannot build net9.0 targets)*
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: installed SDK 8.0.414 cannot build net9.0 targets)*

------
https://chatgpt.com/codex/tasks/task_e_68d692383ddc832b9b0a0c34b4453cc7