### PR TITLE
Fix staging review commit flow and export utilities

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,8 @@
     <PackageVersion Include="UglyToad.PdfPig.Core" Version="1.7.0" />
     <PackageVersion Include="UglyToad.PdfPig.Fonts" Version="1.7.0" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="2.20.0" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.3" />
-    <PackageVersion Include="EPPlus" Version="6.3.0" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />
+    <PackageVersion Include="EPPlus" Version="7.0.0" />
 
     <!-- === Microsoft.Extensions family (pin if used anywhere) === -->
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />

--- a/src/LM.App.Wpf.Tests/Dialogs/Staging/StagingEditorViewModelTests.cs
+++ b/src/LM.App.Wpf.Tests/Dialogs/Staging/StagingEditorViewModelTests.cs
@@ -38,7 +38,7 @@ namespace LM.App.Wpf.Tests.Dialogs.Staging
                 new StagingFiguresTabViewModel(),
                 new StagingEndpointsTabViewModel(),
                 new StagingPopulationTabViewModel(),
-                new StagingReviewCommitTabViewModel());
+                new StagingReviewCommitTabViewModel(list, new DataExtractionCommitBuilder()));
 
             Assert.Equal(6, editor.Tabs.Count);
             Assert.Equal("Metadata", editor.SelectedTab?.Header);
@@ -77,6 +77,7 @@ namespace LM.App.Wpf.Tests.Dialogs.Staging
         {
             public string[]? ShowOpenFileDialog(FilePickerOptions options) => Array.Empty<string>();
             public string? ShowFolderBrowserDialog(FolderPickerOptions options) => null;
+            public string? ShowSaveFileDialog(FileSavePickerOptions options) => null;
             public bool? ShowStagingEditor(StagingListViewModel stagingList) => false;
         }
     }

--- a/src/LM.App.Wpf.Tests/Dialogs/Staging/StagingTablesTabViewModelTests.cs
+++ b/src/LM.App.Wpf.Tests/Dialogs/Staging/StagingTablesTabViewModelTests.cs
@@ -141,6 +141,8 @@ namespace LM.App.Wpf.Tests.Dialogs.Staging
 
             public string? ShowFolderBrowserDialog(FolderPickerOptions options) => null;
 
+            public string? ShowSaveFileDialog(FileSavePickerOptions options) => null;
+
             public bool? ShowStagingEditor(StagingListViewModel stagingList) => false;
         }
     }

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -28,11 +28,6 @@ LM.App.Wpf.Common.Dialogs.IDialogService.ShowSaveFileDialog(LM.App.Wpf.Common.Di
 LM.App.Wpf.Common.Dialogs.WpfDialogService.ShowSaveFileDialog(LM.App.Wpf.Common.Dialogs.FileSavePickerOptions! options) -> string?
 LM.App.Wpf.ViewModels.AddPipeline.AddPipeline(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.ISimilarityService! similarity, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IMetadataExtractor! metadata, IPublicationLookup! publicationLookup, LM.Core.Abstractions.IDoiNormalizer! doiNormalizer, LM.Infrastructure.Hooks.HookOrchestrator! orchestrator, LM.Core.Abstractions.IPmidNormalizer! pmidNormalizer, LM.Core.Abstractions.IDataExtractionPreprocessor! preprocessor, LM.HubSpoke.Abstractions.ISimilarityLog? simLog = null) -> void
 LM.App.Wpf.ViewModels.AddViewModel.AddViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.ISimilarityService! similarity, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IMetadataExtractor! metadata, IPublicationLookup! publicationLookup, LM.Core.Abstractions.IDoiNormalizer! doiNormalizer, LM.Infrastructure.Hooks.HookOrchestrator! orchestrator, LM.Core.Abstractions.IPmidNormalizer! pmidNormalizer, LM.Core.Abstractions.IDataExtractionPreprocessor! preprocessor, LM.HubSpoke.Abstractions.ISimilarityLog? simLog = null) -> void
