### PR TITLE
Add review project wizard

### DIFF
--- a/src/LM.App.Wpf/LM.App.Wpf.csproj
+++ b/src/LM.App.Wpf/LM.App.Wpf.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\LM.Core\LM.Core.csproj" />
     <ProjectReference Include="..\LM.HubAndSpoke\LM.HubSpoke.csproj" />
     <ProjectReference Include="..\LM.Infrastructure\LM.Infrastructure.csproj" />
+    <ProjectReference Include="..\LM.Review.Core\LM.Review.Core.csproj" />
   </ItemGroup>
 
 

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -232,6 +232,9 @@ LM.App.Wpf.Views.SearchView.SearchView() -> void
 LM.App.Wpf.Views.ShellWindow
 LM.App.Wpf.Views.ShellWindow.InitializeComponent() -> void
 LM.App.Wpf.Views.ShellWindow.ShellWindow() -> void
+LM.App.Wpf.Views.ReviewWorkflowWindow
+LM.App.Wpf.Views.ReviewWorkflowWindow.InitializeComponent() -> void
+LM.App.Wpf.Views.ReviewWorkflowWindow.ReviewWorkflowWindow(LM.App.Wpf.ViewModels.Review.ReviewWorkflowViewModel! viewModel) -> void
 LM.App.Wpf.Views.StagingEditorWindow
 LM.App.Wpf.Views.StagingEditorWindow.InitializeComponent() -> void
 LM.App.Wpf.Views.StagingEditorWindow.StagingEditorWindow(LM.App.Wpf.ViewModels.AddViewModel! vm) -> void

--- a/src/LM.App.Wpf/Services/DialogService.cs
+++ b/src/LM.App.Wpf/Services/DialogService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using LM.App.Wpf.ViewModels.Add;
+using LM.App.Wpf.ViewModels.Review;
 using LM.App.Wpf.Views;
 
 namespace LM.App.Wpf.Services
@@ -48,7 +49,19 @@ namespace LM.App.Wpf.Services
                               .FirstOrDefault(w => w.IsActive)
                         ?? Application.Current?.MainWindow;
 
-            var window = new StagingEditorWindow(stagingViewModel)
+            var runLabels = new List<string>();
+            if (stagingViewModel.Items.Count > 0)
+            {
+                runLabels.Add($"Imported files ({stagingViewModel.Items.Count})");
+            }
+
+            var suggestedTitle = stagingViewModel.Current?.Title
+                                 ?? stagingViewModel.Items.FirstOrDefault()?.Title;
+
+            var auditService = new ReviewAuditService();
+            var reviewVm = new ReviewWorkflowViewModel(runLabels, auditService, suggestedTitle);
+
+            var window = new ReviewWorkflowWindow(reviewVm)
             {
                 Owner = owner
             };

--- a/src/LM.App.Wpf/Services/IReviewAuditService.cs
+++ b/src/LM.App.Wpf/Services/IReviewAuditService.cs
@@ -1,0 +1,8 @@
+namespace LM.App.Wpf.Services;
+
+using LM.Review.Core.Models;
+
+internal interface IReviewAuditService
+{
+    void Append(ReviewProjectDefinition project);
+}

