### PR TITLE
Fix LitSearch run picker file access sharing

### DIFF
--- a/src/LM.App.Wpf/Services/Review/LitSearchRunPicker.cs
+++ b/src/LM.App.Wpf/Services/Review/LitSearchRunPicker.cs
@@ -86,7 +86,7 @@ namespace LM.App.Wpf.Services.Review
 
                 try
                 {
-                    await using var stream = File.OpenRead(hookAbsolutePath);
+                    await using var stream = OpenSharedReadStream(hookAbsolutePath);
                     var hook = await JsonSerializer.DeserializeAsync<LitSearchHook>(stream, JsonStd.Options, cancellationToken)
                         .ConfigureAwait(false);
                     if (hook?.Runs is null || hook.Runs.Count == 0)
@@ -122,6 +122,11 @@ namespace LM.App.Wpf.Services.Review
 
             options.Sort(static (left, right) => string.Compare(left.Label, right.Label, true, CultureInfo.CurrentCulture));
             return options;
+        }
+
+        private static FileStream OpenSharedReadStream(string path)
+        {
+            return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
         }
 
         private static bool IsLitSearchEntry(Entry entry)


### PR DESCRIPTION
## Summary
- open LitSearch hook files with shared read access so review creation does not fail when another process is writing the hook

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug`
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: Microsoft.WindowsDesktop.App 9.0.0 is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d72a8ee774832bb8a2e5a04260de11