-LM.App.Wpf.ViewModels.Dialogs.StagingEditorViewModel.HasValidationErrors.get -> bool
-LM.App.Wpf.ViewModels.Dialogs.StagingEditorViewModel.SelectedTab.get -> LM.App.Wpf.ViewModels.Dialogs.Staging.StagingTabViewModel?
-LM.App.Wpf.ViewModels.Dialogs.StagingEditorViewModel.SelectedTab.set -> void
-LM.App.Wpf.ViewModels.Dialogs.StagingEditorViewModel.StagingEditorViewModel(LM.App.Wpf.ViewModels.StagingListViewModel! stagingList, LM.App.Wpf.ViewModels.Dialogs.Staging.StagingMetadataTabViewModel! metadataTab, LM.App.Wpf.ViewModels.Dialogs.Staging.StagingTablesTabViewModel! tablesTab, LM.App.Wpf.ViewModels.Dialogs.Staging.StagingFiguresTabViewModel! figuresTab, LM.App.Wpf.ViewModels.Dialogs.Staging.StagingEndpointsTabViewModel! endpointsTab, LM.App.Wpf.ViewModels.Dialogs.Staging.StagingPopulationTabViewModel! populationTab, LM.App.Wpf.ViewModels.Dialogs.Staging.StagingReviewCommitTabViewModel! reviewTab) -> void
-LM.App.Wpf.ViewModels.Dialogs.StagingEditorViewModel.Tabs.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.Dialogs.Staging.StagingTabViewModel!>!
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.ExportExtractionToExcelCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand!
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.ExportExtractionToPowerPointCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand!
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.ExportExtractionToWordCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand!
@@ -268,9 +263,6 @@ LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel.ResultNotes.get -> strin
 LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel.ResultTags.get -> string!
 LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel.SearchSaveDialogViewModel() -> void
 LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel.Title.get -> string!
-LM.App.Wpf.ViewModels.Dialogs.StagingEditorViewModel
-LM.App.Wpf.ViewModels.Dialogs.StagingEditorViewModel.Dispose() -> void
-LM.App.Wpf.ViewModels.Dialogs.StagingEditorViewModel.StagingList.get -> LM.App.Wpf.ViewModels.StagingListViewModel!
 LM.App.Wpf.ViewModels.Dialogs.WorkspaceChooserViewModel
 LM.App.Wpf.ViewModels.Dialogs.WorkspaceChooserViewModel.SelectedWorkspacePath.get -> string?
 LM.App.Wpf.ViewModels.Dialogs.WorkspaceChooserViewModel.Title.get -> string!
@@ -682,9 +674,6 @@ LM.App.Wpf.Views.SearchView.SearchView() -> void
 LM.App.Wpf.Views.ShellWindow
 LM.App.Wpf.Views.ShellWindow.InitializeComponent() -> void
 LM.App.Wpf.Views.ShellWindow.ShellWindow() -> void
-LM.App.Wpf.Views.StagingEditorWindow
-LM.App.Wpf.Views.StagingEditorWindow.InitializeComponent() -> void
-LM.App.Wpf.Views.StagingEditorWindow.StagingEditorWindow(LM.App.Wpf.ViewModels.Dialogs.StagingEditorViewModel! viewModel) -> void
 override LM.App.Wpf.Views.Library.AttachmentMetadataDialog.OnClosed(System.EventArgs! e) -> void
 LM.App.Wpf.Views.WorkspaceChooser
 LM.App.Wpf.Views.WorkspaceChooser.InitializeComponent() -> void
@@ -694,6 +683,5 @@ override LM.App.Wpf.App.OnExit(System.Windows.ExitEventArgs! e) -> void
 override LM.App.Wpf.App.OnStartup(System.Windows.StartupEventArgs! e) -> void
 override LM.App.Wpf.Views.LibraryPresetPickerDialog.OnClosed(System.EventArgs! e) -> void
 override LM.App.Wpf.Views.LibraryPresetSaveDialog.OnClosed(System.EventArgs! e) -> void
