### PR TITLE
Replace ImageSharp with SkiaSharp and centralize username resolution

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="UglyToad.PdfPig.Core" Version="1.7.0" />
     <PackageVersion Include="UglyToad.PdfPig.Fonts" Version="1.7.0" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="2.20.0" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />
+    <PackageVersion Include="SkiaSharp" Version="2.88.7" />
     <PackageVersion Include="EPPlus" Version="7.0.0" />
 
     <!-- === Microsoft.Extensions family (pin if used anywhere) === -->

--- a/src/LM.App.Wpf.Tests/AddPipelineExtractionCommitTests.cs
+++ b/src/LM.App.Wpf.Tests/AddPipelineExtractionCommitTests.cs
@@ -139,10 +139,7 @@ namespace LM.App.Wpf.Tests
         }
 
         private static string GetCurrentUserName()
-        {
-            var user = Environment.UserName;
-            return string.IsNullOrWhiteSpace(user) ? "unknown" : user;
-        }
+            => SystemUser.GetCurrent();
 
         private static HookM.DataExtractionHook CreateExtractionHook()
         {

--- a/src/LM.App.Wpf.Tests/Dialogs/Staging/StagingTablesTabViewModelTests.cs
+++ b/src/LM.App.Wpf.Tests/Dialogs/Staging/StagingTablesTabViewModelTests.cs
@@ -7,6 +7,7 @@ using LM.App.Wpf.ViewModels;
 using LM.App.Wpf.ViewModels.Dialogs.Staging;
 using LM.Core.Models;
 using LM.Core.Models.DataExtraction;
+using LM.Core.Utils;
 using LM.HubSpoke.Models;
 using LM.Infrastructure.FileSystem;
 using LM.Infrastructure.Hooks;
@@ -69,7 +70,7 @@ namespace LM.App.Wpf.Tests.Dialogs.Staging
             Assert.Single(item.PendingChangeLogEvents);
             var change = item.PendingChangeLogEvents[0];
             Assert.Equal("DigitizedCsvUpdated", change.Action);
-            Assert.Equal(Environment.UserName ?? "unknown", change.PerformedBy);
+            Assert.Equal(SystemUser.GetCurrent(), change.PerformedBy);
             Assert.Equal(item.DataExtractionHook.ExtractedBy, change.PerformedBy);
         }
 

--- a/src/LM.App.Wpf.Tests/LibraryViewModelFullTextTests.cs
+++ b/src/LM.App.Wpf.Tests/LibraryViewModelFullTextTests.cs
@@ -16,6 +16,7 @@ using LM.Core.Abstractions;
 using LM.Core.Abstractions.Configuration;
 using LM.Core.Models;
 using LM.Core.Models.Filters;
+using LM.Core.Utils;
 using LM.Core.Models.Search;
 using LM.HubSpoke.Models;
 using LM.Infrastructure.Hooks;
@@ -301,7 +302,7 @@ namespace LM.App.Wpf.Tests
             Assert.Contains(vm.Results.Selected.Entry.Attachments, a => a.RelativePath == attachment.RelativePath);
             Assert.Equal("paper", attachment.Title);
             Assert.Equal(AttachmentKind.Supplement, attachment.Kind);
-            var expectedUser = string.IsNullOrWhiteSpace(Environment.UserName) ? "unknown" : Environment.UserName;
+            var expectedUser = SystemUser.GetCurrent();
             Assert.Equal(expectedUser, attachment.AddedBy);
             Assert.NotEqual(default, attachment.AddedUtc);
 

--- a/src/LM.App.Wpf/ViewModels/Add/AddPipeline.cs
+++ b/src/LM.App.Wpf/ViewModels/Add/AddPipeline.cs
@@ -277,7 +277,7 @@ namespace LM.App.Wpf.ViewModels
                     // Append to target entry (Attachment has only RelativePath in your model)
                     target.Attachments ??= new List<Attachment>();
                     var now = DateTime.UtcNow;
-                    var addedBy = Environment.UserName ?? string.Empty;
+                    var addedBy = SystemUser.GetCurrent();
                     var title = Path.GetFileNameWithoutExtension(r.FilePath) ?? string.Empty;
                     target.Attachments.Add(new Attachment
                     {
@@ -1014,8 +1014,7 @@ namespace LM.App.Wpf.ViewModels
 
         private static string GetCurrentUserName()
         {
-            var user = Environment.UserName;
-            return string.IsNullOrWhiteSpace(user) ? "unknown" : user;
+            return SystemUser.GetCurrent();
         }
 
         private static List<string> SplitList(string? csv, bool distinct = false)

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/DataExtractionCommitBuilder.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/DataExtractionCommitBuilder.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using LM.App.Wpf.ViewModels;
+using LM.Core.Utils;
 using HookM = LM.HubSpoke.Models;
 
 namespace LM.App.Wpf.ViewModels.Dialogs.Staging
@@ -131,8 +132,7 @@ namespace LM.App.Wpf.ViewModels.Dialogs.Staging
 
         private static string GetCurrentUserName()
         {
-            var user = Environment.UserName;
-            return string.IsNullOrWhiteSpace(user) ? "unknown" : user;
+            return SystemUser.GetCurrent();
         }
     }
 }

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingFiguresTabViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingFiguresTabViewModel.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using LM.App.Wpf.ViewModels;
+using LM.Core.Utils;
 using HookM = LM.HubSpoke.Models;
 
 namespace LM.App.Wpf.ViewModels.Dialogs.Staging
