### PR TITLE
Add retry logic when writing review project files

### DIFF
--- a/src/LM.Infrastructure/Review/JsonReviewProjectStore.cs
+++ b/src/LM.Infrastructure/Review/JsonReviewProjectStore.cs
@@ -19,6 +19,7 @@ internal sealed partial class JsonReviewProjectStore
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly SemaphoreSlim _mutex = new(1, 1);
     private readonly TimeSpan _lockTimeout = TimeSpan.FromMinutes(5);
+    private readonly TimeSpan _ioRetryDelay = TimeSpan.FromMilliseconds(200);
 
     private readonly Dictionary<string, ReviewProject> _projects = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, ReviewStageDto> _stageDtos = new(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
## Summary
- retry replacing review project files when Windows reports them as in use
- reuse a shared I/O retry delay for JsonReviewProjectStore writes

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: .NET 9.0 SDK not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b8e5d9a4832b8b1bb9583fde60f3