-override LM.App.Wpf.Views.StagingEditorWindow.OnClosed(System.EventArgs! e) -> void
 override LM.App.Wpf.Views.WorkspaceChooser.OnClosed(System.EventArgs! e) -> void
 static LM.App.Wpf.App.Main() -> void

--- a/src/LM.App.Wpf/ViewModels/Add/AddPipeline.cs
+++ b/src/LM.App.Wpf/ViewModels/Add/AddPipeline.cs
@@ -742,186 +742,7 @@ namespace LM.App.Wpf.ViewModels
                 Title = string.IsNullOrWhiteSpace(f.Caption) ? "Figure" : f.Caption,
                 Caption = f.Caption,
                 SourcePath = NormalizeWorkspacePath(f.ThumbnailRelativePath),
-                Pages = f.PageNumbers.Select(p => p.ToString(CultureInfo.InvariantCulture)).ToList(),
-                ProvenanceHash = FormatProvenanceHash(f.ProvenanceHash)
-            }).ToList();
-
-            return new HookM.DataExtractionHook
-            {
-                ExtractedAtUtc = result.Provenance.ExtractedAtUtc,
-                ExtractedBy = string.IsNullOrWhiteSpace(result.Provenance.ExtractedBy) ? GetCurrentUserName() : result.Provenance.ExtractedBy,
-                Populations = populations.Values.ToList(),
-                Interventions = interventions.Values.ToList(),
-                Endpoints = endpoints.Values.ToList(),
-                Figures = figureHooks,
-                Tables = tableHooks,
-                Notes = null
-            };
-        }
-
-        private async Task TryPopulateEvidenceAsync(StagingItem item, string path, string sha256, string extension, CancellationToken ct)
-        {
-            if (item is null)
-                throw new ArgumentNullException(nameof(item));
-            if (item.IsDuplicate)
-                return;
-            if (!string.Equals(extension, ".pdf", StringComparison.OrdinalIgnoreCase))
-                return;
-
-            try
-            {
-                var request = new DataExtractionPreprocessRequest(path)
-                {
-                    PreferredCacheKey = sha256
-                };
-
-                var result = await _preprocessor.PreprocessAsync(request, ct).ConfigureAwait(false);
-                if (result is null || result.IsEmpty)
-                    return;
-
-                item.EvidencePreview = BuildEvidencePreview(result);
-                item.DataExtractionHook = BuildDataExtractionHook(result);
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Trace.WriteLine($"[AddPipeline] Data extraction preprocessing failed for '{path}': {ex.Message}");
-            }
-        }
-
-        private static StagingEvidencePreview BuildEvidencePreview(DataExtractionPreprocessResult result)
-        {
-            var sections = result.Sections.Select(s => new StagingEvidencePreview.SectionPreview
-            {
-                Heading = s.Heading,
-                Body = Truncate(s.Body, 800),
-                Pages = s.PageNumbers
-            }).ToList();
-
-            var tables = result.Tables.Select(t => new StagingEvidencePreview.TablePreview
-            {
-                Title = string.IsNullOrWhiteSpace(t.Title) ? "Table" : t.Title,
-                Classification = t.Classification,
-                Populations = t.DetectedPopulations,
-                Endpoints = t.DetectedEndpoints,
-                Pages = t.PageNumbers
-            }).ToList();
-
-            var figures = result.Figures.Select(f => new StagingEvidencePreview.FigurePreview
-            {
-                Caption = f.Caption,
-                Pages = f.PageNumbers,
-                ThumbnailPath = NormalizeWorkspacePath(f.ThumbnailRelativePath)
-            }).ToList();
-
-            return new StagingEvidencePreview
-            {
-                Sections = sections,
-                Tables = tables,
-                Figures = figures,
-                Provenance = result.Provenance
-            };
-        }
-
-        private HookM.DataExtractionHook BuildDataExtractionHook(DataExtractionPreprocessResult result)
-        {
-            var populations = new Dictionary<string, HookM.DataExtractionPopulation>(StringComparer.OrdinalIgnoreCase);
-            var interventions = new Dictionary<string, HookM.DataExtractionIntervention>(StringComparer.OrdinalIgnoreCase);
-            var endpoints = new Dictionary<string, HookM.DataExtractionEndpoint>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var table in result.Tables)
-            {
-                foreach (var pop in table.DetectedPopulations)
-                {
-                    if (string.IsNullOrWhiteSpace(pop))
-                        continue;
-                    if (!populations.ContainsKey(pop))
-                    {
-                        populations[pop] = new HookM.DataExtractionPopulation
-                        {
-                            Label = pop
-                        };
-                    }
-                }
-
-                foreach (var endpoint in table.DetectedEndpoints)
-                {
-                    if (string.IsNullOrWhiteSpace(endpoint))
-                        continue;
-                    if (!endpoints.ContainsKey(endpoint))
-                    {
-                        endpoints[endpoint] = new HookM.DataExtractionEndpoint
-                        {
-                            Name = endpoint
-                        };
-                    }
-                }
-
-                foreach (var column in table.Columns.Where(c => c.Role == TableColumnRole.Intervention))
-                {
-                    var label = string.IsNullOrWhiteSpace(column.Header) ? column.NormalizedHeader : column.Header;
-                    if (string.IsNullOrWhiteSpace(label))
-                        continue;
-                    if (!interventions.ContainsKey(label))
-                    {
-                        interventions[label] = new HookM.DataExtractionIntervention
-                        {
-                            Name = label
-                        };
-                    }
-                }
-            }
-
-            foreach (var intervention in interventions.Values)
-            {
-                foreach (var population in populations.Values)
-                {
-                    if (intervention.Name.Contains(population.Label, StringComparison.OrdinalIgnoreCase))
-                    {
-                        intervention.PopulationIds.Add(population.Id);
-                    }
-                }
-            }
-
-            var tableHooks = new List<HookM.DataExtractionTable>();
-            foreach (var table in result.Tables)
-            {
-                var linkedEndpoints = table.DetectedEndpoints
-                    .Where(e => endpoints.ContainsKey(e))
-                    .Select(e => endpoints[e].Id)
-                    .Distinct()
-                    .ToList();
-
-                var linkedInterventions = table.Columns
-                    .Where(c => c.Role == TableColumnRole.Intervention)
-                    .Select(c => string.IsNullOrWhiteSpace(c.Header) ? c.NormalizedHeader : c.Header)
-                    .Where(label => !string.IsNullOrWhiteSpace(label) && interventions.ContainsKey(label))
-                    .Select(label => interventions[label!].Id)
-                    .Distinct()
-                    .ToList();
-
-                var hookTable = new HookM.DataExtractionTable
-                {
-                    Title = string.IsNullOrWhiteSpace(table.Title) ? "Table" : table.Title,
-                    Caption = table.Classification.ToString(),
-                    SourcePath = NormalizeWorkspacePath(table.CsvRelativePath),
-                    Pages = table.PageNumbers.Select(p => p.ToString(CultureInfo.InvariantCulture)).ToList(),
-                    ProvenanceHash = FormatProvenanceHash(table.ProvenanceHash)
-                };
-
-                hookTable.LinkedEndpointIds.AddRange(linkedEndpoints);
-                hookTable.LinkedInterventionIds.AddRange(linkedInterventions);
-                tableHooks.Add(hookTable);
-            }
-
-            var figureHooks = result.Figures.Select(f => new HookM.DataExtractionFigure
-            {
-                Title = string.IsNullOrWhiteSpace(f.Caption) ? "Figure" : f.Caption,
-                Caption = f.Caption,
-                SourcePath = NormalizeWorkspacePath(f.ThumbnailRelativePath),
+                ThumbnailPath = NormalizeWorkspacePath(f.ThumbnailRelativePath),
                 Pages = f.PageNumbers.Select(p => p.ToString(CultureInfo.InvariantCulture)).ToList(),
                 ProvenanceHash = FormatProvenanceHash(f.ProvenanceHash)
             }).ToList();