--- a/src/LM.App.Wpf/Services/ReviewAuditService.cs
+++ b/src/LM.App.Wpf/Services/ReviewAuditService.cs
@@ -1,0 +1,43 @@
+namespace LM.App.Wpf.Services;
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LM.Review.Core.Models;
+
+internal sealed class ReviewAuditService : IReviewAuditService
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private readonly string _logFile;
+
+    public ReviewAuditService()
+    {
+        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            root = Environment.CurrentDirectory;
+        }
+
+        var directory = Path.Combine(root, "KnowledgeWorks", "review-audit");
+        Directory.CreateDirectory(directory);
+        _logFile = Path.Combine(directory, "review-changelog.jsonl");
+    }
+
+    public void Append(ReviewProjectDefinition project)
+    {
+        if (project is null)
+        {
+            throw new ArgumentNullException(nameof(project));
+        }
+
+        var json = JsonSerializer.Serialize(project, s_jsonOptions);
+        File.AppendAllText(_logFile, json + Environment.NewLine);
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Review/ReviewLayerViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Review/ReviewLayerViewModel.cs
@@ -1,0 +1,105 @@
+namespace LM.App.Wpf.ViewModels.Review;
+
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using LM.Review.Core.Models;
+
+internal sealed class ReviewLayerViewModel : INotifyPropertyChanged
+{
+    private string _name;
+    private ReviewLayerKind _kind;
+    private ReviewLayerDisplayMode _displayMode;
+    private string _fieldsCsv;
+    private string? _instructions;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public ReviewLayerViewModel(string name, ReviewLayerKind kind, ReviewLayerDisplayMode displayMode, string fieldsCsv, string? instructions)
+    {
+        _name = string.IsNullOrWhiteSpace(name) ? "Untitled layer" : name;
+        _kind = kind;
+        _displayMode = displayMode;
+        _fieldsCsv = fieldsCsv ?? string.Empty;
+        _instructions = instructions;
+    }
+
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            if (!string.Equals(_name, value, StringComparison.Ordinal))
+            {
+                _name = value ?? string.Empty;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public ReviewLayerKind Kind
+    {
+        get => _kind;
+        set
+        {
+            if (_kind != value)
+            {
+                _kind = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public ReviewLayerDisplayMode DisplayMode
+    {
+        get => _displayMode;
+        set
+        {
+            if (_displayMode != value)
+            {
+                _displayMode = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public string FieldsCsv
+    {
+        get => _fieldsCsv;
+        set
+        {
+            if (!string.Equals(_fieldsCsv, value, StringComparison.Ordinal))
+            {
+                _fieldsCsv = value ?? string.Empty;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(DisplayFieldsPreview));
+            }
+        }
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set
+        {
+            if (!string.Equals(_instructions, value, StringComparison.Ordinal))
+            {
+                _instructions = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public string DisplayFieldsPreview => string.IsNullOrWhiteSpace(_fieldsCsv) ? "No custom fields" : _fieldsCsv;
+
+    public ReviewLayerDefinition ToDefinition()
+    {
+        var fields = _fieldsCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return new ReviewLayerDefinition(_name, _kind, _displayMode, fields, _instructions);
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Review/ReviewStepViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Review/ReviewStepViewModel.cs
@@ -1,0 +1,39 @@
+namespace LM.App.Wpf.ViewModels.Review;
+
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+internal sealed class ReviewStepViewModel : INotifyPropertyChanged
+{
+    private bool _isActive;
+
+    public ReviewStepViewModel(string title, ReviewWorkflowStep step)
+    {
+        Title = title;
+        Step = step;
+    }
+
+    public string Title { get; }
+
+    public ReviewWorkflowStep Step { get; }
+
+    public bool IsActive
+    {
+        get => _isActive;
+        set
+        {
+            if (_isActive != value)
+            {
+                _isActive = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Review/ReviewWorkflowCompletedEventArgs.cs
+++ b/src/LM.App.Wpf/ViewModels/Review/ReviewWorkflowCompletedEventArgs.cs
@@ -1,0 +1,14 @@
+namespace LM.App.Wpf.ViewModels.Review;
+
+using System;
+using LM.Review.Core.Models;
+
+internal sealed class ReviewWorkflowCompletedEventArgs : EventArgs
+{
+    public ReviewWorkflowCompletedEventArgs(ReviewProjectDefinition definition)
+    {
+        Definition = definition ?? throw new ArgumentNullException(nameof(definition));
+    }
+
+    public ReviewProjectDefinition Definition { get; }
+}

--- a/src/LM.App.Wpf/ViewModels/Review/ReviewWorkflowStep.cs
+++ b/src/LM.App.Wpf/ViewModels/Review/ReviewWorkflowStep.cs
@@ -1,0 +1,8 @@
+namespace LM.App.Wpf.ViewModels.Review;
+
+internal enum ReviewWorkflowStep
+{
+    SelectRun,
+    ConfigureLayers,
+    Overview
+}

--- a/src/LM.App.Wpf/ViewModels/Review/ReviewWorkflowViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Review/ReviewWorkflowViewModel.cs
@@ -1,0 +1,330 @@
+namespace LM.App.Wpf.ViewModels.Review;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using LM.App.Wpf.Common;
+using LM.App.Wpf.Services;
+using LM.Review.Core.Models;
+
+internal sealed class ReviewWorkflowViewModel : INotifyPropertyChanged
+{
+    private readonly ObservableCollection<string> _litSearchRuns;
+    private readonly ObservableCollection<ReviewLayerViewModel> _layers;
+    private readonly ObservableCollection<ReviewStepViewModel> _steps;
+    private readonly ReadOnlyObservableCollection<string> _readOnlyRuns;
+    private readonly ReadOnlyObservableCollection<ReviewStepViewModel> _readOnlySteps;
+    private readonly IReviewAuditService _auditService;
+
+    private readonly RelayCommand _nextCommand;
+    private readonly RelayCommand _backCommand;
+    private readonly RelayCommand _saveCommand;
+    private readonly RelayCommand _cancelCommand;
+    private readonly RelayCommand _addLayerCommand;
+    private readonly RelayCommand _removeLayerCommand;
+
+    private int _currentStepIndex;
+    private string? _selectedLitSearchRun;
+    private ReviewProjectType _selectedProjectType = ReviewProjectType.Picos;
+    private string _reviewTitle;
+    private string? _metadataNotes;
+    private ReviewLayerViewModel? _selectedLayer;
+    private readonly string _createdBy;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public event EventHandler<ReviewWorkflowCompletedEventArgs>? Completed;
+    public event EventHandler? Canceled;
+
+    public ReviewWorkflowViewModel(IEnumerable<string> litSearchRuns, IReviewAuditService auditService, string? suggestedTitle)
+    {
+        if (auditService is null)
+        {
+            throw new ArgumentNullException(nameof(auditService));
+        }
+
+        _auditService = auditService;
+        _litSearchRuns = new ObservableCollection<string>(litSearchRuns?.Distinct(StringComparer.OrdinalIgnoreCase) ?? Array.Empty<string>());
+        _layers = new ObservableCollection<ReviewLayerViewModel>();
+        _steps = new ObservableCollection<ReviewStepViewModel>
+        {
+            new ReviewStepViewModel("Select run", ReviewWorkflowStep.SelectRun),
+            new ReviewStepViewModel("Configure layers", ReviewWorkflowStep.ConfigureLayers),
+            new ReviewStepViewModel("Overview", ReviewWorkflowStep.Overview)
+        };
+
+        _readOnlyRuns = new ReadOnlyObservableCollection<string>(_litSearchRuns);
+        _readOnlySteps = new ReadOnlyObservableCollection<ReviewStepViewModel>(_steps);
+
+        _createdBy = Environment.UserName;
+        _reviewTitle = suggestedTitle ?? string.Empty;
+
+        _nextCommand = new RelayCommand(_ => MoveNext(), _ => CanMoveNext());
+        _backCommand = new RelayCommand(_ => MovePrevious(), _ => CanMovePrevious());
+        _saveCommand = new RelayCommand(_ => Save(), _ => CanSave());
+        _cancelCommand = new RelayCommand(_ => Cancel());
+        _addLayerCommand = new RelayCommand(_ => AddLayer());
+        _removeLayerCommand = new RelayCommand(_ => RemoveLayer(), _ => SelectedLayer is not null);
+
+        if (_litSearchRuns.Count > 0)
+        {
+            _selectedLitSearchRun = _litSearchRuns[0];
+        }
+
+        SeedDefaultLayers();
+        UpdateStepActivation();
+    }
+
+    public ReadOnlyObservableCollection<string> LitSearchRuns => _readOnlyRuns;
+
+    public bool HasLitSearchRuns => _litSearchRuns.Count > 0;
+
+    public IReadOnlyList<ReviewProjectType> ProjectTypes { get; } = Enum.GetValues<ReviewProjectType>();
+
+    public IReadOnlyList<ReviewLayerKind> LayerKinds { get; } = Enum.GetValues<ReviewLayerKind>();
+
+    public IReadOnlyList<ReviewLayerDisplayMode> DisplayModes { get; } = Enum.GetValues<ReviewLayerDisplayMode>();
+
+    public ObservableCollection<ReviewLayerViewModel> Layers => _layers;
+
+    public ReadOnlyObservableCollection<ReviewStepViewModel> Steps => _readOnlySteps;
+
+    public ReviewWorkflowStep CurrentStep => _steps[_currentStepIndex].Step;
+
+    public bool IsOnLastStep => _currentStepIndex == _steps.Count - 1;
+
+    public bool IsOnFirstStep => _currentStepIndex == 0;
+
+    public string? SelectedLitSearchRun
+    {
+        get => _selectedLitSearchRun;
+        set
+        {
+            if (!string.Equals(_selectedLitSearchRun, value, StringComparison.Ordinal))
+            {
+                _selectedLitSearchRun = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public ReviewProjectType SelectedProjectType
+    {
+        get => _selectedProjectType;
+        set
+        {
+            if (_selectedProjectType != value)
+            {
+                _selectedProjectType = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public string ReviewTitle
+    {
+        get => _reviewTitle;
+        set
+        {
+            if (!string.Equals(_reviewTitle, value, StringComparison.Ordinal))
+            {
+                _reviewTitle = value ?? string.Empty;
+                OnPropertyChanged();
+                RaiseGuards();
+            }
+        }
+    }
+
+    public string? MetadataNotes
+    {
+        get => _metadataNotes;
+        set
+        {
+            if (!string.Equals(_metadataNotes, value, StringComparison.Ordinal))
+            {
+                _metadataNotes = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public ReviewLayerViewModel? SelectedLayer
+    {
+        get => _selectedLayer;
+        set
+        {
+            if (!ReferenceEquals(_selectedLayer, value))
+            {
+                _selectedLayer = value;
+                OnPropertyChanged();
+                _removeLayerCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public string CreatedBy => _createdBy;
+
+    public IEnumerable<ReviewLayerViewModel> OverviewLayers => _layers;
+
+    public System.Windows.Input.ICommand NextCommand => _nextCommand;
+    public System.Windows.Input.ICommand BackCommand => _backCommand;
+    public System.Windows.Input.ICommand SaveCommand => _saveCommand;
+    public System.Windows.Input.ICommand CancelCommand => _cancelCommand;
+    public System.Windows.Input.ICommand AddLayerCommand => _addLayerCommand;
+    public System.Windows.Input.ICommand RemoveLayerCommand => _removeLayerCommand;
+
+    private void MoveNext()
+    {
+        if (!CanMoveNext())
+        {
+            return;
+        }
+
+        _currentStepIndex++;
+        UpdateStepActivation();
+        RaiseGuards();
+        OnPropertyChanged(nameof(CurrentStep));
+        OnPropertyChanged(nameof(IsOnLastStep));
+        OnPropertyChanged(nameof(IsOnFirstStep));
+    }
+
+    private void MovePrevious()
+    {
+        if (!CanMovePrevious())
+        {
+            return;
+        }
+
+        _currentStepIndex--;
+        UpdateStepActivation();
+        RaiseGuards();
+        OnPropertyChanged(nameof(CurrentStep));
+        OnPropertyChanged(nameof(IsOnLastStep));
+        OnPropertyChanged(nameof(IsOnFirstStep));
+    }
+
+    private void Cancel()
+    {
+        Canceled?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void Save()
+    {
+        if (!CanSave())
+        {
+            return;
+        }
+
+        var definition = BuildDefinition();
+        _auditService.Append(definition);
+        Completed?.Invoke(this, new ReviewWorkflowCompletedEventArgs(definition));
+    }
+
+    private bool CanMoveNext()
+    {
+        if (IsOnLastStep)
+        {
+            return false;
+        }
+
+        return ValidateStep(CurrentStep);
+    }
+
+    private bool CanMovePrevious() => !IsOnFirstStep;
+
+    private bool CanSave() => IsOnLastStep && ValidateStep(CurrentStep);
+
+    private bool ValidateStep(ReviewWorkflowStep step)
+    {
+        return step switch
+        {
+            ReviewWorkflowStep.SelectRun => !string.IsNullOrWhiteSpace(_reviewTitle),
+            ReviewWorkflowStep.ConfigureLayers => _layers.Count > 0,
+            _ => true
+        };
+    }
+
+    private void RaiseGuards()
+    {
+        _nextCommand.RaiseCanExecuteChanged();
+        _backCommand.RaiseCanExecuteChanged();
+        _saveCommand.RaiseCanExecuteChanged();
+    }
+
+    private void AddLayer()
+    {
+        var layer = new ReviewLayerViewModel("Custom layer", ReviewLayerKind.Custom, ReviewLayerDisplayMode.Custom, string.Empty, null);
+        _layers.Add(layer);
+        SelectedLayer = layer;
+        OnPropertyChanged(nameof(OverviewLayers));
+        RaiseGuards();
+    }
+
+    private void RemoveLayer()
+    {
+        if (SelectedLayer is null)
+        {
+            return;
+        }
+
+        _layers.Remove(SelectedLayer);
+        SelectedLayer = _layers.LastOrDefault();
+        OnPropertyChanged(nameof(OverviewLayers));
+        RaiseGuards();
+    }
+
+    private void SeedDefaultLayers()
+    {
+        _layers.Add(new ReviewLayerViewModel(
+            "Title & abstract screening",
+            ReviewLayerKind.TitleAbstractScreening,
+            ReviewLayerDisplayMode.Picos,
+            "Title,Abstract,Keywords",
+            "Screen by PICOS and mark include/exclude."));
+
+        _layers.Add(new ReviewLayerViewModel(
+            "Full-text review",
+            ReviewLayerKind.FullTextScreening,
+            ReviewLayerDisplayMode.Custom,
+            "Title,Authors,FullText",
+            "Use the PDF viewer to check inclusion."));
+
+        _layers.Add(new ReviewLayerViewModel(
+            "Data extraction",
+            ReviewLayerKind.DataExtraction,
+            ReviewLayerDisplayMode.Custom,
+            "Outcomes,Population,Interventions",
+            "Capture quantitative data for synthesis."));
+
+        SelectedLayer = _layers.FirstOrDefault();
+        OnPropertyChanged(nameof(OverviewLayers));
+    }
+
+    private void UpdateStepActivation()
+    {
+        foreach (var step in _steps)
+        {
+            step.IsActive = step.Step == CurrentStep;
+        }
+    }
+
+    private ReviewProjectDefinition BuildDefinition()
+    {
+        var layers = _layers.Select(l => l.ToDefinition()).ToArray();
+        return new ReviewProjectDefinition(
+            _reviewTitle,
+            _createdBy,
+            _selectedLitSearchRun,
+            _selectedProjectType,
+            layers,
+            _metadataNotes,
+            DateTimeOffset.UtcNow);
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/LM.App.Wpf/Views/ReviewWorkflowWindow.xaml
+++ b/src/LM.App.Wpf/Views/ReviewWorkflowWindow.xaml
@@ -1,0 +1,265 @@
+<Window x:Class="LM.App.Wpf.Views.ReviewWorkflowWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:LM.App.Wpf.ViewModels.Review"
+        mc:Ignorable="d"
+        Title="Create review project"
+        Height="620"
+        Width="980"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
+    </Window.Resources>
+
+    <Window.InputBindings>
+        <KeyBinding Key="Enter" Modifiers="Control" Command="{Binding NextCommand}"/>
+        <KeyBinding Key="Right" Modifiers="Alt" Command="{Binding NextCommand}"/>
+        <KeyBinding Key="Left" Modifiers="Alt" Command="{Binding BackCommand}"/>
+        <KeyBinding Key="S" Modifiers="Control" Command="{Binding SaveCommand}"/>
+        <KeyBinding Key="N" Modifiers="Control" Command="{Binding AddLayerCommand}"/>
+        <KeyBinding Key="Delete" Command="{Binding RemoveLayerCommand}"/>
+        <KeyBinding Key="Escape" Command="{Binding CancelCommand}"/>
+    </Window.InputBindings>
+
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Step indicator -->
+        <ItemsControl Grid.Row="0" ItemsSource="{Binding Steps}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate DataType="{x:Type vm:ReviewStepViewModel}">
+                    <Border x:Name="StepBorder"
+                            Margin="0,0,12,0"
+                            Padding="14,8"
+                            CornerRadius="6"
+                            Background="#FFE6E6E6">
+                        <TextBlock x:Name="StepText"
+                                   Text="{Binding Title}"
+                                   FontWeight="SemiBold"
+                                   Foreground="#FF2D2D2D"/>
+                    </Border>
+                    <DataTemplate.Triggers>
+                        <DataTrigger Binding="{Binding IsActive}" Value="True">
+                            <Setter TargetName="StepBorder" Property="Border.Background" Value="#FF0057B8"/>
+                            <Setter TargetName="StepText" Property="TextBlock.Foreground" Value="White"/>
+                        </DataTrigger>
+                    </DataTemplate.Triggers>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
+        <!-- Step content -->
+        <Grid Grid.Row="1">
+            <!-- Step 1: select run -->
+            <Grid>
+                <Grid.Style>
+                    <Style TargetType="Grid">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding CurrentStep}" Value="{x:Static vm:ReviewWorkflowStep.SelectRun}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Grid.Style>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0" Margin="0,0,18,0">
+                    <TextBlock Text="1. Choose the source run" FontWeight="Bold" FontSize="16"/>
+                    <TextBlock Text="Litsearch run" Margin="0,12,0,2"/>
+                    <ComboBox ItemsSource="{Binding LitSearchRuns}"
+                              SelectedItem="{Binding SelectedLitSearchRun, Mode=TwoWay}"
+                              IsEditable="False"/>
+                    <TextBlock Text="No litsearch runs detected. You can continue without linking a run."
+                               Foreground="#FF8A6E00"
+                               Margin="0,4,0,0">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasLitSearchRuns}" Value="False">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <TextBlock Text="Review type" Margin="0,18,0,2"/>
+                    <ComboBox ItemsSource="{Binding ProjectTypes}"
+                              SelectedItem="{Binding SelectedProjectType, Mode=TwoWay}"
+                              IsEditable="False"/>
+
+                    <TextBlock Text="Review title" Margin="0,18,0,2"/>
+                    <TextBox Text="{Binding ReviewTitle, UpdateSourceTrigger=PropertyChanged}"
+                             FontSize="14"
+                             Padding="6"/>
+
+                    <TextBlock Text="Metadata notes" Margin="0,18,0,2"/>
+                    <TextBox Text="{Binding MetadataNotes, UpdateSourceTrigger=PropertyChanged}"
+                             Height="140"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             Padding="6"/>
+                </StackPanel>
+
+                <Border Grid.Column="1" Background="#FFF5F8FF" Padding="16" CornerRadius="8">
+                    <StackPanel>
+                        <TextBlock Text="Quick tips" FontWeight="Bold" FontSize="15"/>
+                        <TextBlock Text="• Select the litsearch run you want to base this review on." Margin="0,12,0,0" TextWrapping="Wrap"/>
+                        <TextBlock Text="• Choose PICOS or a custom structure for screening." Margin="0,6,0,0" TextWrapping="Wrap"/>
+                        <TextBlock Text="• Add any context, contact details or scope in metadata notes." Margin="0,6,0,0" TextWrapping="Wrap"/>
+                        <TextBlock Text="Created by:" Margin="0,18,0,2" FontWeight="SemiBold"/>
+                        <TextBlock Text="{Binding CreatedBy}"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+
+            <!-- Step 2: configure layers -->
+            <Grid>
+                <Grid.Style>
+                    <Style TargetType="Grid">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding CurrentStep}" Value="{x:Static vm:ReviewWorkflowStep.ConfigureLayers}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Grid.Style>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="1.4*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0" Margin="0,0,18,0">
+                    <DockPanel>
+                        <TextBlock Text="2. Review layers" FontWeight="Bold" FontSize="16" DockPanel.Dock="Left"/>
+                        <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                            <Button Content="Add layer" Command="{Binding AddLayerCommand}" ToolTip="Ctrl+N" Margin="0,0,6,0"/>
+                            <Button Content="Remove" Command="{Binding RemoveLayerCommand}" ToolTip="Delete"/>
+                        </StackPanel>
+                    </DockPanel>
+
+                    <ListBox ItemsSource="{Binding Layers}" SelectedItem="{Binding SelectedLayer, Mode=TwoWay}"
+                             Margin="0,12,0,0" DisplayMemberPath="Name">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate DataType="{x:Type vm:ReviewLayerViewModel}">
+                                <StackPanel Margin="0,4">
+                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                                    <TextBlock Text="{Binding DisplayFieldsPreview}" FontSize="11" Foreground="#FF555555"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </StackPanel>
+
+                <Border Grid.Column="1" Padding="16" Background="#FFF8F8F8" CornerRadius="8">
+                    <ContentControl Content="{Binding SelectedLayer}">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate DataType="{x:Type vm:ReviewLayerViewModel}">
+                                <StackPanel>
+                                    <TextBlock Text="Layer name"/>
+                                    <TextBox Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Padding="6" Margin="0,2,0,8"/>
+
+                                    <TextBlock Text="Layer kind"/>
+                                    <ComboBox ItemsSource="{Binding DataContext.LayerKinds, RelativeSource={RelativeSource AncestorType=Window}}"
+                                              SelectedItem="{Binding Kind, Mode=TwoWay}"
+                                              Margin="0,2,0,8"/>
+
+                                    <TextBlock Text="Display mode"/>
+                                    <ComboBox ItemsSource="{Binding DataContext.DisplayModes, RelativeSource={RelativeSource AncestorType=Window}}"
+                                              SelectedItem="{Binding DisplayMode, Mode=TwoWay}"
+                                              Margin="0,2,0,8"/>
+
+                                    <TextBlock Text="Visible fields (comma-separated)"/>
+                                    <TextBox Text="{Binding FieldsCsv, UpdateSourceTrigger=PropertyChanged}"
+                                             Margin="0,2,0,8" Padding="6" AcceptsReturn="False"/>
+
+                                    <TextBlock Text="Reviewer instructions"/>
+                                    <TextBox Text="{Binding Instructions, UpdateSourceTrigger=PropertyChanged}"
+                                             Height="120"
+                                             TextWrapping="Wrap"
+                                             AcceptsReturn="True"
+                                             Padding="6"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
+                </Border>
+            </Grid>
+
+            <!-- Step 3: overview -->
+            <Grid>
+                <Grid.Style>
+                    <Style TargetType="Grid">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding CurrentStep}" Value="{x:Static vm:ReviewWorkflowStep.Overview}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Grid.Style>
+
+                <StackPanel>
+                    <TextBlock Text="3. Overview" FontWeight="Bold" FontSize="16"/>
+                    <Border Margin="0,12,0,0" Padding="16" Background="#FFF7FBFF" CornerRadius="8">
+                        <StackPanel>
+                            <TextBlock Text="{Binding ReviewTitle}" FontSize="20" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding SelectedProjectType}" Margin="0,6,0,0"/>
+                            <TextBlock Text="{Binding SelectedLitSearchRun, StringFormat=Litsearch run: {0}}" Margin="0,6,0,0"/>
+                            <TextBlock Text="{Binding CreatedBy, StringFormat=Created by: {0}}" Margin="0,6,0,0"/>
+                            <TextBlock Text="{Binding MetadataNotes}" Margin="0,12,0,0" TextWrapping="Wrap" Foreground="#FF444444"/>
+                        </StackPanel>
+                    </Border>
+
+                    <TextBlock Text="Layers" FontWeight="SemiBold" Margin="0,18,0,4"/>
+                    <ItemsControl ItemsSource="{Binding OverviewLayers}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type vm:ReviewLayerViewModel}">
+                                <Border Margin="0,0,0,8" Padding="12" Background="#FFFFFFFF" CornerRadius="6" BorderBrush="#FFE0E0E0" BorderThickness="1">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                                        <TextBlock Text="{Binding Kind}" Margin="0,2,0,0" FontSize="11" Foreground="#FF666666"/>
+                                        <TextBlock Text="{Binding DisplayFieldsPreview}" Margin="0,6,0,0" TextWrapping="Wrap"/>
+                                        <TextBlock Text="{Binding Instructions}" Margin="0,6,0,0" TextWrapping="Wrap" Foreground="#FF444444"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Grid>
+        </Grid>
+
+        <!-- Footer -->
+        <DockPanel Grid.Row="2" Margin="0,18,0,0">
+            <StackPanel DockPanel.Dock="Left" Orientation="Horizontal">
+                <TextBlock Text="Ctrl+Enter / Alt+→ to advance" Foreground="#FF666666" Margin="0,0,12,0"/>
+                <TextBlock Text="Ctrl+S to save" Foreground="#FF666666"/>
+            </StackPanel>
+            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                <Button Content="Back" Command="{Binding BackCommand}" MinWidth="90" Margin="0,0,8,0"/>
+                <Button Content="Next" Command="{Binding NextCommand}" MinWidth="90" Margin="0,0,8,0"/>
+                <Button Content="Save" Command="{Binding SaveCommand}" MinWidth="110" Margin="0,0,8,0"/>
+                <Button Content="Cancel" Command="{Binding CancelCommand}" MinWidth="90"/>
+            </StackPanel>
+        </DockPanel>
+    </Grid>
+</Window>

--- a/src/LM.App.Wpf/Views/ReviewWorkflowWindow.xaml.cs
+++ b/src/LM.App.Wpf/Views/ReviewWorkflowWindow.xaml.cs
@@ -1,0 +1,33 @@
+namespace LM.App.Wpf.Views;
+
+using System;
+using System.Windows;
+using LM.App.Wpf.ViewModels.Review;
+
+public partial class ReviewWorkflowWindow : Window
+{
+    public ReviewWorkflowWindow(ReviewWorkflowViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+        viewModel.Completed += OnCompleted;
+        viewModel.Canceled += OnCanceled;
+        Closed += (_, _) =>
+        {
+            viewModel.Completed -= OnCompleted;
+            viewModel.Canceled -= OnCanceled;
+        };
+    }
+
+    private void OnCompleted(object? sender, ReviewWorkflowCompletedEventArgs e)
+    {
+        DialogResult = true;
+        Close();
+    }
+
+    private void OnCanceled(object? sender, EventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+}

--- a/src/LM.Review.Core/Models/ReviewProjectDefinition.cs
+++ b/src/LM.Review.Core/Models/ReviewProjectDefinition.cs
@@ -1,0 +1,40 @@
+namespace LM.Review.Core.Models;
+
+using System;
+using System.Collections.Generic;
+
+public enum ReviewProjectType
+{
+    Picos,
+    Custom
+}
+
+public enum ReviewLayerKind
+{
+    TitleAbstractScreening,
+    FullTextScreening,
+    DataExtraction,
+    Custom
+}
+
+public enum ReviewLayerDisplayMode
+{
+    Picos,
+    Custom
+}
+
+public sealed record ReviewLayerDefinition(
+    string Name,
+    ReviewLayerKind Kind,
+    ReviewLayerDisplayMode DisplayMode,
+    IReadOnlyList<string> DisplayFields,
+    string? Instructions);
+
+public sealed record ReviewProjectDefinition(
+    string Title,
+    string CreatedBy,
+    string? LitSearchRunId,
+    ReviewProjectType ProjectType,
+    IReadOnlyList<ReviewLayerDefinition> Layers,
+    string? MetadataNotes,
+    DateTimeOffset CreatedAt);


### PR DESCRIPTION
## Summary
- add a multi-step review workflow window with keyboard shortcuts for navigation and clean layout
- introduce review workflow view models, layer editing support, and audit logging for saved review definitions
- add core review domain records and wire the WPF project to the review core library

## Testing
- dotnet build *(fails: installed SDK 8.0.414 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d813936d2c832b9884e80b7b8a8ea9