### PR TITLE
Add review creation diagnostics logging

### DIFF
--- a/src/LM.App.Wpf.Tests/Review/ReviewProjectLauncherTests.cs
+++ b/src/LM.App.Wpf.Tests/Review/ReviewProjectLauncherTests.cs
@@ -40,6 +40,7 @@ namespace LM.App.Wpf.Tests.Review
 
             var messageBox = new FakeMessageBoxService();
             using var workspace = new FakeWorkSpaceService();
+            var diagnostics = new FakeReviewCreationDiagnostics();
             var launcher = new ReviewProjectLauncher(
                 new FakeDialogService(),
                 new FakeEntryStore(new Entry
@@ -54,7 +55,8 @@ namespace LM.App.Wpf.Tests.Review
                 new FakeUserContext("tester"),
                 workspace,
                 new FakeRunPicker(selection),
-                messageBox);
+                messageBox,
+                diagnostics);
 
             try
             {
@@ -105,6 +107,7 @@ namespace LM.App.Wpf.Tests.Review
                 using var workspace = new FakeWorkSpaceService(workspaceRoot);
                 var workflowStore = new RecordingWorkflowStore();
                 var changeLogOrchestrator = new HookOrchestrator(workspace);
+                var diagnostics = new FakeReviewCreationDiagnostics();
                 var launcher = new ReviewProjectLauncher(
                     new FakeDialogService(),
                     new FakeEntryStore(new Entry
@@ -119,7 +122,8 @@ namespace LM.App.Wpf.Tests.Review
                     new FakeUserContext("tester"),
                     workspace,
                     new FakeRunPicker(selection),
-                    new FakeMessageBoxService());
+                    new FakeMessageBoxService(),
+                    diagnostics);
 
                 var project = await launcher.CreateProjectAsync(CancellationToken.None);
 
@@ -270,6 +274,21 @@ namespace LM.App.Wpf.Tests.Review
             }
 
             public string UserName { get; }
+        }
+
+        private sealed class FakeReviewCreationDiagnostics : IReviewCreationDiagnostics
+        {
+            public List<string> Entries { get; } = new();
+
+            public void RecordStep(string message)
+            {
+                Entries.Add($"INFO:{message}");
+            }
+
+            public void RecordException(string message, Exception exception)
+            {
+                Entries.Add($"ERROR:{message}:{exception.GetType().Name}");
+            }
         }
 
         private sealed class FakeWorkSpaceService : IWorkSpaceService, IDisposable

--- a/src/LM.App.Wpf/Composition/Modules/ReviewModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/ReviewModule.cs
@@ -27,6 +27,7 @@ internal sealed class ReviewModule : IAppModule
             sp.GetRequiredService<IReviewHookOrchestrator>(),
             sp.GetRequiredService<IReviewHookContextFactory>()));
         services.AddSingleton<IReviewAnalyticsService, ReviewAnalyticsService>();
+        services.AddSingleton<IReviewCreationDiagnostics, ReviewCreationDiagnostics>();
 
         services.AddSingleton<IUserContext, UserContext>();
 

--- a/src/LM.App.Wpf/Services/Review/ReviewCreationDiagnostics.cs
+++ b/src/LM.App.Wpf/Services/Review/ReviewCreationDiagnostics.cs
@@ -1,0 +1,121 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using LM.Core.Abstractions;
+
+namespace LM.App.Wpf.Services.Review;
+
+internal interface IReviewCreationDiagnostics
+{
+    void RecordStep(string message);
+
+    void RecordException(string message, Exception exception);
+}
+
+internal sealed class ReviewCreationDiagnostics : IReviewCreationDiagnostics
+{
+    private readonly IWorkSpaceService _workspace;
+    private readonly Lazy<string> _logPath;
+    private readonly object _gate = new();
+
+    public ReviewCreationDiagnostics(IWorkSpaceService workspace)
+    {
+        _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+        _logPath = new Lazy<string>(ResolveLogPath, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    public void RecordStep(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return;
+        }
+
+        WriteLine("INFO", message.Trim());
+    }
+
+    public void RecordException(string message, Exception exception)
+    {
+        if (exception is null)
+        {
+            return;
+        }
+
+        var builder = new StringBuilder();
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            builder.Append(message!.Trim());
+            builder.Append(':');
+            builder.Append(' ');
+        }
+
+        builder.Append(exception.GetType().Name);
+        if (!string.IsNullOrWhiteSpace(exception.Message))
+        {
+            builder.Append(" – ");
+            builder.Append(exception.Message.Trim());
+        }
+
+        WriteLine("ERROR", builder.ToString(), exception);
+    }
+
+    private string ResolveLogPath()
+    {
+        try
+        {
+            var root = _workspace.GetWorkspaceRoot();
+            var logDirectory = Path.Combine(root, "logs");
+            Directory.CreateDirectory(logDirectory);
+            return Path.Combine(logDirectory, "review-creation.log");
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or PathTooLongException)
+        {
+            // Fall back to the temp directory if the workspace is not accessible.
+            var fallbackDirectory = Path.Combine(Path.GetTempPath(), "kw-review-diagnostics");
+            Directory.CreateDirectory(fallbackDirectory);
+            return Path.Combine(fallbackDirectory, "review-creation.log");
+        }
+    }
+
+    private void WriteLine(string level, string message, Exception? exception = null)
+    {
+        try
+        {
+            var line = BuildLine(level, message, exception);
+            lock (_gate)
+            {
+                File.AppendAllText(_logPath.Value, line, Encoding.UTF8);
+            }
+        }
+        catch
+        {
+            // Diagnostics must never throw back into the application flow.
+        }
+    }
+
+    private static string BuildLine(string level, string message, Exception? exception)
+    {
+        var builder = new StringBuilder();
+        builder.Append(DateTimeOffset.UtcNow.ToString("O", System.Globalization.CultureInfo.InvariantCulture));
+        builder.Append(' ');
+        builder.Append('[');
+        builder.Append(level);
+        builder.Append(']');
+        builder.Append(' ');
+        builder.Append(message);
+
+        if (exception is not null)
+        {
+            builder.AppendLine();
+            builder.Append(exception.ToString());
+        }
+        else
+        {
+            builder.AppendLine();
+        }
+
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
## Summary
- add a workspace-backed diagnostics logger for review project creation flows
- record project creation and load steps, failures, and file verification in the launcher
- register the diagnostics service for dependency injection and update tests for the new dependency

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: installed SDK 8.0.414 cannot target net9.0)*
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: installed SDK 8.0.414 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d036d9b8832bbf35b5abba5841c9