### PR TITLE
Add review project launcher and creation controls

### DIFF
--- a/src/LM.App.Wpf/Composition/Modules/ReviewModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/ReviewModule.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using LM.App.Wpf.Services;
+using LM.App.Wpf.Services.Review;
 using LM.App.Wpf.ViewModels.Review;
 using LM.Infrastructure.Review;
 using LM.Review.Core.Services;
@@ -25,6 +26,8 @@ internal sealed class ReviewModule : IAppModule
         services.AddSingleton<IReviewAnalyticsService, ReviewAnalyticsService>();
 
         services.AddSingleton<IUserContext, UserContext>();
+
+        services.AddTransient<IReviewProjectLauncher, ReviewProjectLauncher>();
 
         services.AddTransient<ProjectDashboardViewModel>();
         services.AddTransient<ScreeningQueueViewModel>();

--- a/src/LM.App.Wpf/Services/Review/IReviewProjectLauncher.cs
+++ b/src/LM.App.Wpf/Services/Review/IReviewProjectLauncher.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Review.Core.Models;
+
+namespace LM.App.Wpf.Services.Review
+{
+    internal interface IReviewProjectLauncher
+    {
+        Task<ReviewProject?> CreateProjectAsync(CancellationToken cancellationToken);
+
+        Task<ReviewProject?> LoadProjectAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/LM.App.Wpf/Services/Review/ReviewProjectLauncher.cs
+++ b/src/LM.App.Wpf/Services/Review/ReviewProjectLauncher.cs
@@ -1,0 +1,365 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.App.Wpf.Common.Dialogs;
+using LM.App.Wpf.Services;
+using LM.App.Wpf.ViewModels.Review;
+using LM.Core.Abstractions;
+using LM.Core.Models;
+using LM.Infrastructure.Hooks;
+using LM.Review.Core.Models;
+using LM.Review.Core.Services;
+
+namespace LM.App.Wpf.Services.Review
+{
+    internal sealed class ReviewProjectLauncher : IReviewProjectLauncher
+    {
+        private readonly IDialogService _dialogService;
+        private readonly IEntryStore _entryStore;
+        private readonly IReviewWorkflowStore _workflowStore;
+        private readonly IReviewHookContextFactory _hookContextFactory;
+        private readonly IReviewHookOrchestrator _reviewHookOrchestrator;
+        private readonly HookOrchestrator _changeLogOrchestrator;
+        private readonly IUserContext _userContext;
+        private readonly IWorkSpaceService _workspace;
+
+        public ReviewProjectLauncher(
+            IDialogService dialogService,
+            IEntryStore entryStore,
+            IReviewWorkflowStore workflowStore,
+            IReviewHookContextFactory hookContextFactory,
+            IReviewHookOrchestrator reviewHookOrchestrator,
+            HookOrchestrator changeLogOrchestrator,
+            IUserContext userContext,
+            IWorkSpaceService workspace)
+        {
+            _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
+            _entryStore = entryStore ?? throw new ArgumentNullException(nameof(entryStore));
+            _workflowStore = workflowStore ?? throw new ArgumentNullException(nameof(workflowStore));
+            _hookContextFactory = hookContextFactory ?? throw new ArgumentNullException(nameof(hookContextFactory));
+            _reviewHookOrchestrator = reviewHookOrchestrator ?? throw new ArgumentNullException(nameof(reviewHookOrchestrator));
+            _changeLogOrchestrator = changeLogOrchestrator ?? throw new ArgumentNullException(nameof(changeLogOrchestrator));
+            _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+        }
+
+        public async Task<ReviewProject?> CreateProjectAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var litSearchPath = PromptForLitSearchPath();
+                if (litSearchPath is null)
+                {
+                    return null;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var reference = ResolveLitSearchReference(litSearchPath);
+                Entry? entry = null;
+                if (!string.IsNullOrWhiteSpace(reference.EntryId))
+                {
+                    entry = await _entryStore.GetByIdAsync(reference.EntryId!, cancellationToken).ConfigureAwait(false);
+                }
+
+                var project = CreateProject(reference, entry);
+
+                await _workflowStore.SaveProjectAsync(project, cancellationToken).ConfigureAwait(false);
+
+                var context = _hookContextFactory.CreateProjectCreated(project);
+                await _reviewHookOrchestrator.ProcessAsync(project.Id, context, cancellationToken).ConfigureAwait(false);
+
+                var tags = BuildCreationTags(project, reference, entry);
+                await ReviewChangeLogWriter.WriteAsync(
+                    _changeLogOrchestrator,
+                    project.Id,
+                    _userContext.UserName,
+                    "review.ui.project.created",
+                    tags,
+                    cancellationToken).ConfigureAwait(false);
+
+                return project;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                System.Windows.MessageBox.Show(
+                    ex.Message,
+                    "Create review project",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+                return null;
+            }
+        }
+
+        public async Task<ReviewProject?> LoadProjectAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var projectPath = PromptForProjectPath();
+                if (projectPath is null)
+                {
+                    return null;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var reference = ResolveProjectReference(projectPath);
+                if (string.IsNullOrWhiteSpace(reference.ProjectId))
+                {
+                    System.Windows.MessageBox.Show(
+                        "Select a review project JSON inside the workspace to continue.",
+                        "Load review project",
+                        System.Windows.MessageBoxButton.OK,
+                        System.Windows.MessageBoxImage.Information);
+                    return null;
+                }
+
+                var project = await _workflowStore.GetProjectAsync(reference.ProjectId!, cancellationToken).ConfigureAwait(false);
+                if (project is null)
+                {
+                    await _workflowStore.GetProjectsAsync(cancellationToken).ConfigureAwait(false);
+                    project = await _workflowStore.GetProjectAsync(reference.ProjectId!, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (project is null)
+                {
+                    System.Windows.MessageBox.Show(
+                        $"Project '{reference.ProjectId}' could not be loaded from the workspace.",
+                        "Load review project",
+                        System.Windows.MessageBoxButton.OK,
+                        System.Windows.MessageBoxImage.Warning);
+                    return null;
+                }
+
+                var tags = BuildLoadTags(project, reference);
+                await ReviewChangeLogWriter.WriteAsync(
+                    _changeLogOrchestrator,
+                    project.Id,
+                    _userContext.UserName,
+                    "review.ui.project.load-requested",
+                    tags,
+                    cancellationToken).ConfigureAwait(false);
+
+                return project;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                System.Windows.MessageBox.Show(
+                    ex.Message,
+                    "Load review project",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+                return null;
+            }
+        }
+
+        private string? PromptForLitSearchPath()
+        {
+            var selection = _dialogService.ShowOpenFileDialog(new FilePickerOptions
+            {
+                AllowMultiple = false,
+                Filter = "LitSearch run (litsearch.json)|litsearch.json|JSON files (*.json)|*.json|All files (*.*)|*.*"
+            });
+
+            if (selection is null || selection.Length == 0)
+            {
+                return null;
+            }
+
+            return selection[0];
+        }
+
+        private string? PromptForProjectPath()
+        {
+            var selection = _dialogService.ShowOpenFileDialog(new FilePickerOptions
+            {
+                AllowMultiple = false,
+                Filter = "Review project (project.json)|project.json|JSON files (*.json)|*.json|All files (*.*)|*.*"
+            });
+
+            if (selection is null || selection.Length == 0)
+            {
+                return null;
+            }
+
+            return selection[0];
+        }
+
+        private LitSearchReference ResolveLitSearchReference(string absolutePath)
+        {
+            var workspaceRoot = _workspace.GetWorkspaceRoot();
+            if (!absolutePath.StartsWith(workspaceRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Selected litsearch run is outside of the active workspace.");
+            }
+
+            var relativePath = NormalizeRelativePath(Path.GetRelativePath(workspaceRoot, absolutePath));
+            string? entryId = null;
+
+            var segments = relativePath.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length >= 2 && string.Equals(segments[0], "entries", StringComparison.OrdinalIgnoreCase))
+            {
+                entryId = segments[1];
+            }
+
+            return new LitSearchReference(absolutePath, entryId, relativePath);
+        }
+
+        private ProjectReference ResolveProjectReference(string absolutePath)
+        {
+            var workspaceRoot = _workspace.GetWorkspaceRoot();
+            if (!absolutePath.StartsWith(workspaceRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Selected project file is outside of the active workspace.");
+            }
+
+            var fileName = Path.GetFileName(absolutePath);
+            if (!string.Equals(fileName, "project.json", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Select a project.json file to load a review project.");
+            }
+
+            var relativePath = NormalizeRelativePath(Path.GetRelativePath(workspaceRoot, absolutePath));
+            string? projectId = null;
+            var segments = relativePath.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length >= 2 && string.Equals(segments[0], "reviews", StringComparison.OrdinalIgnoreCase))
+            {
+                projectId = segments[1];
+            }
+
+            return new ProjectReference(absolutePath, projectId, relativePath);
+        }
+
+        private ReviewProject CreateProject(LitSearchReference reference, Entry? entry)
+        {
+            var now = DateTimeOffset.UtcNow;
+            var projectId = $"review-{Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)}";
+            var projectName = ResolveProjectName(entry);
+            var definitions = CreateStageDefinitions();
+            var auditDetails = reference.EntryId is null
+                ? $"litsearch:{reference.RelativePath ?? reference.AbsolutePath}"
+                : $"litsearch:{reference.EntryId}";
+
+            var auditEntry = ReviewAuditTrail.AuditEntry.Create(
+                $"audit-{Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)}",
+                _userContext.UserName,
+                "project.created",
+                now,
+                auditDetails);
+            var auditTrail = ReviewAuditTrail.Create(new[] { auditEntry });
+
+            return ReviewProject.Create(projectId, projectName, now, definitions, auditTrail);
+        }
+
+        private static IReadOnlyList<StageDefinition> CreateStageDefinitions()
+        {
+            var definitions = new List<StageDefinition>
+            {
+                StageDefinition.Create(
+                    $"stage-def-{Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)}",
+                    "Title screening",
+                    ReviewStageType.TitleScreening,
+                    ReviewerRequirement.Create(new[]
+                    {
+                        new KeyValuePair<ReviewerRole, int>(ReviewerRole.Primary, 1),
+                        new KeyValuePair<ReviewerRole, int>(ReviewerRole.Secondary, 1)
+                    }),
+                    StageConsensusPolicy.RequireAgreement(2, true, null)),
+                StageDefinition.Create(
+                    $"stage-def-{Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)}",
+                    "Quality assurance",
+                    ReviewStageType.QualityAssurance,
+                    ReviewerRequirement.Create(new[]
+                    {
+                        new KeyValuePair<ReviewerRole, int>(ReviewerRole.Primary, 1)
+                    }),
+                    StageConsensusPolicy.Disabled())
+            };
+
+            return definitions;
+        }
+
+        private static string ResolveProjectName(Entry? entry)
+        {
+            if (entry is null)
+            {
+                return "New evidence review";
+            }
+
+            var label = string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.Title : entry.DisplayName;
+            if (string.IsNullOrWhiteSpace(label))
+            {
+                return $"Review {entry.Id}";
+            }
+
+            return $"Review – {label.Trim()}";
+        }
+
+        private static IEnumerable<string> BuildCreationTags(ReviewProject project, LitSearchReference reference, Entry? entry)
+        {
+            var tags = new List<string>
+            {
+                $"projectId:{project.Id}",
+                $"projectName:{project.Name}".Trim()
+            };
+
+            if (!string.IsNullOrWhiteSpace(reference.EntryId))
+            {
+                tags.Add($"litsearchEntry:{reference.EntryId!.Trim()}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(reference.RelativePath))
+            {
+                tags.Add($"litsearchHook:{reference.RelativePath!.Trim()}");
+            }
+
+            if (entry is not null)
+            {
+                var label = string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.Title : entry.DisplayName;
+                if (!string.IsNullOrWhiteSpace(label))
+                {
+                    tags.Add($"litsearchLabel:{label.Trim()}");
+                }
+            }
+
+            return tags;
+        }
+
+        private static IEnumerable<string> BuildLoadTags(ReviewProject project, ProjectReference reference)
+        {
+            var tags = new List<string>
+            {
+                $"projectId:{project.Id}",
+                "trigger:manual-load"
+            };
+
+            if (!string.IsNullOrWhiteSpace(reference.RelativePath))
+            {
+                tags.Add($"projectPath:{reference.RelativePath!.Trim()}");
+            }
+
+            return tags;
+        }
+
+        private static string NormalizeRelativePath(string relativePath)
+        {
+            return relativePath.Replace('\\', '/');
+        }
+
+        private sealed record LitSearchReference(string AbsolutePath, string? EntryId, string? RelativePath);
+
+        private sealed record ProjectReference(string AbsolutePath, string? ProjectId, string? RelativePath);
+    }
+}

--- a/src/LM.App.Wpf/Views/Review/ReviewView.xaml
+++ b/src/LM.App.Wpf/Views/Review/ReviewView.xaml
@@ -25,15 +25,36 @@
       <RowDefinition Height="*" />
     </Grid.RowDefinitions>
 
-    <StackPanel Grid.Row="0">
-      <TextBlock Text="Evidence review workspace"
-                 FontSize="26"
-                 FontWeight="SemiBold"
-                 Foreground="{StaticResource ReviewCardHeaderBrush}" />
-      <TextBlock Text="Navigate projects, progress assignments, and monitor quality from a single view."
-                 Margin="0,6,0,0"
-                 Foreground="{StaticResource ReviewCardSubduedBrush}" />
-    </StackPanel>
+    <Grid Grid.Row="0">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+      </Grid.ColumnDefinitions>
+
+      <StackPanel Grid.Column="0">
+        <TextBlock Text="Evidence review workspace"
+                   FontSize="26"
+                   FontWeight="SemiBold"
+                   Foreground="{StaticResource ReviewCardHeaderBrush}" />
+        <TextBlock Text="Navigate projects, progress assignments, and monitor quality from a single view."
+                   Margin="0,6,0,0"
+                   Foreground="{StaticResource ReviewCardSubduedBrush}" />
+      </StackPanel>
+
+      <StackPanel Grid.Column="1"
+                  Orientation="Horizontal"
+                  VerticalAlignment="Center"
+                  HorizontalAlignment="Right"
+                  Margin="24,0,0,0">
+        <Button Content="New project"
+                Command="{Binding CreateProjectCommand}"
+                Padding="16,6"
+                Margin="0,0,12,0" />
+        <Button Content="Load project"
+                Command="{Binding LoadProjectCommand}"
+                Padding="16,6" />
+      </StackPanel>
+    </Grid>
 
     <Grid Grid.Row="1" Margin="0,24,0,24">
       <Grid.ColumnDefinitions>

--- a/src/LM.Infrastructure/PublicAPI.Unshipped.txt
+++ b/src/LM.Infrastructure/PublicAPI.Unshipped.txt
@@ -119,5 +119,6 @@ LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.GetProjectAsync(string! pr
 LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.GetProjectsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.ReviewProject!>!>!
 LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.GetStageAsync(string! stageId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<LM.Review.Core.Models.ReviewStage?>!
 LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.SaveAssignmentAsync(string! projectId, LM.Review.Core.Models.ScreeningAssignment! assignment, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.SaveProjectAsync(LM.Review.Core.Models.ReviewProject! project, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.SaveStageAsync(LM.Review.Core.Models.ReviewStage! stage, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 LM.Infrastructure.Review.WorkspaceReviewWorkflowStore.WorkspaceReviewWorkflowStore(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void

--- a/src/LM.Infrastructure/Review/WorkspaceReviewWorkflowStore.cs
+++ b/src/LM.Infrastructure/Review/WorkspaceReviewWorkflowStore.cs
@@ -59,6 +59,13 @@ public sealed class WorkspaceReviewWorkflowStore : IReviewWorkflowStore
         return await _store.GetAssignmentsByStageAsync(stageId, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task SaveProjectAsync(ReviewProject project, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        await _store.SaveProjectAsync(project, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task SaveStageAsync(ReviewStage stage, CancellationToken cancellationToken)
     {
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);

--- a/src/LM.Review.Core.Tests/Services/ReviewWorkflowServiceTests.cs
+++ b/src/LM.Review.Core.Tests/Services/ReviewWorkflowServiceTests.cs
@@ -337,6 +337,12 @@ public sealed class ReviewWorkflowServiceTests
             return Task.FromResult<IReadOnlyList<ScreeningAssignment>>(Array.Empty<ScreeningAssignment>());
         }
 
+        public Task SaveProjectAsync(ReviewProject project, CancellationToken cancellationToken)
+        {
+            _projects[project.Id] = project;
+            return Task.CompletedTask;
+        }
+
         public Task SaveStageAsync(ReviewStage stage, CancellationToken cancellationToken)
         {
             _stages[stage.Id] = stage;
@@ -391,6 +397,14 @@ public sealed class ReviewWorkflowServiceTests
         public sealed record TestHookContext(string Action, Dictionary<string, string> Tags) : IReviewHookContext;
 
         public List<TestHookContext> Contexts { get; } = new();
+
+        public IReviewHookContext CreateProjectCreated(ReviewProject project)
+        {
+            return Record("project.created", new Dictionary<string, string>
+            {
+                ["projectId"] = project.Id
+            });
+        }
 
         public IReviewHookContext CreateAssignmentUpdated(ReviewStage stage, ScreeningAssignment assignment)
         {

--- a/src/LM.Review.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Review.Core/PublicAPI.Unshipped.txt
@@ -17,6 +17,7 @@ LM.Review.Core.Services.IReviewWorkflowStore.GetProjectsAsync(System.Threading.C
 LM.Review.Core.Services.IReviewWorkflowStore.GetStageAsync(string! stageId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<LM.Review.Core.Models.ReviewStage?>!
 LM.Review.Core.Services.IReviewWorkflowStore.GetStagesByProjectAsync(string! projectId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.ReviewStage!>>!
 LM.Review.Core.Services.IReviewWorkflowStore.SaveAssignmentAsync(string! projectId, LM.Review.Core.Models.ScreeningAssignment! assignment, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+LM.Review.Core.Services.IReviewWorkflowStore.SaveProjectAsync(LM.Review.Core.Models.ReviewProject! project, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 LM.Review.Core.Services.IReviewWorkflowStore.SaveStageAsync(LM.Review.Core.Models.ReviewStage! stage, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 LM.Review.Core.Services.ReviewWorkflowService
 LM.Review.Core.Services.ReviewWorkflowService.CreateStageAsync(string! projectId, string! stageDefinitionId, System.Collections.Generic.IReadOnlyCollection<LM.Review.Core.Services.ReviewerAssignmentRequest!>! assignments, System.Threading.CancellationToken cancellationToken = default) -> LM.Review.Core.Models.ReviewStage!

--- a/src/LM.Review.Core/Services/IReviewHookContextFactory.cs
+++ b/src/LM.Review.Core/Services/IReviewHookContextFactory.cs
@@ -4,6 +4,8 @@ namespace LM.Review.Core.Services;
 
 public interface IReviewHookContextFactory
 {
+    IReviewHookContext CreateProjectCreated(ReviewProject project);
+
     IReviewHookContext CreateAssignmentUpdated(ReviewStage stage, ScreeningAssignment assignment);
 
     IReviewHookContext CreateReviewerDecisionRecorded(ScreeningAssignment assignment, ReviewerDecision decision);

--- a/src/LM.Review.Core/Services/IReviewWorkflowStore.cs
+++ b/src/LM.Review.Core/Services/IReviewWorkflowStore.cs
@@ -19,6 +19,8 @@ public interface IReviewWorkflowStore
 
     Task<IReadOnlyList<ScreeningAssignment>> GetAssignmentsByStageAsync(string stageId, CancellationToken cancellationToken);
 
+    Task SaveProjectAsync(ReviewProject project, CancellationToken cancellationToken);
+
     Task SaveStageAsync(ReviewStage stage, CancellationToken cancellationToken);
 
     Task SaveAssignmentAsync(string projectId, ScreeningAssignment assignment, CancellationToken cancellationToken);


### PR DESCRIPTION
## Summary
- add a review project launcher service to create projects from litsearch runs and load saved projects
- expose new launcher commands in the review view model and surface New/Load buttons in the review workspace UI
- update workflow store and hook contracts to support persisting new projects and adjust tests for the new flow

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: WindowsDesktop runtime not available on Linux runner)*

------
https://chatgpt.com/codex/tasks/task_e_68d719723784832bafe68a9dd10dc669