@@ -36,7 +37,7 @@ namespace LM.App.Wpf.ViewModels.Dialogs.Staging
             item.DataExtractionHook ??= new HookM.DataExtractionHook
             {
                 ExtractedAtUtc = DateTime.UtcNow,
-                ExtractedBy = Environment.UserName ?? "unknown"
+                ExtractedBy = SystemUser.GetCurrent()
             };
 
             var hookFigures = item.DataExtractionHook.Figures;

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingTablesTabViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Staging/StagingTablesTabViewModel.cs
@@ -15,6 +15,7 @@ using LM.App.Wpf.ViewModels;
 using LM.Core.Abstractions;
 using LM.Core.Models;
 using LM.Core.Models.DataExtraction;
+using LM.Core.Utils;
 using LM.Infrastructure.Hooks;
 using HookM = LM.HubSpoke.Models;
 
@@ -311,8 +312,7 @@ namespace LM.App.Wpf.ViewModels.Dialogs.Staging
 
         private static string GetCurrentUserName()
         {
-            var user = Environment.UserName;
-            return string.IsNullOrWhiteSpace(user) ? "unknown" : user;
+            return SystemUser.GetCurrent();
         }
     }
 }

--- a/src/LM.App.Wpf/ViewModels/Library/LibraryResultsViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LibraryResultsViewModel.cs
@@ -16,6 +16,7 @@ using LM.App.Wpf.Views.Behaviors;
 using LM.Core.Abstractions;
 using LM.Core.Models;
 using LM.Core.Models.Search;
+using LM.Core.Utils;
 using LM.Infrastructure.Hooks;
 using HookM = LM.HubSpoke.Models;
 
@@ -727,8 +728,7 @@ namespace LM.App.Wpf.ViewModels.Library
 
         private static string GetCurrentUserName()
         {
-            var user = Environment.UserName;
-            return string.IsNullOrWhiteSpace(user) ? "unknown" : user;
+            return SystemUser.GetCurrent();
         }
 
         private static void ExecuteOnDispatcher(Action action)

--- a/src/LM.App.Wpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Search/SearchViewModel.cs
@@ -3,6 +3,7 @@ using LM.App.Wpf.Common;             // ViewModelBase, AsyncRelayCommand, RelayC
 using LM.Core.Abstractions;
 using LM.Core.Abstractions.Configuration;
 using LM.Core.Models;            // LitSearchHook, LitSearchRun, JsonStd
+using LM.Core.Utils;
 using LM.Core.Models.Search;
 using LM.HubSpoke.Models;
 using LM.App.Wpf.ViewModels.Search;