@@ -1171,7 +992,7 @@ namespace LM.App.Wpf.ViewModels
 
             return value.Length <= maxLength
                 ? value
-                : string.Concat(value.AsSpan(0, maxLength), '…');
+                : value.Substring(0, maxLength) + "…";
         }
 
         private static string ResolveContentType(string storagePath)
@@ -1302,22 +1123,5 @@ namespace LM.App.Wpf.ViewModels
             public string? TagsCsv { get; set; }
         }
 
-        // Null-objects to keep the compatibility constructor safe
-        internal sealed class NullPublicationLookup : IPublicationLookup
-        {
-            internal static readonly NullPublicationLookup Instance = new();
-            public Task<PublicationRecord?> TryGetByDoiAsync(string doi, bool includeCitedBy, CancellationToken ct)
-                => Task.FromResult<PublicationRecord?>(null);
-        }
-        internal sealed class NullPmidNormalizer : IPmidNormalizer
-        {
-            internal static readonly NullPmidNormalizer Instance = new();
-            public string? Normalize(string? raw) => raw?.Trim(); // encourages DI to supply real impl
-        }
-        internal sealed class NullDoiNormalizer : IDoiNormalizer
-        {
-            internal static readonly NullDoiNormalizer Instance = new();
-            public string? Normalize(string? raw) => raw?.Trim(); // encourage DI registration for real cleaning
-        }
     }
 }

