### PR TITLE
Ensure review project launcher surfaces UI-thread errors

### DIFF
--- a/src/LM.App.Wpf.Tests/Review/ReviewProjectLauncherTests.cs
+++ b/src/LM.App.Wpf.Tests/Review/ReviewProjectLauncherTests.cs
@@ -1,0 +1,230 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.App.Wpf.Common.Dialogs;
+using LM.App.Wpf.Services;
+using LM.App.Wpf.Services.Review;
+using LM.Core.Abstractions;
+using LM.Core.Models;
+using LM.Infrastructure.Hooks;
+using LM.Review.Core.Models;
+using LM.Review.Core.Services;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.Review
+{
+    public sealed class ReviewProjectLauncherTests
+    {
+        [Fact]
+        public async Task CreateProjectAsync_ShowsDialog_WhenSaveProjectFailsAfterCheckedEntryLoad()
+        {
+            var checkedEntriesPath = Path.Combine(Path.GetTempPath(), $"checked-{Guid.NewGuid():N}.json");
+            await File.WriteAllTextAsync(
+                checkedEntriesPath,
+                "{\"checkedEntries\":{\"entryIds\":[\"lit-entry-1\"]}}",
+                CancellationToken.None);
+
+            var selection = new LitSearchRunSelection(
+                "entry-1",
+                "hooks/run.json",
+                "hooks/run.json",
+                "run-1",
+                checkedEntriesPath,
+                "hooks/checked.json",
+                Array.Empty<string>());
+
+            var messageBox = new FakeMessageBoxService();
+            var workspace = new FakeWorkSpaceService();
+            var launcher = new ReviewProjectLauncher(
+                new FakeDialogService(),
+                new FakeEntryStore(new Entry
+                {
+                    Id = selection.EntryId,
+                    Title = "Sample Entry"
+                }),
+                new ThrowingWorkflowStore(),
+                new FakeReviewHookContextFactory(),
+                new FakeReviewHookOrchestrator(),
+                new HookOrchestrator(workspace),
+                new FakeUserContext("tester"),
+                workspace,
+                new FakeRunPicker(selection),
+                messageBox);
+
+            try
+            {
+                var result = await launcher.CreateProjectAsync(CancellationToken.None);
+
+                Assert.Null(result);
+
+                var invocation = Assert.Single(messageBox.Invocations);
+                Assert.Equal("Create review project", invocation.Caption);
+                Assert.Equal(System.Windows.MessageBoxButton.OK, invocation.Buttons);
+                Assert.Equal(System.Windows.MessageBoxImage.Error, invocation.Image);
+                Assert.Equal("Review project save failed", invocation.Message);
+            }
+            finally
+            {
+                if (File.Exists(checkedEntriesPath))
+                {
+                    File.Delete(checkedEntriesPath);
+                }
+            }
+        }
+
+        private sealed class FakeDialogService : IDialogService
+        {
+            public string[]? ShowOpenFileDialog(FilePickerOptions options) => null;
+
+            public string? ShowFolderBrowserDialog(FolderPickerOptions options) => null;
+
+            public bool? ShowStagingEditor(LM.App.Wpf.ViewModels.StagingListViewModel stagingList) => null;
+        }
+
+        private sealed class FakeEntryStore : IEntryStore
+        {
+            private readonly Entry? _entry;
+
+            public FakeEntryStore(Entry? entry)
+            {
+                _entry = entry;
+            }
+
+            public Task InitializeAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+            public Task SaveAsync(Entry entry, CancellationToken ct = default) => Task.CompletedTask;
+
+            public Task<Entry?> GetByIdAsync(string id, CancellationToken ct = default) => Task.FromResult(_entry);
+
+            public async IAsyncEnumerable<Entry> EnumerateAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+            {
+                await Task.CompletedTask;
+                yield break;
+            }
+
+            public Task<IReadOnlyList<Entry>> SearchAsync(LM.Core.Models.Filters.EntryFilter filter, CancellationToken ct = default)
+                => Task.FromResult<IReadOnlyList<Entry>>(Array.Empty<Entry>());
+
+            public Task<Entry?> FindByHashAsync(string sha256, CancellationToken ct = default)
+                => Task.FromResult<Entry?>(null);
+
+            public Task<IReadOnlyList<Entry>> FindSimilarByNameYearAsync(string title, int? year, CancellationToken ct = default)
+                => Task.FromResult<IReadOnlyList<Entry>>(Array.Empty<Entry>());
+
+            public Task<Entry?> FindByIdsAsync(string? doi, string? pmid, CancellationToken ct = default)
+                => Task.FromResult<Entry?>(null);
+        }
+
+        private sealed class ThrowingWorkflowStore : IReviewWorkflowStore
+        {
+            public Task<ReviewProject?> GetProjectAsync(string projectId, CancellationToken cancellationToken)
+                => Task.FromResult<ReviewProject?>(null);
+
+            public Task<IReadOnlyList<ReviewProject>> GetProjectsAsync(CancellationToken cancellationToken)
+                => Task.FromResult<IReadOnlyList<ReviewProject>>(Array.Empty<ReviewProject>());
+
+            public Task<ReviewStage?> GetStageAsync(string stageId, CancellationToken cancellationToken)
+                => Task.FromResult<ReviewStage?>(null);
+
+            public Task<IReadOnlyList<ReviewStage>> GetStagesByProjectAsync(string projectId, CancellationToken cancellationToken)
+                => Task.FromResult<IReadOnlyList<ReviewStage>>(Array.Empty<ReviewStage>());
+
+            public Task<ScreeningAssignment?> GetAssignmentAsync(string assignmentId, CancellationToken cancellationToken)
+                => Task.FromResult<ScreeningAssignment?>(null);
+
+            public Task<IReadOnlyList<ScreeningAssignment>> GetAssignmentsByStageAsync(string stageId, CancellationToken cancellationToken)
+                => Task.FromResult<IReadOnlyList<ScreeningAssignment>>(Array.Empty<ScreeningAssignment>());
+
+            public Task SaveProjectAsync(ReviewProject project, CancellationToken cancellationToken)
+                => Task.FromException(new InvalidOperationException("Review project save failed"));
+
+            public Task SaveStageAsync(ReviewStage stage, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+
+            public Task SaveAssignmentAsync(string projectId, ScreeningAssignment assignment, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+        }
+
+        private sealed class FakeReviewHookContextFactory : IReviewHookContextFactory
+        {
+            private sealed class FakeReviewHookContext : IReviewHookContext
+            {
+            }
+
+            public IReviewHookContext CreateProjectCreated(ReviewProject project) => new FakeReviewHookContext();
+
+            public IReviewHookContext CreateAssignmentUpdated(ReviewStage stage, ScreeningAssignment assignment)
+                => new FakeReviewHookContext();
+
+            public IReviewHookContext CreateReviewerDecisionRecorded(ScreeningAssignment assignment, ReviewerDecision decision)
+                => new FakeReviewHookContext();
+
+            public IReviewHookContext CreateStageTransition(ReviewStage stage, ConflictState previousState, ConflictState currentState)
+                => new FakeReviewHookContext();
+        }
+
+        private sealed class FakeReviewHookOrchestrator : IReviewHookOrchestrator
+        {
+            public Task ProcessAsync(string entryId, IReviewHookContext context, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+        }
+
+        private sealed class FakeUserContext : IUserContext
+        {
+            public FakeUserContext(string userName)
+            {
+                UserName = userName;
+            }
+
+            public string UserName { get; }
+        }
+
+        private sealed class FakeWorkSpaceService : IWorkSpaceService
+        {
+            public string? WorkspacePath => Path.GetTempPath();
+
+            public string GetWorkspaceRoot() => WorkspacePath!;
+
+            public string GetLocalDbPath() => Path.Combine(GetWorkspaceRoot(), "workspace.db");
+
+            public string GetAbsolutePath(string relativePath) => Path.Combine(GetWorkspaceRoot(), relativePath);
+
+            public Task EnsureWorkspaceAsync(string absoluteWorkspacePath, CancellationToken ct = default)
+                => Task.CompletedTask;
+        }
+
+        private sealed class FakeRunPicker : ILitSearchRunPicker
+        {
+            private readonly LitSearchRunSelection _selection;
+
+            public FakeRunPicker(LitSearchRunSelection selection)
+            {
+                _selection = selection;
+            }
+
+            public Task<LitSearchRunSelection?> PickAsync(CancellationToken cancellationToken)
+                => Task.FromResult<LitSearchRunSelection?>(_selection);
+        }
+
+        private sealed record MessageBoxInvocation(
+            string Message,
+            string Caption,
+            System.Windows.MessageBoxButton Buttons,
+            System.Windows.MessageBoxImage Image);
+
+        private sealed class FakeMessageBoxService : IMessageBoxService
+        {
+            private readonly List<MessageBoxInvocation> _invocations = new();
+
+            public IReadOnlyList<MessageBoxInvocation> Invocations => _invocations;
+
+            public void Show(string message, string caption, System.Windows.MessageBoxButton buttons, System.Windows.MessageBoxImage image)
+            {
+                _invocations.Add(new MessageBoxInvocation(message, caption, buttons, image));
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/Common/Dialogs/IMessageBoxService.cs
+++ b/src/LM.App.Wpf/Common/Dialogs/IMessageBoxService.cs
@@ -1,0 +1,10 @@
+#nullable enable
+using System;
+
+namespace LM.App.Wpf.Common.Dialogs
+{
+    internal interface IMessageBoxService
+    {
+        void Show(string message, string caption, System.Windows.MessageBoxButton buttons, System.Windows.MessageBoxImage image);
+    }
+}

--- a/src/LM.App.Wpf/Common/Dialogs/WpfMessageBoxService.cs
+++ b/src/LM.App.Wpf/Common/Dialogs/WpfMessageBoxService.cs
@@ -1,0 +1,13 @@
+#nullable enable
+using System;
+
+namespace LM.App.Wpf.Common.Dialogs
+{
+    internal sealed class WpfMessageBoxService : IMessageBoxService
+    {
+        public void Show(string message, string caption, System.Windows.MessageBoxButton buttons, System.Windows.MessageBoxImage image)
+        {
+            System.Windows.MessageBox.Show(message, caption, buttons, image);
+        }
+    }
+}

--- a/src/LM.App.Wpf/Composition/Modules/ReviewModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/ReviewModule.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using LM.App.Wpf.Common.Dialogs;
 using LM.App.Wpf.Services;
 using LM.App.Wpf.Services.Review;
 using LM.App.Wpf.ViewModels.Dialogs;
@@ -30,6 +31,7 @@ internal sealed class ReviewModule : IAppModule
         services.AddSingleton<IUserContext, UserContext>();
 
         services.AddTransient<ILitSearchRunPicker, LitSearchRunPicker>();
+        services.AddSingleton<IMessageBoxService, WpfMessageBoxService>();
         services.AddTransient<IReviewProjectLauncher, ReviewProjectLauncher>();
         services.AddTransient<LitSearchRunPickerViewModel>();
         services.AddTransient<LitSearchRunPickerWindow>();

--- a/src/LM.App.Wpf/Services/Review/ReviewProjectLauncher.cs
+++ b/src/LM.App.Wpf/Services/Review/ReviewProjectLauncher.cs
@@ -20,6 +20,7 @@ namespace LM.App.Wpf.Services.Review
     internal sealed class ReviewProjectLauncher : IReviewProjectLauncher
     {
         private readonly IDialogService _dialogService;
+        private readonly IMessageBoxService _messageBoxService;
         private readonly IEntryStore _entryStore;
         private readonly IReviewWorkflowStore _workflowStore;
         private readonly IReviewHookContextFactory _hookContextFactory;
@@ -39,7 +40,8 @@ namespace LM.App.Wpf.Services.Review
             HookOrchestrator changeLogOrchestrator,
             IUserContext userContext,
             IWorkSpaceService workspace,
-            ILitSearchRunPicker runPicker)
+            ILitSearchRunPicker runPicker,
+            IMessageBoxService messageBoxService)
 
         {
             _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
@@ -51,6 +53,7 @@ namespace LM.App.Wpf.Services.Review
             _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
             _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
             _runPicker = runPicker ?? throw new ArgumentNullException(nameof(runPicker));
+            _messageBoxService = messageBoxService ?? throw new ArgumentNullException(nameof(messageBoxService));
 
         }
 
@@ -70,8 +73,7 @@ namespace LM.App.Wpf.Services.Review
                 var entry = await _entryStore.GetByIdAsync(selection.EntryId, cancellationToken);
                 var checkedEntryIds = selection.CheckedEntryIds.Count > 0
                     ? selection.CheckedEntryIds
-                    : await LoadCheckedEntryIdsAsync(selection.CheckedEntriesAbsolutePath, cancellationToken)
-                        .ConfigureAwait(false);
+                    : await LoadCheckedEntryIdsAsync(selection.CheckedEntriesAbsolutePath, cancellationToken);
 
                 var project = CreateProject(selection, entry);
 
@@ -99,7 +101,7 @@ namespace LM.App.Wpf.Services.Review
             }
             catch (Exception ex)
             {
-                System.Windows.MessageBox.Show(
+                _messageBoxService.Show(
                     ex.Message,
                     "Create review project",
                     System.Windows.MessageBoxButton.OK,
@@ -123,7 +125,7 @@ namespace LM.App.Wpf.Services.Review
                 var reference = ResolveProjectReference(projectPath);
                 if (string.IsNullOrWhiteSpace(reference.ProjectId))
                 {
-                    System.Windows.MessageBox.Show(
+                    _messageBoxService.Show(
                         "Select a review project JSON inside the workspace to continue.",
                         "Load review project",
                         System.Windows.MessageBoxButton.OK,
@@ -140,7 +142,7 @@ namespace LM.App.Wpf.Services.Review
 
                 if (project is null)
                 {
-                    System.Windows.MessageBox.Show(
+                    _messageBoxService.Show(
                         $"Project '{reference.ProjectId}' could not be loaded from the workspace.",
                         "Load review project",
                         System.Windows.MessageBoxButton.OK,
@@ -165,7 +167,7 @@ namespace LM.App.Wpf.Services.Review
             }
             catch (Exception ex)
             {
-                System.Windows.MessageBox.Show(
+                _messageBoxService.Show(
                     ex.Message,
                     "Load review project",
                     System.Windows.MessageBoxButton.OK,


### PR DESCRIPTION
## Summary
- add an IMessageBoxService abstraction and WpfMessageBoxService implementation so the review project launcher can surface errors without cross-thread issues
- wire the message box service into dependency injection and keep CreateProjectAsync on the UI thread when loading checked entries
- add a regression test covering the failure path after checked-entry loading to ensure the launcher displays the error dialog

## Testing
- dotnet test src/LM.App.Wpf.Tests/LM.App.Wpf.Tests.csproj -c Debug *(fails: Microsoft.WindowsDesktop.App 9.0.0 runtime is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c055a100832b9e20ff0c15259b31