@@ -385,7 +386,7 @@ namespace LM.App.Wpf.ViewModels
             {
                 var now = DateTime.UtcNow;
                 var provider = SelectedDatabase == SearchDatabase.PubMed ? "pubmed" : "ctgov";
-                var user = Environment.UserName;
+                var user = SystemUser.GetCurrent();
 
                 var run = new LitSearchRun
                 {

--- a/src/LM.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Core/PublicAPI.Unshipped.txt
@@ -498,6 +498,7 @@ static LM.Core.Utils.Hashes.Sha256File(string! path) -> string!
 static LM.Core.Utils.IdGen.NewId() -> string!
 static LM.Core.Utils.JsonEx.Deserialize<T>(string! s) -> T?
 static LM.Core.Utils.JsonEx.Serialize<T>(T v) -> string!
+static LM.Core.Utils.SystemUser.GetCurrent() -> string!
 LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.WatchedFolderSettings!>!
 LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore.SaveAsync(LM.Core.Models.WatchedFolderSettings! settings, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.Core.Abstractions.Configuration.ISearchHistoryStore

--- a/src/LM.Core/Utils/SystemUser.cs
+++ b/src/LM.Core/Utils/SystemUser.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace LM.Core.Utils;
+
+public static class SystemUser
+{
+    private const string Unknown = "unknown";
+
+    public static string GetCurrent()
+    {
+        var user = TryResolveUserName();
+        if (string.IsNullOrWhiteSpace(user))
+            return Unknown;
+
+        var domain = TryResolveDomain();
+        return string.IsNullOrWhiteSpace(domain) ? user : $"{domain}\\{user}";
+    }
+
+    private static string? TryResolveUserName()
+    {
+        var user = Environment.UserName;
+        if (!string.IsNullOrWhiteSpace(user))
+            return user;
+
+        user = Environment.GetEnvironmentVariable("USERNAME");
+        return string.IsNullOrWhiteSpace(user) ? null : user;
+    }
+
+    private static string? TryResolveDomain()
+    {
+        if (!OperatingSystem.IsWindows())
+            return null;
+
+        var domain = Environment.GetEnvironmentVariable("USERDOMAIN");
+        if (!string.IsNullOrWhiteSpace(domain))
+            return domain;
+
+        try
+        {
+            domain = Environment.UserDomainName;
+        }
+        catch (PlatformNotSupportedException)
+        {
+            return null;
+        }
+
+        return string.IsNullOrWhiteSpace(domain) ? null : domain;
+    }
+}

--- a/src/LM.Infrastructure/LM.Infrastructure.csproj
+++ b/src/LM.Infrastructure/LM.Infrastructure.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="UglyToad.PdfPig" />
     <PackageReference Include="DocumentFormat.OpenXml" />
     <PackageReference Include="EPPlus" />
-    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="SkiaSharp" />
   </ItemGroup>
 
 

--- a/src/LM.Infrastructure/Metadata/EvidenceExtraction/DataExtractionPreprocessor.cs
+++ b/src/LM.Infrastructure/Metadata/EvidenceExtraction/DataExtractionPreprocessor.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using LM.Core.Abstractions;
 using LM.Core.Models.DataExtraction;
+using LM.Core.Utils;
 using LM.Infrastructure.Metadata.EvidenceExtraction;
 using UglyToad.PdfPig;
 
@@ -52,7 +53,7 @@ namespace LM.Infrastructure.Metadata.EvidenceExtraction
                 SourceSha256 = $"sha256-{hash.ToLowerInvariant()}",
                 SourceFileName = Path.GetFileName(pdfPath) ?? string.Empty,
                 ExtractedAtUtc = DateTime.UtcNow,
-                ExtractedBy = Environment.UserName ?? string.Empty,
+                ExtractedBy = SystemUser.GetCurrent(),
                 AdditionalMetadata = new Dictionary<string, string>
                 {
                     ["source_pdf"] = pdfPath,

--- a/src/LM.Infrastructure/Review/Mappers/ReviewDtoAuditStamp.cs
+++ b/src/LM.Infrastructure/Review/Mappers/ReviewDtoAuditStamp.cs
@@ -1,4 +1,5 @@
 using System;
+using LM.Core.Utils;
 using LM.Infrastructure.Review.Dto;
 
 namespace LM.Infrastructure.Review.Mappers;
@@ -8,7 +9,7 @@ internal static class ReviewDtoAuditStamp
     public static T Stamp<T>(T dto)
         where T : AuditableReviewDto
     {
-        dto.ModifiedBy = Environment.UserName ?? string.Empty;
+        dto.ModifiedBy = SystemUser.GetCurrent();
         dto.ModifiedUtc = DateTimeOffset.UtcNow;
         return dto;
     }

--- a/src/LM.Infrastructure/Review/ReviewHookContextFactory.cs
+++ b/src/LM.Infrastructure/Review/ReviewHookContextFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using LM.Core.Utils;
 using LM.Infrastructure.Hooks;
 using LM.Review.Core.Models;
 using LM.Review.Core.Services;
@@ -115,7 +116,7 @@ public sealed class ReviewHookContextFactory : IReviewHookContextFactory
 
     private static HookM.EntryChangeLogEvent CreateEvent(string action, IEnumerable<string> tags)
     {
-        var userName = Environment.UserName ?? string.Empty;
+        var userName = SystemUser.GetCurrent();
         var sanitizedTags = new List<string>();
         foreach (var tag in tags)
         {
@@ -133,7 +134,7 @@ public sealed class ReviewHookContextFactory : IReviewHookContextFactory
         return new HookM.EntryChangeLogEvent
         {
             Action = action,
-            PerformedBy = string.IsNullOrWhiteSpace(userName) ? "unknown" : userName,
+            PerformedBy = userName,
             TimestampUtc = DateTime.UtcNow,
             Details = details
         };

--- a/src/LM.Review.Core/Models/Forms/FormUserContext.cs
+++ b/src/LM.Review.Core/Models/Forms/FormUserContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security.Principal;
+using LM.Core.Utils;
 
 namespace LM.Review.Core.Models.Forms;
 
@@ -28,10 +29,10 @@ internal static class FormUserContext
             // Ignore failures and fallback to environment values.
         }
 
-        var environmentUser = Environment.UserName;
-        if (!string.IsNullOrWhiteSpace(environmentUser))
+        var environmentUser = SystemUser.GetCurrent();
+        if (!string.Equals(environmentUser, "unknown", StringComparison.OrdinalIgnoreCase))
         {
-            return environmentUser.Trim();
+            return environmentUser;
         }
 
         var machineName = Environment.MachineName;
@@ -40,6 +41,6 @@ internal static class FormUserContext
             return machineName.Trim();
         }
 
-        return "unknown";
+        return environmentUser;
     }
 }


### PR DESCRIPTION
## Summary
- switch placeholder thumbnail generation to SkiaSharp and drop the SixLabors.ImageSharp dependency
- add a SystemUser helper for domain-aware usernames and update infrastructure, view models, and tests to consume it
- make provenance and changelog writes capture the resolved Windows username consistently

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: .NET SDK 8.0.414 cannot target net9.0)*
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: .NET SDK 8.0.414 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ab5c5330832b9a7b438900654a32