### PR TITLE
Fix bounds key generation for TabulaSharp tables

### DIFF
--- a/src/LM.Infrastructure/Metadata/EvidenceExtraction/Tables/TabulaSharpTableExtractor.cs
+++ b/src/LM.Infrastructure/Metadata/EvidenceExtraction/Tables/TabulaSharpTableExtractor.cs
@@ -372,10 +372,12 @@ namespace LM.Infrastructure.Metadata.EvidenceExtraction.Tables
 
         private static string CreateBoundsKey(int pageNumber, TabulaSharpBoundingBox bounds)
         {
-            return FormattableString.Invariant($"{pageNumber}:{Math.Round(bounds.Left, 2, MidpointRounding.AwayFromZero)}:" +
-                                               $"{Math.Round(bounds.Bottom, 2, MidpointRounding.AwayFromZero)}:" +
-                                               $"{Math.Round(bounds.Width, 2, MidpointRounding.AwayFromZero)}:" +
-                                               $"{Math.Round(bounds.Height, 2, MidpointRounding.AwayFromZero)}");
+            var left = Math.Round(bounds.Left, 2, MidpointRounding.AwayFromZero);
+            var bottom = Math.Round(bounds.Bottom, 2, MidpointRounding.AwayFromZero);
+            var width = Math.Round(bounds.Width, 2, MidpointRounding.AwayFromZero);
+            var height = Math.Round(bounds.Height, 2, MidpointRounding.AwayFromZero);
+
+            return FormattableString.Invariant($"{pageNumber}:{left}:{bottom}:{width}:{height}");
         }
 
         private static double Clamp01(double value)


### PR DESCRIPTION
## Summary
- ensure the TabulaSharp bounds cache key is built as a single invariant interpolated string
- avoid concatenation that caused the table extractor to fail compiling under the new tooling

## Testing
- dotnet build src/LM.Infrastructure/LM.Infrastructure.csproj -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: LM.HubSpoke.Tests.SqliteSearchIndexFullTextTests snippet assertion and CoreModule TabulaTableImageWriter accessibility)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d21993a0832b99c425b320a28c80