### PR TITLE
Expose Tabula extraction services for composition

### DIFF
--- a/CombinedPublicAPI.txt
+++ b/CombinedPublicAPI.txt
@@ -1671,6 +1671,13 @@ LM.Infrastructure.Metadata.CompositeMetadataExtractor.ExtractAsync(string! absol
 LM.Infrastructure.Metadata.EvidenceExtraction.DataExtractionPreprocessor
 LM.Infrastructure.Metadata.EvidenceExtraction.DataExtractionPreprocessor.DataExtractionPreprocessor(LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
 LM.Infrastructure.Metadata.EvidenceExtraction.DataExtractionPreprocessor.PreprocessAsync(LM.Core.Models.DataExtraction.DataExtractionPreprocessRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.DataExtraction.DataExtractionPreprocessResult!>!
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaSharpTableExtractor
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaSharpTableExtractor.TabulaSharpTableExtractor(LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter! imageWriter) -> void
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaSharpTableExtractor.ExtractAsync(UglyToad.PdfPig.PdfDocument! document, string! pdfPath, string! tablesRoot, string! hash, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.PreprocessedTable!>!>!
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter.TabulaTableImageWriter(double scalingFactor = 2) -> void
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter.CreateDocumentReader(string! pdfPath) -> Docnet.Core.Readers.IDocReader!
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter.WriteAsync(Docnet.Core.Readers.IDocReader! docReader, int pageNumber, string! tablesRoot, string! fileStem, LM.Core.Models.DataExtraction.TableRegion! region, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<string!>!
 LM.Infrastructure.Review.ReviewHookContextFactory
 LM.Infrastructure.Review.ReviewHookContextFactory.CreateAssignmentUpdated(LM.Review.Core.Models.ReviewStage! stage, LM.Review.Core.Models.ScreeningAssignment! assignment) -> LM.Review.Core.Services.IReviewHookContext!
 LM.Infrastructure.Review.ReviewHookContextFactory.CreateConsensusResolved(LM.Review.Core.Models.ReviewStage! stage, LM.Review.Core.Models.ConsensusOutcome! consensus) -> LM.Review.Core.Services.IReviewHookContext!

--- a/src/LM.Infrastructure/Metadata/EvidenceExtraction/Tables/TabulaSharpTableExtractor.cs
+++ b/src/LM.Infrastructure/Metadata/EvidenceExtraction/Tables/TabulaSharpTableExtractor.cs
@@ -24,7 +24,7 @@ namespace LM.Infrastructure.Metadata.EvidenceExtraction.Tables
                                                              CancellationToken ct);
     }
 
-    internal sealed class TabulaSharpTableExtractor : IPdfTableExtractor
+    public sealed class TabulaSharpTableExtractor : IPdfTableExtractor
     {
         private readonly TabulaSharpExtractor _extractor;
         private readonly TabulaTableImageWriter _imageWriter;

--- a/src/LM.Infrastructure/Metadata/EvidenceExtraction/Tables/TabulaTableImageWriter.cs
+++ b/src/LM.Infrastructure/Metadata/EvidenceExtraction/Tables/TabulaTableImageWriter.cs
@@ -12,7 +12,7 @@ using SkiaSharp;
 
 namespace LM.Infrastructure.Metadata.EvidenceExtraction.Tables
 {
-    internal sealed class TabulaTableImageWriter
+    public sealed class TabulaTableImageWriter
     {
         private readonly PageDimensions _dimensions;
 

--- a/src/LM.Infrastructure/PublicAPI.Unshipped.txt
+++ b/src/LM.Infrastructure/PublicAPI.Unshipped.txt
@@ -66,6 +66,13 @@ LM.Infrastructure.Metadata.EvidenceExtraction.DataExtractionPreprocessor.DataExt
 LM.Infrastructure.Metadata.EvidenceExtraction.DataExtractionPreprocessor.PreprocessAsync(LM.Core.Models.DataExtraction.DataExtractionPreprocessRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.DataExtraction.DataExtractionPreprocessResult!>!
 LM.Infrastructure.Metadata.EvidenceExtraction.Tables.IPdfTableExtractor
 LM.Infrastructure.Metadata.EvidenceExtraction.Tables.IPdfTableExtractor.ExtractAsync(UglyToad.PdfPig.PdfDocument! document, string! pdfPath, string! tablesRoot, string! hash, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.PreprocessedTable!>!>!
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaSharpTableExtractor
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaSharpTableExtractor.ExtractAsync(UglyToad.PdfPig.PdfDocument! document, string! pdfPath, string! tablesRoot, string! hash, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.PreprocessedTable!>!>!
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaSharpTableExtractor.TabulaSharpTableExtractor(LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter! imageWriter) -> void
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter.CreateDocumentReader(string! pdfPath) -> Docnet.Core.Readers.IDocReader!
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter.TabulaTableImageWriter(double scalingFactor = 2) -> void
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter.WriteAsync(Docnet.Core.Readers.IDocReader! docReader, int pageNumber, string! tablesRoot, string! fileStem, LM.Core.Models.DataExtraction.TableRegion! region, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<string!>!
 LM.Infrastructure.Review.ReviewHookContextFactory
 LM.Infrastructure.Review.ReviewHookContextFactory.CreateAssignmentUpdated(LM.Review.Core.Models.ReviewStage! stage, LM.Review.Core.Models.ScreeningAssignment! assignment) -> LM.Review.Core.Services.IReviewHookContext!
 LM.Infrastructure.Review.ReviewHookContextFactory.CreateConsensusResolved(LM.Review.Core.Models.ReviewStage! stage, LM.Review.Core.Models.ConsensusOutcome! consensus) -> LM.Review.Core.Services.IReviewHookContext!


### PR DESCRIPTION
## Summary
- make `TabulaSharpTableExtractor` public so the WPF composition root can resolve the PDF table extractor implementation
- expose `TabulaTableImageWriter` and refresh the aggregated PublicAPI listings to cover the new surface

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: requires Microsoft.WindowsDesktop runtime and libSkiaSharp on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d429ff4c832bae44f90121f5b3fd