### PR TITLE
Register review hook orchestrator with DI

### DIFF
--- a/src/LM.App.Wpf/Composition/Modules/CoreModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/CoreModule.cs
@@ -15,6 +15,7 @@ using LM.Infrastructure.Settings;
 using LM.Infrastructure.Storage;
 using LM.Infrastructure.Text;
 using LM.Infrastructure.Utils;
+using LM.Review.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -50,6 +51,7 @@ namespace LM.App.Wpf.Composition.Modules
             services.AddSingleton<ISpokeHandler>(sp => new LitSearchSpokeHandler(sp.GetRequiredService<IWorkSpaceService>()));
 
             services.AddSingleton<HookOrchestrator>(sp => new HookOrchestrator(sp.GetRequiredService<IWorkSpaceService>()));
+            services.AddSingleton<IReviewHookOrchestrator>(static sp => sp.GetRequiredService<HookOrchestrator>());
             services.AddSingleton<ISimilarityLog>(sp => new SimilarityLog(sp.GetRequiredService<IWorkSpaceService>()));
 
             services.AddSingleton<HubSpokeStore>(sp => new HubSpokeStore(


### PR DESCRIPTION
## Summary
- register the infrastructure HookOrchestrator as the IReviewHookOrchestrator implementation so the review workflow services can resolve

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: Microsoft.WindowsDesktop.App 9.0.0 not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6cd0166c4832bb7ce3b707ea4cef5