### PR TITLE
Fix Tabula playground dialog activation

### DIFF
--- a/src/LM.App.Wpf/Composition/Modules/AddModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/AddModule.cs
@@ -3,7 +3,9 @@ using LM.App.Wpf.ViewModels;
 using LM.App.Wpf.ViewModels.Dialogs;
 using LM.App.Wpf.Views;
 using LM.App.Wpf.Views.Dialogs.Staging;
+using LM.App.Wpf.Views.Playground;
 using LM.App.Wpf.ViewModels.Dialogs.Staging;
+using LM.App.Wpf.ViewModels.Playground;
 using LM.Core.Abstractions;
 using LM.Core.Abstractions.Configuration;
 using LM.HubSpoke.Abstractions;
@@ -51,6 +53,9 @@ namespace LM.App.Wpf.Composition.Modules
             services.AddTransient<DataExtractionWorkspaceWindow>();
             services.AddTransient<StagingEditorViewModel>();
             services.AddTransient<StagingEditorWindow>();
+            services.AddTransient<TabulaSharpPlaygroundEngine>();
+            services.AddTransient<TabulaSharpPlaygroundViewModel>();
+            services.AddTransient<TabulaSharpPlaygroundWindow>();
 
             services.AddSingleton<StagingListViewModel>(sp => new StagingListViewModel(sp.GetRequiredService<IAddPipeline>()));
             services.AddSingleton<WatchedFoldersViewModel>(sp => new WatchedFoldersViewModel(


### PR DESCRIPTION
## Summary
- register the TabulaSharp playground engine, view model, and window with the add module's service collection
- include the playground namespaces so the dialog service can resolve its dependencies at runtime

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: SkiaSharp native assets unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f9e6dd50832b9a35334634159c37