### PR TITLE
Enable table extraction from workspace selections

### DIFF
--- a/src/LM.App.Wpf/Views/Dialogs/Staging/DataExtractionWorkspaceWindow.xaml
+++ b/src/LM.App.Wpf/Views/Dialogs/Staging/DataExtractionWorkspaceWindow.xaml
@@ -75,6 +75,9 @@
                       Command="{Binding BeginRegionCreationCommand}" />
           <swc:Button Content="Re-detect"
                       Command="{Binding RedetectRegionsCommand}" />
+          <swc:Button Content="Extract"
+                      Margin="4,0,0,0"
+                      Command="{Binding ExtractSelectedAssetCommand}" />
         </swc:StackPanel>
 
         <controls:PdfDocumentView Grid.Row="1"


### PR DESCRIPTION
## Summary
- add an Extract command in the data extraction workspace to reuse preprocessed tables for the selected regions
- populate table assets with extracted CSV metadata via a dedicated ApplyExtraction helper
- expose the workflow through the toolbar and cover it with a focused unit test

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: repo targets net9.0 while installed SDK is 8.0.414)*
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: repo targets net9.0 while installed SDK is 8.0.414)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e5a412cc832bb96fc70dfada4d42