--- a/src/LM.App.Wpf/ViewModels/Add/NullAddPipelineServices.cs
+++ b/src/LM.App.Wpf/ViewModels/Add/NullAddPipelineServices.cs
@@ -1,0 +1,30 @@
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Abstractions;
+
+namespace LM.App.Wpf.ViewModels
+{
+    internal sealed class NullPublicationLookup : IPublicationLookup
+    {
+        internal static readonly NullPublicationLookup Instance = new();
+
+        public Task<PublicationRecord?> TryGetByDoiAsync(string doi, bool includeCitedBy, CancellationToken ct)
+            => Task.FromResult<PublicationRecord?>(null);
+    }
+
+    internal sealed class NullPmidNormalizer : IPmidNormalizer
+    {
+        internal static readonly NullPmidNormalizer Instance = new();
+
+        public string? Normalize(string? raw) => raw?.Trim();
+    }
+
+    internal sealed class NullDoiNormalizer : IDoiNormalizer
+    {
+        internal static readonly NullDoiNormalizer Instance = new();
+
+        public string? Normalize(string? raw) => raw?.Trim();
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingReviewCommitTabViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingReviewCommitTabViewModel.cs
@@ -7,18 +7,31 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
+using LM.App.Wpf.ViewModels;
 
 
 namespace LM.App.Wpf.ViewModels.Dialogs.Staging
 {
     internal sealed class StagingReviewCommitTabViewModel : StagingTabViewModel
     {
-        private IReadOnlyList<StagingTabViewModel>? _tabs;
+        private readonly StagingListViewModel _stagingList;
+        private readonly IDataExtractionCommitBuilder _builder;
+        private readonly AsyncRelayCommand _commitExtractionCommand;
+        private readonly AsyncRelayCommand _commitMetadataOnlyCommand;
 
-        public StagingReviewCommitTabViewModel()
+        private IReadOnlyList<StagingTabViewModel>? _tabs;
+        private StagingTablesTabViewModel? _tablesTab;
+        private StagingEndpointsTabViewModel? _endpointsTab;
+
+        public StagingReviewCommitTabViewModel(StagingListViewModel stagingList,
+                                               IDataExtractionCommitBuilder builder)
             : base("Review & Commit")
         {
+            _stagingList = stagingList ?? throw new ArgumentNullException(nameof(stagingList));
+            _builder = builder ?? throw new ArgumentNullException(nameof(builder));
 
+            _commitExtractionCommand = new AsyncRelayCommand(CommitExtractionAsync, CanCommit);
+            _commitMetadataOnlyCommand = new AsyncRelayCommand(CommitMetadataOnlyAsync, CanCommit);
         }
 
         public ObservableCollection<string> Messages { get; } = new();

--- a/src/LM.App.Wpf/ViewModels/Dialogs/StagingEditorViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/StagingEditorViewModel.cs
@@ -12,7 +12,7 @@ using LM.Infrastructure.Utils;
 
 namespace LM.App.Wpf.ViewModels.Dialogs
 {
-    public sealed partial class StagingEditorViewModel : DialogViewModelBase, IDisposable
+    internal sealed partial class StagingEditorViewModel : DialogViewModelBase, IDisposable
     {
         private readonly StagingReviewCommitTabViewModel _reviewTab;
         private StagingTabViewModel? _selectedTab;

--- a/src/LM.App.Wpf/Views/StagingEditorWindow.xaml.cs
+++ b/src/LM.App.Wpf/Views/StagingEditorWindow.xaml.cs
@@ -5,7 +5,7 @@ using LM.App.Wpf.ViewModels.Dialogs;
 
 namespace LM.App.Wpf.Views
 {
-    public partial class StagingEditorWindow : System.Windows.Window
+    internal partial class StagingEditorWindow : System.Windows.Window
     {
         private readonly StagingEditorViewModel _viewModel;
 

--- a/src/LM.HubAndSpoke/Models/DataExtraction/DataExtractionFigure.cs
+++ b/src/LM.HubAndSpoke/Models/DataExtraction/DataExtractionFigure.cs
@@ -8,5 +8,8 @@ namespace LM.HubSpoke.Models
     {
         [JsonPropertyName("figure_label")]
         public string? FigureLabel { get; init; }
+
+        [JsonPropertyName("thumbnail_path")]
+        public string? ThumbnailPath { get; init; }
     }
 }

--- a/src/LM.HubAndSpoke/Models/DataExtraction/DataExtractionIntervention.cs
+++ b/src/LM.HubAndSpoke/Models/DataExtraction/DataExtractionIntervention.cs
@@ -26,6 +26,9 @@ namespace LM.HubSpoke.Models
         [JsonPropertyName("dosage")]
         public string? Dosage { get; init; }
 
+        [JsonPropertyName("comparator")]
+        public string? Comparator { get; init; }
+
         [JsonPropertyName("notes")]
         public string? Notes { get; init; }
     }

--- a/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
+++ b/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
@@ -343,6 +343,8 @@ LM.HubSpoke.Models.DataExtractionFigure
 LM.HubSpoke.Models.DataExtractionFigure.DataExtractionFigure() -> void
 LM.HubSpoke.Models.DataExtractionFigure.FigureLabel.get -> string?
 LM.HubSpoke.Models.DataExtractionFigure.FigureLabel.init -> void
+LM.HubSpoke.Models.DataExtractionFigure.ThumbnailPath.get -> string?
+LM.HubSpoke.Models.DataExtractionFigure.ThumbnailPath.init -> void
 LM.HubSpoke.Models.DataExtractionHook
 LM.HubSpoke.Models.DataExtractionHook.DataExtractionHook() -> void
 LM.HubSpoke.Models.DataExtractionHook.Endpoints.get -> System.Collections.Generic.List<LM.HubSpoke.Models.DataExtractionEndpoint!>!
@@ -377,6 +379,8 @@ LM.HubSpoke.Models.DataExtractionIntervention.Notes.get -> string?
 LM.HubSpoke.Models.DataExtractionIntervention.Notes.init -> void
 LM.HubSpoke.Models.DataExtractionIntervention.PopulationIds.get -> System.Collections.Generic.List<string!>!
 LM.HubSpoke.Models.DataExtractionIntervention.PopulationIds.init -> void
+LM.HubSpoke.Models.DataExtractionIntervention.Comparator.get -> string?
+LM.HubSpoke.Models.DataExtractionIntervention.Comparator.init -> void
 LM.HubSpoke.Models.DataExtractionIntervention.Type.get -> string?
 LM.HubSpoke.Models.DataExtractionIntervention.Type.init -> void
 LM.HubSpoke.Models.DataExtractionEndpoint

--- a/src/LM.Infrastructure/Export/DataExtractionExportLoader.cs
+++ b/src/LM.Infrastructure/Export/DataExtractionExportLoader.cs
@@ -11,7 +11,7 @@ using HookM = LM.HubSpoke.Models;
 
 namespace LM.Infrastructure.Export
 {
-    internal sealed class DataExtractionExportLoader
+    public sealed class DataExtractionExportLoader
     {
         private readonly IWorkSpaceService _workspace;
 

--- a/src/LM.Infrastructure/Export/DataExtractionWordExporter.cs
+++ b/src/LM.Infrastructure/Export/DataExtractionWordExporter.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using LM.Core.Abstractions;
@@ -91,7 +92,7 @@ namespace LM.Infrastructure.Export
 
             if (rows.Count == 0)
             {
-                tableElement.Append(new TableRow(new TableCell(new Paragraph(new Run(new Text("No CSV data found") { Space = SpaceProcessingModeValues.Preserve })))));
+                tableElement.Append(new TableRow(new TableCell(new Paragraph(new Run(new DocumentFormat.OpenXml.Wordprocessing.Text("No CSV data found") { Space = SpaceProcessingModeValues.Preserve })))));
             }
             else
             {
@@ -100,7 +101,7 @@ namespace LM.Infrastructure.Export
                     var tableRow = new TableRow();
                     foreach (var cell in row)
                     {
-                        tableRow.Append(new TableCell(new Paragraph(new Run(new Text(cell ?? string.Empty) { Space = SpaceProcessingModeValues.Preserve }))));
+                        tableRow.Append(new TableCell(new Paragraph(new Run(new DocumentFormat.OpenXml.Wordprocessing.Text(cell ?? string.Empty) { Space = SpaceProcessingModeValues.Preserve }))));
                     }
 
                     tableElement.Append(tableRow);
@@ -128,7 +129,7 @@ namespace LM.Infrastructure.Export
 
         private static void AppendParagraph(Body body, string text, bool bold = false, int size = 24)
         {
-            var run = new Run(new Text(text ?? string.Empty) { Space = SpaceProcessingModeValues.Preserve });
+            var run = new Run(new DocumentFormat.OpenXml.Wordprocessing.Text(text ?? string.Empty) { Space = SpaceProcessingModeValues.Preserve });
             if (bold)
             {
                 run.PrependChild(new RunProperties(new Bold(), new FontSize { Val = size.ToString(CultureInfo.InvariantCulture) }));

--- a/src/LM.Infrastructure/PublicAPI.Unshipped.txt
+++ b/src/LM.Infrastructure/PublicAPI.Unshipped.txt
@@ -128,3 +128,7 @@ LM.Infrastructure.Export.DataExtractionWordExporter
 LM.Infrastructure.Export.DataExtractionWordExporter.DataExtractionWordExporter(LM.Infrastructure.Export.DataExtractionExportLoader! loader) -> void
 LM.Infrastructure.Export.DataExtractionExcelExporter
 LM.Infrastructure.Export.DataExtractionExcelExporter.DataExtractionExcelExporter(LM.Infrastructure.Export.DataExtractionExportLoader! loader) -> void
+LM.Infrastructure.Export.DataExtractionExportLoader
+LM.Infrastructure.Export.DataExtractionExportLoader.DataExtractionExportLoader(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.Infrastructure.Export.DataExtractionExportLoader.HasExtractionAsync(string! entryId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<bool>!
+LM.Infrastructure.Export.DataExtractionExportLoader.LoadAsync(string! entryId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Infrastructure.Export.DataExtractionExportContext?>!


### PR DESCRIPTION
## Summary
- align the staging review tab with injected staging list/builder dependencies and scope the editor window/view model internally
- add reusable null DI shims, ensure AddPipeline and hub models carry figure thumbnails/comparators, and upgrade ImageSharp/EPPlus to supported versions
- update word exporter and unit tests to honor the new dialog/export loader contracts

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: installed SDK 8.0.414 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a547e1a0832ba680af60c8cd998a