### PR TITLE
Ensure review dialogs resume on UI thread

### DIFF
--- a/src/LM.App.Wpf/Services/Review/LitSearchRunPicker.cs
+++ b/src/LM.App.Wpf/Services/Review/LitSearchRunPicker.cs
@@ -32,7 +32,7 @@ namespace LM.App.Wpf.Services.Review
 
         public async Task<LitSearchRunSelection?> PickAsync(CancellationToken cancellationToken)
         {
-            var options = await LoadOptionsAsync(cancellationToken).ConfigureAwait(false);
+            var options = await LoadOptionsAsync(cancellationToken);
             if (options.Count == 0)
             {
                 System.Windows.MessageBox.Show(

--- a/src/LM.App.Wpf/Services/Review/ReviewProjectLauncher.cs
+++ b/src/LM.App.Wpf/Services/Review/ReviewProjectLauncher.cs
@@ -57,7 +57,7 @@ namespace LM.App.Wpf.Services.Review
         {
             try
             {
-                var selection = await _runPicker.PickAsync(cancellationToken).ConfigureAwait(false);
+                var selection = await _runPicker.PickAsync(cancellationToken);
                 if (selection is null)
 
                 {
@@ -66,15 +66,15 @@ namespace LM.App.Wpf.Services.Review
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var entry = await _entryStore.GetByIdAsync(selection.EntryId, cancellationToken).ConfigureAwait(false);
+                var entry = await _entryStore.GetByIdAsync(selection.EntryId, cancellationToken);
 
                 var project = CreateProject(selection, entry);
 
 
-                await _workflowStore.SaveProjectAsync(project, cancellationToken).ConfigureAwait(false);
+                await _workflowStore.SaveProjectAsync(project, cancellationToken);
 
                 var context = _hookContextFactory.CreateProjectCreated(project);
-                await _reviewHookOrchestrator.ProcessAsync(project.Id, context, cancellationToken).ConfigureAwait(false);
+                await _reviewHookOrchestrator.ProcessAsync(project.Id, context, cancellationToken);
 
                 var tags = BuildCreationTags(project, selection, entry);
 
@@ -84,7 +84,7 @@ namespace LM.App.Wpf.Services.Review
                     _userContext.UserName,
                     "review.ui.project.created",
                     tags,
-                    cancellationToken).ConfigureAwait(false);
+                    cancellationToken);
 
                 return project;
             }
@@ -126,11 +126,11 @@ namespace LM.App.Wpf.Services.Review
                     return null;
                 }
 
-                var project = await _workflowStore.GetProjectAsync(reference.ProjectId!, cancellationToken).ConfigureAwait(false);
+                var project = await _workflowStore.GetProjectAsync(reference.ProjectId!, cancellationToken);
                 if (project is null)
                 {
-                    await _workflowStore.GetProjectsAsync(cancellationToken).ConfigureAwait(false);
-                    project = await _workflowStore.GetProjectAsync(reference.ProjectId!, cancellationToken).ConfigureAwait(false);
+                    await _workflowStore.GetProjectsAsync(cancellationToken);
+                    project = await _workflowStore.GetProjectAsync(reference.ProjectId!, cancellationToken);
                 }
 
                 if (project is null)
@@ -150,7 +150,7 @@ namespace LM.App.Wpf.Services.Review
                     _userContext.UserName,
                     "review.ui.project.load-requested",
                     tags,
-                    cancellationToken).ConfigureAwait(false);
+                    cancellationToken);
 
                 return project;
             }


### PR DESCRIPTION
## Summary
- ensure the LitSearch run picker resumes on the STA context before displaying WPF dialogs
- stop suppressing the synchronization context in review project creation and loading flows so MessageBox invocations stay on the UI thread

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: installed SDK only supports net8 while projects target net9)*

------
https://chatgpt.com/codex/tasks/task_e_68d727779fc8832b9fcf40d81ed16d76