### PR TITLE
Add TabulaSharp playground window

### DIFF
--- a/src/LM.App.Wpf/ViewModels/TabulaSharp/Models/TabulaSharpPlaygroundTableResult.cs
+++ b/src/LM.App.Wpf/ViewModels/TabulaSharp/Models/TabulaSharpPlaygroundTableResult.cs
@@ -1,0 +1,68 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TabulaSharp.Models;
+
+namespace LM.App.Wpf.ViewModels.TabulaSharp.Models
+{
+    internal sealed class TabulaSharpPlaygroundTableResult
+    {
+        public TabulaSharpPlaygroundTableResult(int pageNumber,
+                                                int tableIndex,
+                                                TabulaSharpBoundingBox bounds,
+                                                IReadOnlyList<string[]> rows)
+        {
+            Rows = rows ?? throw new ArgumentNullException(nameof(rows));
+            PageNumber = pageNumber;
+            TableIndex = tableIndex;
+            Bounds = bounds;
+            RowCount = rows.Count;
+            ColumnCount = rows.Count == 0 ? 0 : rows.Max(r => r?.Length ?? 0);
+            FriendlyName = FormattableString.Invariant($"Page {PageNumber} · Table {TableIndex}");
+            BoundsDisplay = FormattableString.Invariant($"x={bounds.Left:0.##}, y={bounds.Bottom:0.##}, w={bounds.Width:0.##}, h={bounds.Height:0.##}");
+            Preview = BuildPreview(rows);
+        }
+
+        public int PageNumber { get; }
+
+        public int TableIndex { get; }
+
+        public TabulaSharpBoundingBox Bounds { get; }
+
+        public IReadOnlyList<string[]> Rows { get; }
+
+        public int RowCount { get; }
+
+        public int ColumnCount { get; }
+
+        public string FriendlyName { get; }
+
+        public string BoundsDisplay { get; }
+
+        public string Preview { get; }
+
+        private static string BuildPreview(IReadOnlyList<string[]> rows)
+        {
+            if (rows.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var builder = new StringBuilder();
+            foreach (var row in rows)
+            {
+                if (row is null)
+                {
+                    continue;
+                }
+
+                var cells = row.Select(cell => cell?.Replace("\r", string.Empty) ?? string.Empty);
+                builder.AppendLine(string.Join(" | ", cells));
+            }
+
+            return builder.ToString().TrimEnd();
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/TabulaSharp/Services/TabulaSharpPlaygroundExtractor.cs
+++ b/src/LM.App.Wpf/ViewModels/TabulaSharp/Services/TabulaSharpPlaygroundExtractor.cs
@@ -1,0 +1,146 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.App.Wpf.ViewModels.TabulaSharp.Models;
+using TabulaSharp.Models;
+using TabulaSharp.Processing;
+using UglyToad.PdfPig;
+using UglyToad.PdfPig.Content;
+
+namespace LM.App.Wpf.ViewModels.TabulaSharp.Services
+{
+    internal sealed class TabulaSharpPlaygroundExtractor
+    {
+        private readonly TabulaSharpExtractor _extractor = new();
+
+        public Task<IReadOnlyList<TabulaSharpPlaygroundTableResult>> ExtractAsync(string pdfPath, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(pdfPath))
+                throw new ArgumentException("PDF path must be provided.", nameof(pdfPath));
+
+            if (!File.Exists(pdfPath))
+                throw new FileNotFoundException("PDF file not found.", pdfPath);
+
+            return Task.Run(() => ExtractInternal(pdfPath, ct), ct);
+        }
+
+        private IReadOnlyList<TabulaSharpPlaygroundTableResult> ExtractInternal(string pdfPath, CancellationToken ct)
+        {
+            var results = new List<TabulaSharpPlaygroundTableResult>();
+
+            using var document = PdfDocument.Open(pdfPath);
+            foreach (var page in document.GetPages())
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var lines = BuildLines(page);
+                if (lines.Count == 0)
+                {
+                    continue;
+                }
+
+                var tables = _extractor.ExtractTables(lines);
+                if (tables.Count == 0)
+                {
+                    continue;
+                }
+
+                var tableIndex = 1;
+                foreach (var table in tables)
+                {
+                    ct.ThrowIfCancellationRequested();
+
+                    var normalized = NormalizeRows(table.Rows);
+                    if (normalized.Count < 2)
+                    {
+                        continue;
+                    }
+
+                    results.Add(new TabulaSharpPlaygroundTableResult(page.Number, tableIndex, table.Bounds, normalized));
+                    tableIndex++;
+                }
+            }
+
+            return results;
+        }
+
+        private static IReadOnlyList<TabulaSharpLine> BuildLines(Page page)
+        {
+            var words = page.GetWords();
+            var buffers = new List<LineBuffer>();
+            foreach (var word in words)
+            {
+                if (string.IsNullOrWhiteSpace(word.Text))
+                {
+                    continue;
+                }
+
+                var centerY = (word.BoundingBox.Bottom + word.BoundingBox.Top) / 2d;
+                var buffer = FindOrCreateBuffer(buffers, centerY);
+                buffer.Add(word);
+            }
+
+            return buffers.Select(buffer => buffer.ToLine()).ToArray();
+        }
+
+        private static LineBuffer FindOrCreateBuffer(List<LineBuffer> buffers, double centerY)
+        {
+            const double tolerance = 3d;
+            foreach (var buffer in buffers)
+            {
+                if (Math.Abs(buffer.CenterY - centerY) <= tolerance)
+                {
+                    return buffer;
+                }
+            }
+
+            var created = new LineBuffer(centerY);
+            buffers.Add(created);
+            return created;
+        }
+
+        private static IReadOnlyList<string[]> NormalizeRows(IReadOnlyList<IReadOnlyList<string>> rows)
+        {
+            return rows.Select(row => row.Select(cell => cell?.Trim() ?? string.Empty).ToArray())
+                       .Where(row => row.Any(cell => !string.IsNullOrWhiteSpace(cell)))
+                       .ToArray();
+        }
+
+        private sealed class LineBuffer
+        {
+            private readonly List<Word> _words = new();
+
+            public LineBuffer(double centerY)
+            {
+                CenterY = centerY;
+            }
+
+            public double CenterY { get; private set; }
+
+            public void Add(Word word)
+            {
+                _words.Add(word);
+                var y = (word.BoundingBox.Bottom + word.BoundingBox.Top) / 2d;
+                CenterY = (CenterY + y) / 2d;
+            }
+
+            public TabulaSharpLine ToLine()
+            {
+                var ordered = _words.OrderBy(w => w.BoundingBox.Left)
+                                     .Select(w => new TabulaSharpToken(w.Text,
+                                                                       w.BoundingBox.Left,
+                                                                       w.BoundingBox.Bottom,
+                                                                       w.BoundingBox.Right,
+                                                                       w.BoundingBox.Top))
+                                     .Where(t => t.HasContent)
+                                     .ToArray();
+
+                return new TabulaSharpLine(CenterY, ordered);
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/TabulaSharp/TabulaSharpPlaygroundViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/TabulaSharp/TabulaSharpPlaygroundViewModel.cs
@@ -1,0 +1,188 @@
+#nullable enable
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.App.Wpf.Common;
+using LM.App.Wpf.ViewModels.TabulaSharp.Models;
+using LM.App.Wpf.ViewModels.TabulaSharp.Services;
+
+namespace LM.App.Wpf.ViewModels.TabulaSharp
+{
+    internal sealed class TabulaSharpPlaygroundViewModel : INotifyPropertyChanged, IDisposable
+    {
+        private readonly TabulaSharpPlaygroundExtractor _extractor = new();
+        private readonly RelayCommand _browsePdfCommand;
+        private readonly AsyncRelayCommand _extractTablesCommand;
+        private readonly ObservableCollection<TabulaSharpPlaygroundTableResult> _tables = new();
+        private string? _pdfPath;
+        private string _statusMessage = "Select a PDF to begin.";
+        private TabulaSharpPlaygroundTableResult? _selectedTable;
+        private bool _isBusy;
+        private CancellationTokenSource? _extractionCts;
+
+        public TabulaSharpPlaygroundViewModel()
+        {
+            _browsePdfCommand = new RelayCommand(_ => BrowseForPdf(), _ => !IsBusy);
+            _extractTablesCommand = new AsyncRelayCommand(ExtractAsync, () => !IsBusy && IsPdfPathValid());
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public ObservableCollection<TabulaSharpPlaygroundTableResult> Tables => _tables;
+
+        public System.Windows.Input.ICommand BrowsePdfCommand => _browsePdfCommand;
+
+        public System.Windows.Input.ICommand ExtractTablesCommand => _extractTablesCommand;
+
+        public string? PdfPath
+        {
+            get => _pdfPath;
+            set
+            {
+                if (string.Equals(_pdfPath, value, StringComparison.OrdinalIgnoreCase))
+                    return;
+
+                _pdfPath = value;
+                OnPropertyChanged();
+                _extractTablesCommand.RaiseCanExecuteChanged();
+            }
+        }
+
+        public string StatusMessage
+        {
+            get => _statusMessage;
+            private set
+            {
+                if (string.Equals(_statusMessage, value, StringComparison.Ordinal))
+                    return;
+
+                _statusMessage = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public TabulaSharpPlaygroundTableResult? SelectedTable
+        {
+            get => _selectedTable;
+            set
+            {
+                if (ReferenceEquals(_selectedTable, value))
+                    return;
+
+                _selectedTable = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool IsBusy
+        {
+            get => _isBusy;
+            private set
+            {
+                if (_isBusy == value)
+                    return;
+
+                _isBusy = value;
+                OnPropertyChanged();
+                _browsePdfCommand.RaiseCanExecuteChanged();
+                _extractTablesCommand.RaiseCanExecuteChanged();
+            }
+        }
+
+        public void Dispose()
+        {
+            var cts = _extractionCts;
+            if (cts is null)
+                return;
+
+            _extractionCts = null;
+            try
+            {
+                cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+
+            cts.Dispose();
+        }
+
+        private void BrowseForPdf()
+        {
+            var dialog = new Microsoft.Win32.OpenFileDialog
+            {
+                Filter = "PDF files (*.pdf)|*.pdf|All files (*.*)|*.*",
+                Multiselect = false
+            };
+
+            if (dialog.ShowDialog() == true)
+            {
+                PdfPath = dialog.FileName;
+                StatusMessage = "Ready to extract tables.";
+            }
+        }
+
+        private bool IsPdfPathValid()
+            => !string.IsNullOrWhiteSpace(_pdfPath) && File.Exists(_pdfPath);
+
+        private async Task ExtractAsync()
+        {
+            if (!IsPdfPathValid())
+            {
+                StatusMessage = "Select a valid PDF file.";
+                return;
+            }
+
+            var cts = new CancellationTokenSource();
+            _extractionCts?.Cancel();
+            _extractionCts?.Dispose();
+            _extractionCts = cts;
+
+            IsBusy = true;
+            try
+            {
+                StatusMessage = "Running TabulaSharp heuristics…";
+                var results = await _extractor.ExtractAsync(_pdfPath!, cts.Token);
+
+                _tables.Clear();
+                foreach (var result in results)
+                {
+                    _tables.Add(result);
+                }
+
+                SelectedTable = _tables.FirstOrDefault();
+                StatusMessage = _tables.Count == 0
+                    ? "No tables detected."
+                    : FormattableString.Invariant($"Detected {_tables.Count} table(s).");
+            }
+            catch (OperationCanceledException)
+            {
+                StatusMessage = "Extraction canceled.";
+            }
+            catch (Exception ex)
+            {
+                StatusMessage = FormattableString.Invariant($"Extraction failed: {ex.Message}");
+            }
+            finally
+            {
+                cts.Dispose();
+                if (ReferenceEquals(_extractionCts, cts))
+                {
+                    _extractionCts = null;
+                }
+
+                IsBusy = false;
+            }
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string? name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/AddView.xaml
+++ b/src/LM.App.Wpf/Views/AddView.xaml
@@ -13,6 +13,7 @@
       <Button Content="Review staged…" Command="{Binding ReviewStagedCommand}"/>
       <Button Content="Commit selected" Command="{Binding CommitSelectedCommand}"/>
       <Button Content="Clear" Command="{Binding ClearCommand}"/>
+      <Button Content="TabulaSharp playground" Command="{Binding OpenTabulaSharpPlaygroundCommand}"/>
     </StackPanel>
 
     <!-- Watched folders management -->

--- a/src/LM.App.Wpf/Views/TabulaSharp/TabulaSharpPlaygroundWindow.xaml
+++ b/src/LM.App.Wpf/Views/TabulaSharp/TabulaSharpPlaygroundWindow.xaml
@@ -1,0 +1,62 @@
+<Window x:Class="LM.App.Wpf.Views.TabulaSharp.TabulaSharpPlaygroundWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="TabulaSharp Playground"
+        Height="600"
+        Width="900">
+  <DockPanel Margin="12">
+    <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,12">
+      <TextBox Width="360"
+               Margin="0,0,8,0"
+               Text="{Binding PdfPath, UpdateSourceTrigger=PropertyChanged}"/>
+      <Button Content="Browse..."
+              Width="100"
+              Margin="0,0,8,0"
+              Command="{Binding BrowsePdfCommand}"/>
+      <Button Content="Extract tables"
+              Width="140"
+              Command="{Binding ExtractTablesCommand}"/>
+    </StackPanel>
+
+    <Grid>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="2*"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="*"/>
+      </Grid.RowDefinitions>
+
+      <ListView Grid.Row="0"
+                ItemsSource="{Binding Tables}"
+                SelectedItem="{Binding SelectedTable, Mode=TwoWay}"
+                Margin="0,0,0,12">
+        <ListView.View>
+          <GridView>
+            <GridViewColumn Width="160" Header="Table" DisplayMemberBinding="{Binding FriendlyName}"/>
+            <GridViewColumn Width="80" Header="Rows" DisplayMemberBinding="{Binding RowCount}"/>
+            <GridViewColumn Width="80" Header="Columns" DisplayMemberBinding="{Binding ColumnCount}"/>
+            <GridViewColumn Width="260" Header="Bounds" DisplayMemberBinding="{Binding BoundsDisplay}"/>
+          </GridView>
+        </ListView.View>
+      </ListView>
+
+      <TextBlock Grid.Row="1"
+                 Text="{Binding StatusMessage}"
+                 Foreground="Gray"
+                 Margin="0,0,0,8"/>
+
+      <Border Grid.Row="2" BorderBrush="#FFE0E0E0" BorderThickness="1">
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+          <TextBox Text="{Binding SelectedTable.Preview, TargetNullValue=Select a table to view details.}"
+                   IsReadOnly="True"
+                   TextWrapping="Wrap"
+                   AcceptsReturn="True"
+                   BorderThickness="0"
+                   Background="Transparent"/>
+        </ScrollViewer>
+      </Border>
+    </Grid>
+  </DockPanel>
+</Window>

--- a/src/LM.App.Wpf/Views/TabulaSharp/TabulaSharpPlaygroundWindow.xaml.cs
+++ b/src/LM.App.Wpf/Views/TabulaSharp/TabulaSharpPlaygroundWindow.xaml.cs
@@ -1,0 +1,12 @@
+#nullable enable
+
+namespace LM.App.Wpf.Views.TabulaSharp
+{
+    internal partial class TabulaSharpPlaygroundWindow : System.Windows.Window
+    {
+        public TabulaSharpPlaygroundWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a TabulaSharp playground launch button to the Add view toolbar
- provide a standalone TabulaSharp playground window with view model, extractor, and result models
- enable ad-hoc PDF table extraction previews without touching existing pipeline wiring

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: .NET 8 SDK cannot target net9.0 projects in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d82115c0f8832ba0a3ed29f936856c