### PR TITLE
Improve HookWriter concurrency handling

### DIFF
--- a/src/LM.Infrastructure.Tests/HookWriterTests.cs
+++ b/src/LM.Infrastructure.Tests/HookWriterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading;
@@ -63,6 +64,102 @@ namespace LM.Infrastructure.Tests.Hooks
             Assert.True(firstSection.TryGetProperty("content", out var contentEl),
                 "Missing 'content' in first abstract section. Preview:\n" + Preview(json));
             Assert.Equal("Hello", contentEl.GetString());
+        }
+
+        [Fact]
+        public async Task AppendChangeLogAsync_RetriesWhenFileIsLocked()
+        {
+            using var temp = new TempDir();
+
+            var ws = new WorkspaceService();
+            await ws.EnsureWorkspaceAsync(temp.Path);
+
+            var writer = new HookWriter(ws);
+            var entryId = "retry-entry";
+
+            var initialHook = new HookM.EntryChangeLogHook
+            {
+                Events = new List<HookM.EntryChangeLogEvent>
+                {
+                    new() { Type = "created", Author = "tester", Timestamp = DateTimeOffset.UtcNow }
+                }
+            };
+
+            await writer.AppendChangeLogAsync(entryId, initialHook, CancellationToken.None);
+
+            var changeLogPath = Path.Combine(temp.Path, "entries", entryId, "hooks", "changelog.json");
+
+            using var externalHandle = new FileStream(
+                changeLogPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read);
+
+            var appendTask = writer.AppendChangeLogAsync(
+                entryId,
+                new HookM.EntryChangeLogHook
+                {
+                    Events = new List<HookM.EntryChangeLogEvent>
+                    {
+                        new() { Type = "updated", Author = "tester", Timestamp = DateTimeOffset.UtcNow }
+                    }
+                },
+                CancellationToken.None);
+
+            await Task.Delay(200);
+
+            Assert.False(appendTask.IsCompleted, "Append should wait for the external handle to be released.");
+
+            externalHandle.Dispose();
+
+            await appendTask.ConfigureAwait(false);
+
+            var json = await File.ReadAllTextAsync(changeLogPath);
+            var payload = JsonSerializer.Deserialize<HookM.EntryChangeLogHook>(json);
+
+            Assert.NotNull(payload);
+            Assert.NotNull(payload!.Events);
+            Assert.Equal(2, payload.Events!.Count);
+        }
+
+        [Fact]
+        public async Task AppendChangeLogAsync_AppendsBackToBack()
+        {
+            using var temp = new TempDir();
+
+            var ws = new WorkspaceService();
+            await ws.EnsureWorkspaceAsync(temp.Path);
+
+            var writer = new HookWriter(ws);
+            var entryId = "double-append";
+
+            var first = new HookM.EntryChangeLogHook
+            {
+                Events = new List<HookM.EntryChangeLogEvent>
+                {
+                    new() { Type = "created", Author = "tester", Timestamp = DateTimeOffset.UtcNow }
+                }
+            };
+
+            await writer.AppendChangeLogAsync(entryId, first, CancellationToken.None);
+
+            var second = new HookM.EntryChangeLogHook
+            {
+                Events = new List<HookM.EntryChangeLogEvent>
+                {
+                    new() { Type = "updated", Author = "tester", Timestamp = DateTimeOffset.UtcNow }
+                }
+            };
+
+            await writer.AppendChangeLogAsync(entryId, second, CancellationToken.None);
+
+            var changeLogPath = Path.Combine(temp.Path, "entries", entryId, "hooks", "changelog.json");
+            var json = await File.ReadAllTextAsync(changeLogPath);
+            var payload = JsonSerializer.Deserialize<HookM.EntryChangeLogHook>(json);
+
+            Assert.NotNull(payload);
+            Assert.NotNull(payload!.Events);
+            Assert.Equal(2, payload.Events!.Count);
         }
 
         private static string Preview(string s)


### PR DESCRIPTION
## Summary
- add shared file-locking helpers in HookWriter so hooks are written through temp files while holding a .lock gate
- read changelog data with permissive sharing and retry temp file swaps so background sync tools cannot block appends
- extend HookWriterTests to cover locked changelog retry behaviour and back-to-back append scenarios

## Testing
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: installed SDK 8.0 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b4e28d28832b959989e1d01dc348