### PR TITLE
Fix TabulaSharp playground accessibility

### DIFF
--- a/CombinedPublicAPI.txt
+++ b/CombinedPublicAPI.txt
@@ -1,5 +1,6 @@
 === Combined Public API for KnowledgeWorks_20250820_082416 ===
 ---------- LM.Core ----------
+---------- LM.Infrastructure ----------
 #nullable enable
 LM.Core.Models.DataExtraction.TablePageLocation
 LM.Core.Models.DataExtraction.TablePageLocation.TablePageLocation() -> void
@@ -622,989 +623,6 @@ static readonly LM.Core.Utils.JsonEx.Options -> System.Text.Json.JsonSerializerO
 LM.Core.Abstractions.IDataExtractionPowerPointExporter
 LM.Core.Abstractions.IDataExtractionExcelExporter
 LM.Core.Abstractions.IDataExtractionWordExporter
----------- LM.HubSpoke ----------
-#nullable enable
-#nullable enable
-LM.HubSpoke.Abstractions.CasResult
-LM.HubSpoke.Abstractions.CasResult.Bytes.get -> long
-LM.HubSpoke.Abstractions.CasResult.Bytes.init -> void
-LM.HubSpoke.Abstractions.CasResult.CasResult() -> void
-LM.HubSpoke.Abstractions.CasResult.CasResult(string? RelPath, string? Sha, long Bytes, string? Mime, string? Original) -> void
-LM.HubSpoke.Abstractions.CasResult.Mime.get -> string?
-LM.HubSpoke.Abstractions.CasResult.Mime.init -> void
-LM.HubSpoke.Abstractions.CasResult.Original.get -> string?
-LM.HubSpoke.Abstractions.CasResult.Original.init -> void
-LM.HubSpoke.Abstractions.CasResult.RelPath.get -> string?
-LM.HubSpoke.Abstractions.CasResult.RelPath.init -> void
-LM.HubSpoke.Abstractions.CasResult.Sha.get -> string?
-LM.HubSpoke.Abstractions.CasResult.Sha.init -> void
-LM.HubSpoke.Abstractions.ISimilarityLog
-LM.HubSpoke.Abstractions.ISimilarityLog.LogAsync(string! sessionId, string! stagedPath, string! candidateEntryId, double score, string! method, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-LM.HubSpoke.Abstractions.ISimilarityLog.NewSessionId() -> string!
-LM.HubSpoke.Abstractions.ISpokeHandler
-LM.HubSpoke.Abstractions.ISpokeHandler.BuildHookAsync(LM.Core.Models.Entry! entry, LM.HubSpoke.Abstractions.CasResult primary, System.Collections.Generic.IEnumerable<string!>! attachmentRelPaths, System.Func<string!, System.Threading.CancellationToken, System.Threading.Tasks.Task<LM.HubSpoke.Abstractions.CasResult>!>! moveToCas, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<object?>!
-LM.HubSpoke.Abstractions.ISpokeHandler.BuildIndex(LM.HubSpoke.Models.EntryHub! hub, object? hook, string? extractedFullText) -> LM.HubSpoke.Abstractions.SpokeIndexContribution
-LM.HubSpoke.Abstractions.ISpokeHandler.Handles.get -> LM.Core.Models.EntryType
-LM.HubSpoke.Abstractions.ISpokeHandler.HookPath.get -> string!
-LM.HubSpoke.Abstractions.ISpokeHandler.LoadHookAsync(LM.Core.Abstractions.IWorkSpaceService! ws, string! entryId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<object?>!
-LM.HubSpoke.Abstractions.ISpokeHandler.MapToEntry(LM.HubSpoke.Models.EntryHub! hub, object? hook) -> LM.Core.Models.Entry!
-LM.HubSpoke.Abstractions.SpokeIndexContribution
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Abstract.get -> string?
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Abstract.init -> void
-LM.HubSpoke.Abstractions.SpokeIndexContribution.AssetHashes.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.HubSpoke.Abstractions.SpokeIndexContribution.AssetHashes.init -> void
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Authors.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Authors.init -> void
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Doi.get -> string?
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Doi.init -> void
-LM.HubSpoke.Abstractions.SpokeIndexContribution.FullText.get -> string?
-LM.HubSpoke.Abstractions.SpokeIndexContribution.FullText.init -> void
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Journal.get -> string?
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Journal.init -> void
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Keywords.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Keywords.init -> void
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Pmid.get -> string?
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Pmid.init -> void
-LM.HubSpoke.Abstractions.SpokeIndexContribution.SpokeIndexContribution() -> void
-LM.HubSpoke.Abstractions.SpokeIndexContribution.SpokeIndexContribution(string? Title, string? Abstract, System.Collections.Generic.IReadOnlyList<string!>! Authors, System.Collections.Generic.IReadOnlyList<string!>! Keywords, string? Journal, string? Doi, string? Pmid, int? Year, System.Collections.Generic.IReadOnlyList<string!>! AssetHashes, string? FullText) -> void
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Title.get -> string?
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Title.init -> void
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Year.get -> int?
-LM.HubSpoke.Abstractions.SpokeIndexContribution.Year.init -> void
-LM.HubSpoke.Entries.HubSpokeStore
-LM.HubSpoke.Entries.HubSpokeStore.EnumerateAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<LM.Core.Models.Entry!>!
-LM.HubSpoke.Entries.HubSpokeStore.FindByHashAsync(string! sha256, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
-LM.HubSpoke.Entries.HubSpokeStore.FindByIdsAsync(string? doi, string? pmid, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
-LM.HubSpoke.Entries.HubSpokeStore.FindSimilarByNameYearAsync(string! title, int? year, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
-LM.HubSpoke.Entries.HubSpokeStore.FullTextSearch.get -> LM.Core.Abstractions.IFullTextSearchService!
-LM.HubSpoke.Entries.HubSpokeStore.GetByIdAsync(string! id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
-LM.HubSpoke.Entries.HubSpokeStore.HubSpokeStore(LM.Core.Abstractions.IWorkSpaceService! ws, LM.Core.Abstractions.IHasher! hasher, System.Collections.Generic.IEnumerable<LM.HubSpoke.Abstractions.ISpokeHandler!>! handlers, LM.Core.Abstractions.IContentExtractor? contentExtractor = null) -> void
-LM.HubSpoke.Entries.HubSpokeStore.HubSpokeStore(LM.Core.Abstractions.IWorkSpaceService! ws, LM.Core.Abstractions.IHasher! hasher, System.Collections.Generic.IEnumerable<LM.HubSpoke.Abstractions.ISpokeHandler!>! handlers, LM.Core.Abstractions.IDoiNormalizer! doiNormalizer, LM.Core.Abstractions.IPmidNormalizer! pmidNormalizer, LM.Core.Abstractions.IContentExtractor? contentExtractor = null) -> void
-LM.HubSpoke.Entries.HubSpokeStore.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-LM.HubSpoke.Entries.HubSpokeStore.SaveAsync(LM.Core.Models.Entry! entry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-LM.HubSpoke.Entries.HubSpokeStore.SearchAsync(LM.Core.Models.Filters.EntryFilter! filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
-LM.HubSpoke.Indexing.SimilarityLog
-LM.HubSpoke.Indexing.SimilarityLog.LogAsync(string! sessionId, string! stagedPath, string! candidateEntryId, double score, string! method, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-LM.HubSpoke.Indexing.SimilarityLog.NewSessionId() -> string!
-LM.HubSpoke.Indexing.SimilarityLog.SimilarityLog(LM.Core.Abstractions.IWorkSpaceService! ws) -> void
-LM.HubSpoke.Models.AbstractSection
-LM.HubSpoke.Models.AbstractSection.AbstractSection() -> void
-LM.HubSpoke.Models.AbstractSection.Label.get -> string?
-LM.HubSpoke.Models.AbstractSection.Label.init -> void
-LM.HubSpoke.Models.AbstractSection.Text.get -> string!
-LM.HubSpoke.Models.AbstractSection.Text.init -> void
-LM.HubSpoke.Models.Affiliation
-LM.HubSpoke.Models.Affiliation.Affiliation() -> void
-LM.HubSpoke.Models.Affiliation.Email.get -> string?
-LM.HubSpoke.Models.Affiliation.Email.init -> void
-LM.HubSpoke.Models.Affiliation.Text.get -> string!
-LM.HubSpoke.Models.Affiliation.Text.init -> void
-LM.HubSpoke.Models.AttachmentHook
-LM.HubSpoke.Models.AttachmentHook.AttachmentHook() -> void
-LM.HubSpoke.Models.AttachmentHook.Attachments.get -> System.Collections.Generic.List<LM.HubSpoke.Models.AttachmentHookItem!>!
-LM.HubSpoke.Models.AttachmentHook.Attachments.set -> void
-LM.HubSpoke.Models.AttachmentHook.SchemaVersion.get -> string!
-LM.HubSpoke.Models.AttachmentHook.SchemaVersion.init -> void
-LM.HubSpoke.Models.AttachmentHookItem
-LM.HubSpoke.Models.AttachmentHookItem.AddedBy.get -> string!
-LM.HubSpoke.Models.AttachmentHookItem.AddedBy.init -> void
-LM.HubSpoke.Models.AttachmentHookItem.AddedUtc.get -> System.DateTime
-LM.HubSpoke.Models.AttachmentHookItem.AddedUtc.init -> void
-LM.HubSpoke.Models.AttachmentHookItem.AttachmentHookItem() -> void
-LM.HubSpoke.Models.AttachmentHookItem.AttachmentId.get -> string!
-LM.HubSpoke.Models.AttachmentHookItem.AttachmentId.init -> void
-LM.HubSpoke.Models.AttachmentHookItem.LibraryPath.get -> string!
-LM.HubSpoke.Models.AttachmentHookItem.LibraryPath.init -> void
-LM.HubSpoke.Models.AttachmentHookItem.Notes.get -> string?
-LM.HubSpoke.Models.AttachmentHookItem.Notes.init -> void
-LM.HubSpoke.Models.AttachmentHookItem.Purpose.get -> LM.Core.Models.AttachmentKind
-LM.HubSpoke.Models.AttachmentHookItem.Purpose.init -> void
-LM.HubSpoke.Models.AttachmentHookItem.Tags.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.AttachmentHookItem.Tags.init -> void
-LM.HubSpoke.Models.AttachmentHookItem.Title.get -> string!
-LM.HubSpoke.Models.AttachmentHookItem.Title.init -> void
-LM.HubSpoke.Models.ArticleAbstract
-LM.HubSpoke.Models.ArticleAbstract.ArticleAbstract() -> void
-LM.HubSpoke.Models.ArticleAbstract.Sections.get -> System.Collections.Generic.List<LM.HubSpoke.Models.AbstractSection!>!
-LM.HubSpoke.Models.ArticleAbstract.Sections.init -> void
-LM.HubSpoke.Models.ArticleAbstract.Text.get -> string?
-LM.HubSpoke.Models.ArticleAbstract.Text.init -> void
-LM.HubSpoke.Models.ArticleAsset
-LM.HubSpoke.Models.ArticleAsset.ArticleAsset() -> void
-LM.HubSpoke.Models.ArticleAsset.Bytes.get -> long
-LM.HubSpoke.Models.ArticleAsset.Bytes.init -> void
-LM.HubSpoke.Models.ArticleAsset.ContentType.get -> string!
-LM.HubSpoke.Models.ArticleAsset.ContentType.init -> void
-LM.HubSpoke.Models.ArticleAsset.Hash.get -> string!
-LM.HubSpoke.Models.ArticleAsset.Hash.init -> void
-LM.HubSpoke.Models.ArticleAsset.OriginalFilename.get -> string?
-LM.HubSpoke.Models.ArticleAsset.OriginalFilename.init -> void
-LM.HubSpoke.Models.ArticleAsset.OriginalFolderPath.get -> string?
-LM.HubSpoke.Models.ArticleAsset.OriginalFolderPath.init -> void
-LM.HubSpoke.Models.ArticleAsset.Purpose.get -> LM.HubSpoke.Models.ArticleAssetPurpose
-LM.HubSpoke.Models.ArticleAsset.Purpose.init -> void
-LM.HubSpoke.Models.ArticleAsset.StoragePath.get -> string!
-LM.HubSpoke.Models.ArticleAsset.StoragePath.init -> void
-LM.HubSpoke.Models.ArticleAsset.Title.get -> string!
-LM.HubSpoke.Models.ArticleAsset.Title.init -> void
-LM.HubSpoke.Models.ArticleAssetPurpose
-LM.HubSpoke.Models.ArticleAssetPurpose.Manuscript = 0 -> LM.HubSpoke.Models.ArticleAssetPurpose
-LM.HubSpoke.Models.ArticleAssetPurpose.Supplement = 1 -> LM.HubSpoke.Models.ArticleAssetPurpose
-LM.HubSpoke.Models.ArticleDates
-LM.HubSpoke.Models.ArticleDates.Accepted.get -> System.DateTimeOffset?
-LM.HubSpoke.Models.ArticleDates.Accepted.init -> void
-LM.HubSpoke.Models.ArticleDates.ArticleDates() -> void
-LM.HubSpoke.Models.ArticleDates.Electronic.get -> System.DateTimeOffset?
-LM.HubSpoke.Models.ArticleDates.Electronic.init -> void
-LM.HubSpoke.Models.ArticleDates.Print.get -> System.DateTimeOffset?
-LM.HubSpoke.Models.ArticleDates.Print.init -> void
-LM.HubSpoke.Models.ArticleDates.Received.get -> System.DateTimeOffset?
-LM.HubSpoke.Models.ArticleDates.Received.init -> void
-LM.HubSpoke.Models.ArticleDates.Revised.get -> System.DateTimeOffset?
-LM.HubSpoke.Models.ArticleDates.Revised.init -> void
-LM.HubSpoke.Models.ArticleDetails
-LM.HubSpoke.Models.ArticleDetails.ArticleDetails() -> void
-LM.HubSpoke.Models.ArticleDetails.Dates.get -> LM.HubSpoke.Models.ArticleDates!
-LM.HubSpoke.Models.ArticleDetails.Dates.init -> void
-LM.HubSpoke.Models.ArticleDetails.Language.get -> string?
-LM.HubSpoke.Models.ArticleDetails.Language.init -> void
-LM.HubSpoke.Models.ArticleDetails.Pagination.get -> LM.HubSpoke.Models.Pagination!
-LM.HubSpoke.Models.ArticleDetails.Pagination.init -> void
-LM.HubSpoke.Models.ArticleDetails.PublicationTypes.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.ArticleDetails.PublicationTypes.init -> void
-LM.HubSpoke.Models.ArticleDetails.Status.get -> LM.HubSpoke.Models.PubStatus
-LM.HubSpoke.Models.ArticleDetails.Status.init -> void
-LM.HubSpoke.Models.ArticleDetails.Title.get -> string!
-LM.HubSpoke.Models.ArticleDetails.Title.init -> void
-LM.HubSpoke.Models.ArticleHook
-LM.HubSpoke.Models.ArticleHook.Abstract.get -> LM.HubSpoke.Models.ArticleAbstract?
-LM.HubSpoke.Models.ArticleHook.Abstract.init -> void
-LM.HubSpoke.Models.ArticleHook.Article.get -> LM.HubSpoke.Models.ArticleDetails!
-LM.HubSpoke.Models.ArticleHook.Article.init -> void
-LM.HubSpoke.Models.ArticleHook.ArticleHook() -> void
-LM.HubSpoke.Models.ArticleHook.Assets.get -> System.Collections.Generic.List<LM.HubSpoke.Models.ArticleAsset!>!
-LM.HubSpoke.Models.ArticleHook.Assets.init -> void
-LM.HubSpoke.Models.ArticleHook.Authors.get -> System.Collections.Generic.List<LM.HubSpoke.Models.Author!>!
-LM.HubSpoke.Models.ArticleHook.Authors.init -> void
-LM.HubSpoke.Models.ArticleHook.Chemicals.get -> System.Collections.Generic.List<LM.HubSpoke.Models.Chemical!>!
-LM.HubSpoke.Models.ArticleHook.Chemicals.init -> void
-LM.HubSpoke.Models.ArticleHook.ConflictOfInterest.get -> string?
-LM.HubSpoke.Models.ArticleHook.ConflictOfInterest.init -> void
-LM.HubSpoke.Models.ArticleHook.Copyright.get -> string?
-LM.HubSpoke.Models.ArticleHook.Copyright.init -> void
-LM.HubSpoke.Models.ArticleHook.Grants.get -> System.Collections.Generic.List<LM.HubSpoke.Models.Grant!>!
-LM.HubSpoke.Models.ArticleHook.Grants.init -> void
-LM.HubSpoke.Models.ArticleHook.History.get -> LM.HubSpoke.Models.PublicationHistory!
-LM.HubSpoke.Models.ArticleHook.History.init -> void
-LM.HubSpoke.Models.ArticleHook.Identifier.get -> LM.HubSpoke.Models.ArticleIdentifier!
-LM.HubSpoke.Models.ArticleHook.Identifier.init -> void
-LM.HubSpoke.Models.ArticleHook.Journal.get -> LM.HubSpoke.Models.JournalInfo!
-LM.HubSpoke.Models.ArticleHook.Journal.init -> void
-LM.HubSpoke.Models.ArticleHook.Keywords.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.ArticleHook.Keywords.init -> void
-LM.HubSpoke.Models.ArticleHook.Medline.get -> LM.HubSpoke.Models.MedlineInfo!
-LM.HubSpoke.Models.ArticleHook.Medline.init -> void
-LM.HubSpoke.Models.ArticleHook.MeshHeadings.get -> System.Collections.Generic.List<LM.HubSpoke.Models.MeshHeading!>!
-LM.HubSpoke.Models.ArticleHook.MeshHeadings.init -> void
-LM.HubSpoke.Models.ArticleHook.References.get -> System.Collections.Generic.List<LM.HubSpoke.Models.Citation!>!
-LM.HubSpoke.Models.ArticleHook.References.init -> void
-LM.HubSpoke.Models.ArticleHook.SchemaVersion.get -> string!
-LM.HubSpoke.Models.ArticleHook.SchemaVersion.init -> void
-LM.HubSpoke.Models.ArticleIdentifier
-LM.HubSpoke.Models.ArticleIdentifier.ArticleIdentifier() -> void
-LM.HubSpoke.Models.ArticleIdentifier.DOI.get -> string?
-LM.HubSpoke.Models.ArticleIdentifier.DOI.init -> void
-LM.HubSpoke.Models.ArticleIdentifier.OtherIds.get -> System.Collections.Generic.Dictionary<string!, string!>!
-LM.HubSpoke.Models.ArticleIdentifier.OtherIds.init -> void
-LM.HubSpoke.Models.ArticleIdentifier.PII.get -> string?
-LM.HubSpoke.Models.ArticleIdentifier.PII.init -> void
-LM.HubSpoke.Models.ArticleIdentifier.PMCID.get -> string?
-LM.HubSpoke.Models.ArticleIdentifier.PMCID.init -> void
-LM.HubSpoke.Models.ArticleIdentifier.PMID.get -> string!
-LM.HubSpoke.Models.ArticleIdentifier.PMID.init -> void
-LM.HubSpoke.Models.AssetRef
-LM.HubSpoke.Models.AssetRef.AssetRef() -> void
-LM.HubSpoke.Models.AssetRef.Bytes.get -> long
-LM.HubSpoke.Models.AssetRef.Bytes.init -> void
-LM.HubSpoke.Models.AssetRef.ContentType.get -> string!
-LM.HubSpoke.Models.AssetRef.ContentType.init -> void
-LM.HubSpoke.Models.AssetRef.Hash.get -> string!
-LM.HubSpoke.Models.AssetRef.Hash.init -> void
-LM.HubSpoke.Models.AssetRef.OriginalFilename.get -> string?
-LM.HubSpoke.Models.AssetRef.OriginalFilename.init -> void
-LM.HubSpoke.Models.AssetRef.Role.get -> string!
-LM.HubSpoke.Models.AssetRef.Role.init -> void
-LM.HubSpoke.Models.AssetRef.StoragePath.get -> string!
-LM.HubSpoke.Models.AssetRef.StoragePath.init -> void
-LM.HubSpoke.Models.Author
-LM.HubSpoke.Models.Author.Affiliations.get -> System.Collections.Generic.List<LM.HubSpoke.Models.Affiliation!>!
-LM.HubSpoke.Models.Author.Affiliations.init -> void
-LM.HubSpoke.Models.Author.Author() -> void
-LM.HubSpoke.Models.Author.ForeName.get -> string?
-LM.HubSpoke.Models.Author.ForeName.init -> void
-LM.HubSpoke.Models.Author.Initials.get -> string?
-LM.HubSpoke.Models.Author.Initials.init -> void
-LM.HubSpoke.Models.Author.LastName.get -> string?
-LM.HubSpoke.Models.Author.LastName.init -> void
-LM.HubSpoke.Models.Author.ORCID.get -> string?
-LM.HubSpoke.Models.Author.ORCID.init -> void
-LM.HubSpoke.Models.ChangeLogAttachmentDetails
-LM.HubSpoke.Models.ChangeLogAttachmentDetails.AttachmentId.get -> string!
-LM.HubSpoke.Models.ChangeLogAttachmentDetails.AttachmentId.init -> void
-LM.HubSpoke.Models.ChangeLogAttachmentDetails.ChangeLogAttachmentDetails() -> void
-LM.HubSpoke.Models.ChangeLogAttachmentDetails.LibraryPath.get -> string!
-LM.HubSpoke.Models.ChangeLogAttachmentDetails.LibraryPath.init -> void
-LM.HubSpoke.Models.ChangeLogAttachmentDetails.Purpose.get -> LM.Core.Models.AttachmentKind
-LM.HubSpoke.Models.ChangeLogAttachmentDetails.Purpose.init -> void
-LM.HubSpoke.Models.ChangeLogAttachmentDetails.Tags.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.ChangeLogAttachmentDetails.Tags.init -> void
-LM.HubSpoke.Models.ChangeLogAttachmentDetails.Title.get -> string!
-LM.HubSpoke.Models.ChangeLogAttachmentDetails.Title.init -> void
-LM.HubSpoke.Models.Chemical
-LM.HubSpoke.Models.Chemical.Chemical() -> void
-LM.HubSpoke.Models.Chemical.Name.get -> string!
-LM.HubSpoke.Models.Chemical.Name.init -> void
-LM.HubSpoke.Models.Chemical.RegistryNumber.get -> string?
-LM.HubSpoke.Models.Chemical.RegistryNumber.init -> void
-LM.HubSpoke.Models.Citation
-LM.HubSpoke.Models.Citation.Citation() -> void
-LM.HubSpoke.Models.Citation.DOI.get -> string?
-LM.HubSpoke.Models.Citation.DOI.init -> void
-LM.HubSpoke.Models.Citation.PMID.get -> string?
-LM.HubSpoke.Models.Citation.PMID.init -> void
-LM.HubSpoke.Models.Citation.Text.get -> string!
-LM.HubSpoke.Models.Citation.Text.init -> void
-LM.HubSpoke.Models.CreationMethod
-LM.HubSpoke.Models.CreationMethod.Manual = 0 -> LM.HubSpoke.Models.CreationMethod
-LM.HubSpoke.Models.CreationMethod.Search = 1 -> LM.HubSpoke.Models.CreationMethod
-LM.HubSpoke.Models.DocumentHook
-LM.HubSpoke.Models.DocumentHook.Assets.get -> System.Collections.Generic.IReadOnlyList<LM.HubSpoke.Models.AssetRef!>!
-LM.HubSpoke.Models.DocumentHook.Assets.init -> void
-LM.HubSpoke.Models.DocumentHook.Description.get -> string?
-LM.HubSpoke.Models.DocumentHook.Description.init -> void
-LM.HubSpoke.Models.DocumentHook.DocumentHook() -> void
-LM.HubSpoke.Models.DocumentHook.DocumentType.get -> LM.HubSpoke.Models.DocumentType
-LM.HubSpoke.Models.DocumentHook.DocumentType.init -> void
-LM.HubSpoke.Models.DocumentHook.EffectiveUtc.get -> System.DateTime?
-LM.HubSpoke.Models.DocumentHook.EffectiveUtc.init -> void
-LM.HubSpoke.Models.DocumentHook.ExpiresUtc.get -> System.DateTime?
-LM.HubSpoke.Models.DocumentHook.ExpiresUtc.init -> void
-LM.HubSpoke.Models.DocumentHook.Owner.get -> string?
-LM.HubSpoke.Models.DocumentHook.Owner.init -> void
-LM.HubSpoke.Models.DocumentHook.SchemaVersion.get -> string!
-LM.HubSpoke.Models.DocumentHook.SchemaVersion.init -> void
-LM.HubSpoke.Models.DocumentHook.Title.get -> string?
-LM.HubSpoke.Models.DocumentHook.Title.init -> void
-LM.HubSpoke.Models.DocumentHook.Version.get -> string?
-LM.HubSpoke.Models.DocumentHook.Version.init -> void
-LM.HubSpoke.Models.DocumentType
-LM.HubSpoke.Models.DocumentType.MarketingMaterial = 1 -> LM.HubSpoke.Models.DocumentType
-LM.HubSpoke.Models.DocumentType.Other = 6 -> LM.HubSpoke.Models.DocumentType
-LM.HubSpoke.Models.DocumentType.Poster = 5 -> LM.HubSpoke.Models.DocumentType
-LM.HubSpoke.Models.DocumentType.Presentation = 0 -> LM.HubSpoke.Models.DocumentType
-LM.HubSpoke.Models.DocumentType.Report = 2 -> LM.HubSpoke.Models.DocumentType
-LM.HubSpoke.Models.DocumentType.StandardOperatingProcedure = 3 -> LM.HubSpoke.Models.DocumentType
-LM.HubSpoke.Models.DocumentType.Whitepaper = 4 -> LM.HubSpoke.Models.DocumentType
-LM.HubSpoke.Models.EntryChangeLogEvent
-LM.HubSpoke.Models.EntryChangeLogEvent.Action.get -> string!
-LM.HubSpoke.Models.EntryChangeLogEvent.Action.init -> void
-LM.HubSpoke.Models.EntryChangeLogEvent.Details.get -> LM.HubSpoke.Models.ChangeLogAttachmentDetails?
-LM.HubSpoke.Models.EntryChangeLogEvent.Details.init -> void
-LM.HubSpoke.Models.EntryChangeLogEvent.EntryChangeLogEvent() -> void
-LM.HubSpoke.Models.EntryChangeLogEvent.EventId.get -> string!
-LM.HubSpoke.Models.EntryChangeLogEvent.EventId.init -> void
-LM.HubSpoke.Models.EntryChangeLogEvent.PerformedBy.get -> string!
-LM.HubSpoke.Models.EntryChangeLogEvent.PerformedBy.init -> void
-LM.HubSpoke.Models.EntryChangeLogEvent.TimestampUtc.get -> System.DateTime
-LM.HubSpoke.Models.EntryChangeLogEvent.TimestampUtc.init -> void
-LM.HubSpoke.Models.EntryChangeLogHook
-LM.HubSpoke.Models.EntryChangeLogHook.EntryChangeLogHook() -> void
-LM.HubSpoke.Models.EntryChangeLogHook.Events.get -> System.Collections.Generic.List<LM.HubSpoke.Models.EntryChangeLogEvent!>!
-LM.HubSpoke.Models.EntryChangeLogHook.Events.set -> void
-LM.HubSpoke.Models.EntryChangeLogHook.SchemaVersion.get -> string!
-LM.HubSpoke.Models.EntryChangeLogHook.SchemaVersion.init -> void
-LM.HubSpoke.Models.EntryHooks
-LM.HubSpoke.Models.EntryHooks.Article.get -> string?
-LM.HubSpoke.Models.EntryHooks.Article.init -> void
-LM.HubSpoke.Models.EntryHooks.LitSearch.get -> string?
-LM.HubSpoke.Models.EntryHooks.LitSearch.init -> void
-LM.HubSpoke.Models.EntryHooks.DataExtraction.get -> string?
-LM.HubSpoke.Models.EntryHooks.DataExtraction.init -> void
-LM.HubSpoke.Models.EntryHooks.Document.get -> string?
-LM.HubSpoke.Models.EntryHooks.Document.init -> void
-LM.HubSpoke.Models.EntryHooks.EntryHooks() -> void
-LM.HubSpoke.Models.EntryHooks.History.get -> string?
-LM.HubSpoke.Models.EntryHooks.History.init -> void
-LM.HubSpoke.Models.EntryHooks.Notes.get -> string?
-LM.HubSpoke.Models.EntryHooks.Notes.init -> void
-LM.HubSpoke.Models.EntryHooks.Provenance.get -> string?
-LM.HubSpoke.Models.EntryHooks.Provenance.init -> void
-LM.HubSpoke.Models.EntryHooks.Relations.get -> string?
-LM.HubSpoke.Models.EntryHooks.Relations.init -> void
-LM.HubSpoke.Models.EntryHooks.SearchHits.get -> string?
-LM.HubSpoke.Models.EntryHooks.SearchHits.init -> void
-LM.HubSpoke.Models.EntryHooks.Trial.get -> string?
-LM.HubSpoke.Models.EntryHooks.Trial.init -> void
-LM.HubSpoke.Models.DataExtractionArtifact
-LM.HubSpoke.Models.DataExtractionArtifact.DataExtractionArtifact() -> void
-LM.HubSpoke.Models.DataExtractionArtifact.Caption.get -> string?
-LM.HubSpoke.Models.DataExtractionArtifact.Caption.init -> void
-LM.HubSpoke.Models.DataExtractionArtifact.Id.get -> string!
-LM.HubSpoke.Models.DataExtractionArtifact.Id.init -> void
-LM.HubSpoke.Models.DataExtractionArtifact.LinkedEndpointIds.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.DataExtractionArtifact.LinkedEndpointIds.init -> void
-LM.HubSpoke.Models.DataExtractionArtifact.LinkedInterventionIds.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.DataExtractionArtifact.LinkedInterventionIds.init -> void
-LM.HubSpoke.Models.DataExtractionArtifact.Notes.get -> string?
-LM.HubSpoke.Models.DataExtractionArtifact.Notes.init -> void
-LM.HubSpoke.Models.DataExtractionArtifact.Pages.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.DataExtractionArtifact.Pages.init -> void
-LM.HubSpoke.Models.DataExtractionArtifact.ProvenanceHash.get -> string!
-LM.HubSpoke.Models.DataExtractionArtifact.ProvenanceHash.init -> void
-LM.HubSpoke.Models.DataExtractionArtifact.Regions.get -> System.Collections.Generic.List<LM.HubSpoke.Models.DataExtractionRegion!>!
-LM.HubSpoke.Models.DataExtractionArtifact.Regions.init -> void
-LM.HubSpoke.Models.DataExtractionArtifact.SourcePath.get -> string?
-LM.HubSpoke.Models.DataExtractionArtifact.SourcePath.init -> void
-LM.HubSpoke.Models.DataExtractionArtifact.Tags.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.DataExtractionArtifact.Tags.init -> void
-LM.HubSpoke.Models.DataExtractionArtifact.Title.get -> string!
-LM.HubSpoke.Models.DataExtractionArtifact.Title.init -> void
-LM.HubSpoke.Models.DataExtractionPagePosition
-LM.HubSpoke.Models.DataExtractionPagePosition.DataExtractionPagePosition() -> void
-LM.HubSpoke.Models.DataExtractionPagePosition.Height.get -> double
-LM.HubSpoke.Models.DataExtractionPagePosition.Height.init -> void
-LM.HubSpoke.Models.DataExtractionPagePosition.Left.get -> double
-LM.HubSpoke.Models.DataExtractionPagePosition.Left.init -> void
-LM.HubSpoke.Models.DataExtractionPagePosition.PageHeight.get -> double
-LM.HubSpoke.Models.DataExtractionPagePosition.PageHeight.init -> void
-LM.HubSpoke.Models.DataExtractionPagePosition.PageNumber.get -> int
-LM.HubSpoke.Models.DataExtractionPagePosition.PageNumber.init -> void
-LM.HubSpoke.Models.DataExtractionPagePosition.PageWidth.get -> double
-LM.HubSpoke.Models.DataExtractionPagePosition.PageWidth.init -> void
-LM.HubSpoke.Models.DataExtractionPagePosition.Top.get -> double
-LM.HubSpoke.Models.DataExtractionPagePosition.Top.init -> void
-LM.HubSpoke.Models.DataExtractionPagePosition.Width.get -> double
-LM.HubSpoke.Models.DataExtractionPagePosition.Width.init -> void
-LM.HubSpoke.Models.DataExtractionFigure
-LM.HubSpoke.Models.DataExtractionFigure.DataExtractionFigure() -> void
-LM.HubSpoke.Models.DataExtractionFigure.FigureLabel.get -> string?
-LM.HubSpoke.Models.DataExtractionFigure.FigureLabel.init -> void
-LM.HubSpoke.Models.DataExtractionFigure.ThumbnailPath.get -> string?
-LM.HubSpoke.Models.DataExtractionFigure.ThumbnailPath.init -> void
-LM.HubSpoke.Models.DataExtractionFigure.ImagePath.get -> string?
-LM.HubSpoke.Models.DataExtractionFigure.ImagePath.init -> void
-LM.HubSpoke.Models.DataExtractionRegion
-LM.HubSpoke.Models.DataExtractionRegion.DataExtractionRegion() -> void
-LM.HubSpoke.Models.DataExtractionRegion.Height.get -> double
-LM.HubSpoke.Models.DataExtractionRegion.Height.init -> void
-LM.HubSpoke.Models.DataExtractionRegion.Label.get -> string?
-LM.HubSpoke.Models.DataExtractionRegion.Label.init -> void
-LM.HubSpoke.Models.DataExtractionRegion.PageNumber.get -> int
-LM.HubSpoke.Models.DataExtractionRegion.PageNumber.init -> void
-LM.HubSpoke.Models.DataExtractionRegion.Width.get -> double
-LM.HubSpoke.Models.DataExtractionRegion.Width.init -> void
-LM.HubSpoke.Models.DataExtractionRegion.X.get -> double
-LM.HubSpoke.Models.DataExtractionRegion.X.init -> void
-LM.HubSpoke.Models.DataExtractionRegion.Y.get -> double
-LM.HubSpoke.Models.DataExtractionRegion.Y.init -> void
-LM.HubSpoke.Models.DataExtractionHook
-LM.HubSpoke.Models.DataExtractionHook.DataExtractionHook() -> void
-LM.HubSpoke.Models.DataExtractionHook.Endpoints.get -> System.Collections.Generic.List<LM.HubSpoke.Models.DataExtractionEndpoint!>!
-LM.HubSpoke.Models.DataExtractionHook.Endpoints.init -> void
-LM.HubSpoke.Models.DataExtractionHook.ExtractedAtUtc.get -> System.DateTime
-LM.HubSpoke.Models.DataExtractionHook.ExtractedAtUtc.init -> void
-LM.HubSpoke.Models.DataExtractionHook.ExtractedBy.get -> string!
-LM.HubSpoke.Models.DataExtractionHook.ExtractedBy.init -> void
-LM.HubSpoke.Models.DataExtractionHook.Figures.get -> System.Collections.Generic.List<LM.HubSpoke.Models.DataExtractionFigure!>!
-LM.HubSpoke.Models.DataExtractionHook.Figures.init -> void
-LM.HubSpoke.Models.DataExtractionHook.GeographyScope.get -> string?
-LM.HubSpoke.Models.DataExtractionHook.GeographyScope.init -> void
-LM.HubSpoke.Models.DataExtractionHook.Interventions.get -> System.Collections.Generic.List<LM.HubSpoke.Models.DataExtractionIntervention!>!
-LM.HubSpoke.Models.DataExtractionHook.Interventions.init -> void
-LM.HubSpoke.Models.DataExtractionHook.Notes.get -> string?
-LM.HubSpoke.Models.DataExtractionHook.Notes.init -> void
-LM.HubSpoke.Models.DataExtractionHook.IsCohortStudy.get -> bool?
-LM.HubSpoke.Models.DataExtractionHook.IsCohortStudy.init -> void
-LM.HubSpoke.Models.DataExtractionHook.IsRegistryStudy.get -> bool?
-LM.HubSpoke.Models.DataExtractionHook.IsRegistryStudy.init -> void
-LM.HubSpoke.Models.DataExtractionHook.StudyDesign.get -> string?
-LM.HubSpoke.Models.DataExtractionHook.StudyDesign.init -> void
-LM.HubSpoke.Models.DataExtractionHook.StudySetting.get -> string?
-LM.HubSpoke.Models.DataExtractionHook.StudySetting.init -> void
-LM.HubSpoke.Models.DataExtractionHook.Populations.get -> System.Collections.Generic.List<LM.HubSpoke.Models.DataExtractionPopulation!>!
-LM.HubSpoke.Models.DataExtractionHook.Populations.init -> void
-LM.HubSpoke.Models.DataExtractionHook.SchemaVersion.get -> string!
-LM.HubSpoke.Models.DataExtractionHook.SchemaVersion.init -> void
-LM.HubSpoke.Models.DataExtractionHook.SiteCount.get -> int?
-LM.HubSpoke.Models.DataExtractionHook.SiteCount.init -> void
-LM.HubSpoke.Models.DataExtractionHook.Tables.get -> System.Collections.Generic.List<LM.HubSpoke.Models.DataExtractionTable!>!
-LM.HubSpoke.Models.DataExtractionHook.Tables.init -> void
-LM.HubSpoke.Models.DataExtractionHook.TrialClassification.get -> string?
-LM.HubSpoke.Models.DataExtractionHook.TrialClassification.init -> void
-LM.HubSpoke.Models.DataExtractionIntervention
-LM.HubSpoke.Models.DataExtractionIntervention.DataExtractionIntervention() -> void
-LM.HubSpoke.Models.DataExtractionIntervention.Description.get -> string?
-LM.HubSpoke.Models.DataExtractionIntervention.Description.init -> void
-LM.HubSpoke.Models.DataExtractionIntervention.Dosage.get -> string?
-LM.HubSpoke.Models.DataExtractionIntervention.Dosage.init -> void
-LM.HubSpoke.Models.DataExtractionIntervention.Id.get -> string!
-LM.HubSpoke.Models.DataExtractionIntervention.Id.init -> void
-LM.HubSpoke.Models.DataExtractionIntervention.Name.get -> string!
-LM.HubSpoke.Models.DataExtractionIntervention.Name.init -> void
-LM.HubSpoke.Models.DataExtractionIntervention.Notes.get -> string?
-LM.HubSpoke.Models.DataExtractionIntervention.Notes.init -> void
-LM.HubSpoke.Models.DataExtractionIntervention.PopulationIds.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.DataExtractionIntervention.PopulationIds.init -> void
-LM.HubSpoke.Models.DataExtractionIntervention.Comparator.get -> string?
-LM.HubSpoke.Models.DataExtractionIntervention.Comparator.init -> void
-LM.HubSpoke.Models.DataExtractionIntervention.Type.get -> string?
-LM.HubSpoke.Models.DataExtractionIntervention.Type.init -> void
-LM.HubSpoke.Models.DataExtractionEndpoint
-LM.HubSpoke.Models.DataExtractionEndpoint.DataExtractionEndpoint() -> void
-LM.HubSpoke.Models.DataExtractionEndpoint.Description.get -> string?
-LM.HubSpoke.Models.DataExtractionEndpoint.Description.init -> void
-LM.HubSpoke.Models.DataExtractionEndpoint.EffectSize.get -> string?
-LM.HubSpoke.Models.DataExtractionEndpoint.EffectSize.init -> void
-LM.HubSpoke.Models.DataExtractionEndpoint.Id.get -> string!
-LM.HubSpoke.Models.DataExtractionEndpoint.Id.init -> void
-LM.HubSpoke.Models.DataExtractionEndpoint.InterventionIds.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.DataExtractionEndpoint.InterventionIds.init -> void
-LM.HubSpoke.Models.DataExtractionEndpoint.Measure.get -> string?
-LM.HubSpoke.Models.DataExtractionEndpoint.Measure.init -> void
-LM.HubSpoke.Models.DataExtractionEndpoint.Name.get -> string!
-LM.HubSpoke.Models.DataExtractionEndpoint.Name.init -> void
-LM.HubSpoke.Models.DataExtractionEndpoint.Notes.get -> string?
-LM.HubSpoke.Models.DataExtractionEndpoint.Notes.init -> void
-LM.HubSpoke.Models.DataExtractionEndpoint.PopulationIds.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.DataExtractionEndpoint.PopulationIds.init -> void
-LM.HubSpoke.Models.DataExtractionEndpoint.ResultSummary.get -> string?
-LM.HubSpoke.Models.DataExtractionEndpoint.ResultSummary.init -> void
-LM.HubSpoke.Models.DataExtractionEndpoint.Timepoint.get -> string?
-LM.HubSpoke.Models.DataExtractionEndpoint.Timepoint.init -> void
-LM.HubSpoke.Models.DataExtractionEndpoint.Confirmed.get -> bool
-LM.HubSpoke.Models.DataExtractionEndpoint.Confirmed.init -> void
-LM.HubSpoke.Models.DataExtractionPopulation
-LM.HubSpoke.Models.DataExtractionPopulation.DataExtractionPopulation() -> void
-LM.HubSpoke.Models.DataExtractionPopulation.Description.get -> string?
-LM.HubSpoke.Models.DataExtractionPopulation.Description.init -> void
-LM.HubSpoke.Models.DataExtractionPopulation.ExclusionCriteria.get -> string?
-LM.HubSpoke.Models.DataExtractionPopulation.ExclusionCriteria.init -> void
-LM.HubSpoke.Models.DataExtractionPopulation.Id.get -> string!
-LM.HubSpoke.Models.DataExtractionPopulation.Id.init -> void
-LM.HubSpoke.Models.DataExtractionPopulation.InclusionCriteria.get -> string?
-LM.HubSpoke.Models.DataExtractionPopulation.InclusionCriteria.init -> void
-LM.HubSpoke.Models.DataExtractionPopulation.Label.get -> string!
-LM.HubSpoke.Models.DataExtractionPopulation.Label.init -> void
-LM.HubSpoke.Models.DataExtractionPopulation.Notes.get -> string?
-LM.HubSpoke.Models.DataExtractionPopulation.Notes.init -> void
-LM.HubSpoke.Models.DataExtractionPopulation.SampleSize.get -> int?
-LM.HubSpoke.Models.DataExtractionPopulation.SampleSize.init -> void
-LM.HubSpoke.Models.DataExtractionTable
-LM.HubSpoke.Models.DataExtractionTable.DataExtractionTable() -> void
-LM.HubSpoke.Models.DataExtractionTable.Summary.get -> string?
-LM.HubSpoke.Models.DataExtractionTable.Summary.init -> void
-LM.HubSpoke.Models.DataExtractionTable.TableLabel.get -> string?
-LM.HubSpoke.Models.DataExtractionTable.TableLabel.init -> void
-LM.HubSpoke.Models.DataExtractionTable.ColumnCountHint.get -> int?
-LM.HubSpoke.Models.DataExtractionTable.ColumnCountHint.init -> void
-LM.HubSpoke.Models.DataExtractionTable.DictionaryPath.get -> string?
-LM.HubSpoke.Models.DataExtractionTable.DictionaryPath.init -> void
-LM.HubSpoke.Models.DataExtractionTable.FriendlyName.get -> string?
-LM.HubSpoke.Models.DataExtractionTable.FriendlyName.init -> void
-LM.HubSpoke.Models.DataExtractionTable.ImagePath.get -> string?
-LM.HubSpoke.Models.DataExtractionTable.ImagePath.init -> void
-LM.HubSpoke.Models.DataExtractionTable.ImageProvenanceHash.get -> string?
-LM.HubSpoke.Models.DataExtractionTable.ImageProvenanceHash.init -> void
-LM.HubSpoke.Models.DataExtractionTable.PagePositions.get -> System.Collections.Generic.List<LM.HubSpoke.Models.DataExtractionPagePosition!>!
-LM.HubSpoke.Models.DataExtractionTable.PagePositions.init -> void
-LM.HubSpoke.Models.EntryHub
-LM.HubSpoke.Models.EntryHub.ConcurrencyStamp.get -> string!
-LM.HubSpoke.Models.EntryHub.ConcurrencyStamp.init -> void
-LM.HubSpoke.Models.EntryHub.CreatedBy.get -> LM.HubSpoke.Models.PersonRef
-LM.HubSpoke.Models.EntryHub.CreatedBy.init -> void
-LM.HubSpoke.Models.EntryHub.CreatedUtc.get -> System.DateTime
-LM.HubSpoke.Models.EntryHub.CreatedUtc.init -> void
-LM.HubSpoke.Models.EntryHub.CreationMethod.get -> LM.HubSpoke.Models.CreationMethod
-LM.HubSpoke.Models.EntryHub.CreationMethod.init -> void
-LM.HubSpoke.Models.EntryHub.DisplayTitle.get -> string!
-LM.HubSpoke.Models.EntryHub.DisplayTitle.init -> void
-LM.HubSpoke.Models.EntryHub.EntryHub() -> void
-LM.HubSpoke.Models.EntryHub.EntryId.get -> string!
-LM.HubSpoke.Models.EntryHub.EntryId.init -> void
-LM.HubSpoke.Models.EntryHub.Flags.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.HubSpoke.Models.EntryHub.Flags.init -> void
-LM.HubSpoke.Models.EntryHub.Hooks.get -> LM.HubSpoke.Models.EntryHooks!
-LM.HubSpoke.Models.EntryHub.Hooks.init -> void
-LM.HubSpoke.Models.EntryHub.LastActivityUtc.get -> System.DateTime?
-LM.HubSpoke.Models.EntryHub.LastActivityUtc.init -> void
-LM.HubSpoke.Models.EntryHub.Origin.get -> LM.HubSpoke.Models.EntryOrigin
-LM.HubSpoke.Models.EntryHub.Origin.init -> void
-LM.HubSpoke.Models.EntryHub.PrimaryPurpose.get -> LM.HubSpoke.Models.EntryPurpose
-LM.HubSpoke.Models.EntryHub.PrimaryPurpose.init -> void
-LM.HubSpoke.Models.EntryHub.PrimaryPurposeSource.get -> LM.HubSpoke.Models.PurposeSource
-LM.HubSpoke.Models.EntryHub.PrimaryPurposeSource.init -> void
-LM.HubSpoke.Models.EntryHub.RelationsSummary.get -> LM.HubSpoke.Models.EntryRelationsSummary?
-LM.HubSpoke.Models.EntryHub.RelationsSummary.init -> void
-LM.HubSpoke.Models.EntryHub.SchemaVersion.get -> string!
-LM.HubSpoke.Models.EntryHub.SchemaVersion.init -> void
-LM.HubSpoke.Models.EntryHub.Tags.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.HubSpoke.Models.EntryHub.Tags.init -> void
-LM.HubSpoke.Models.EntryHub.UpdatedBy.get -> LM.HubSpoke.Models.PersonRef
-LM.HubSpoke.Models.EntryHub.UpdatedBy.init -> void
-LM.HubSpoke.Models.EntryHub.UpdatedUtc.get -> System.DateTime
-LM.HubSpoke.Models.EntryHub.UpdatedUtc.init -> void
-LM.HubSpoke.Models.EntryNotesHook
-LM.HubSpoke.Models.EntryNotesHook.EntryNotesHook() -> void
-LM.HubSpoke.Models.EntryNotesHook.SchemaVersion.get -> string!
-LM.HubSpoke.Models.EntryNotesHook.SchemaVersion.init -> void
-LM.HubSpoke.Models.EntryNotesHook.Summary.get -> LM.HubSpoke.Models.EntryNotesSummary?
-LM.HubSpoke.Models.EntryNotesHook.Summary.init -> void
-LM.HubSpoke.Models.EntryNotesHook.SummaryText.get -> string?
-LM.HubSpoke.Models.EntryNotesHook.UpdatedUtc.get -> System.DateTime
-LM.HubSpoke.Models.EntryNotesHook.UpdatedUtc.init -> void
-LM.HubSpoke.Models.EntryNotesHook.UserNotes.get -> string?
-LM.HubSpoke.Models.EntryNotesHook.UserNotes.init -> void
-LM.HubSpoke.Models.EntryNotesSummary
-LM.HubSpoke.Models.EntryNotesSummary.EntryNotesSummary() -> void
-LM.HubSpoke.Models.EntryNotesSummary.GetRenderedText() -> string?
-LM.HubSpoke.Models.EntryNotesSummary.LitSearch.get -> LM.HubSpoke.Models.LitSearchNoteSummary?
-LM.HubSpoke.Models.EntryNotesSummary.LitSearch.init -> void
-LM.HubSpoke.Models.EntryNotesSummary.RawText.get -> string?
-LM.HubSpoke.Models.EntryNotesSummary.RawText.init -> void
-LM.HubSpoke.Models.EntryNotesSummary.Rendered.get -> string?
-LM.HubSpoke.Models.EntryNotesSummary.Rendered.init -> void
-LM.HubSpoke.Models.LitSearchNoteRunSummary
-LM.HubSpoke.Models.LitSearchNoteRunSummary.ExecutedBy.get -> string?
-LM.HubSpoke.Models.LitSearchNoteRunSummary.ExecutedBy.init -> void
-LM.HubSpoke.Models.LitSearchNoteRunSummary.From.get -> System.DateTime?
-LM.HubSpoke.Models.LitSearchNoteRunSummary.From.init -> void
-LM.HubSpoke.Models.LitSearchNoteRunSummary.LitSearchNoteRunSummary() -> void
-LM.HubSpoke.Models.LitSearchNoteRunSummary.RunId.get -> string!
-LM.HubSpoke.Models.LitSearchNoteRunSummary.RunId.init -> void
-LM.HubSpoke.Models.LitSearchNoteRunSummary.RunUtc.get -> System.DateTime
-LM.HubSpoke.Models.LitSearchNoteRunSummary.RunUtc.init -> void
-LM.HubSpoke.Models.LitSearchNoteRunSummary.To.get -> System.DateTime?
-LM.HubSpoke.Models.LitSearchNoteRunSummary.To.init -> void
-LM.HubSpoke.Models.LitSearchNoteRunSummary.TotalHits.get -> int
-LM.HubSpoke.Models.LitSearchNoteRunSummary.TotalHits.init -> void
-LM.HubSpoke.Models.LitSearchNoteSummary
-LM.HubSpoke.Models.LitSearchNoteSummary.CreatedBy.get -> string?
-LM.HubSpoke.Models.LitSearchNoteSummary.CreatedBy.init -> void
-LM.HubSpoke.Models.LitSearchNoteSummary.CreatedUtc.get -> System.DateTime
-LM.HubSpoke.Models.LitSearchNoteSummary.CreatedUtc.init -> void
-LM.HubSpoke.Models.LitSearchNoteSummary.DerivedFromEntryId.get -> string?
-LM.HubSpoke.Models.LitSearchNoteSummary.DerivedFromEntryId.init -> void
-LM.HubSpoke.Models.LitSearchNoteSummary.LatestRun.get -> LM.HubSpoke.Models.LitSearchNoteRunSummary?
-LM.HubSpoke.Models.LitSearchNoteSummary.LatestRun.init -> void
-LM.HubSpoke.Models.LitSearchNoteSummary.LitSearchNoteSummary() -> void
-LM.HubSpoke.Models.LitSearchNoteSummary.Provider.get -> string!
-LM.HubSpoke.Models.LitSearchNoteSummary.Provider.init -> void
-LM.HubSpoke.Models.LitSearchNoteSummary.Query.get -> string!
-LM.HubSpoke.Models.LitSearchNoteSummary.Query.init -> void
-LM.HubSpoke.Models.LitSearchNoteSummary.RunCount.get -> int
-LM.HubSpoke.Models.LitSearchNoteSummary.RunCount.init -> void
-LM.HubSpoke.Models.LitSearchNoteSummary.Title.get -> string?
-LM.HubSpoke.Models.LitSearchNoteSummary.Title.init -> void
-LM.HubSpoke.Models.LitSearchNoteSummary.ToDisplayString() -> string!
-LM.HubSpoke.Models.EntryOrigin
-LM.HubSpoke.Models.EntryOrigin.External = 0 -> LM.HubSpoke.Models.EntryOrigin
-LM.HubSpoke.Models.EntryOrigin.Internal = 1 -> LM.HubSpoke.Models.EntryOrigin
-LM.HubSpoke.Models.EntryPurpose
-LM.HubSpoke.Models.EntryPurpose.Code = 5 -> LM.HubSpoke.Models.EntryPurpose
-LM.HubSpoke.Models.EntryPurpose.Dataset = 4 -> LM.HubSpoke.Models.EntryPurpose
-LM.HubSpoke.Models.EntryPurpose.Document = 3 -> LM.HubSpoke.Models.EntryPurpose
-LM.HubSpoke.Models.EntryPurpose.Manuscript = 1 -> LM.HubSpoke.Models.EntryPurpose
-LM.HubSpoke.Models.EntryPurpose.Trial = 2 -> LM.HubSpoke.Models.EntryPurpose
-LM.HubSpoke.Models.EntryPurpose.Unknown = 0 -> LM.HubSpoke.Models.EntryPurpose
-LM.HubSpoke.Models.EntryRelationsSummary
-LM.HubSpoke.Models.EntryRelationsSummary.EntryRelationsSummary() -> void
-LM.HubSpoke.Models.EntryRelationsSummary.RelatedCount.get -> int
-LM.HubSpoke.Models.EntryRelationsSummary.RelatedCount.init -> void
-LM.HubSpoke.Models.EntryRelationsSummary.RelationsUpdatedUtc.get -> System.DateTime?
-LM.HubSpoke.Models.EntryRelationsSummary.RelationsUpdatedUtc.init -> void
-LM.HubSpoke.Models.EntryRelationsSummary.VariantOfCount.get -> int
-LM.HubSpoke.Models.EntryRelationsSummary.VariantOfCount.init -> void
-LM.HubSpoke.Models.Grant
-LM.HubSpoke.Models.Grant.Agency.get -> string?
-LM.HubSpoke.Models.Grant.Agency.init -> void
-LM.HubSpoke.Models.Grant.Country.get -> string?
-LM.HubSpoke.Models.Grant.Country.init -> void
-LM.HubSpoke.Models.Grant.Grant() -> void
-LM.HubSpoke.Models.Grant.GrantId.get -> string?
-LM.HubSpoke.Models.Grant.GrantId.init -> void
-LM.HubSpoke.Models.JournalInfo
-LM.HubSpoke.Models.JournalInfo.Country.get -> string?
-LM.HubSpoke.Models.JournalInfo.Country.init -> void
-LM.HubSpoke.Models.JournalInfo.ISOAbbreviation.get -> string?
-LM.HubSpoke.Models.JournalInfo.ISOAbbreviation.init -> void
-LM.HubSpoke.Models.JournalInfo.ISSN.get -> string?
-LM.HubSpoke.Models.JournalInfo.ISSN.init -> void
-LM.HubSpoke.Models.JournalInfo.ISSNElectronic.get -> string?
-LM.HubSpoke.Models.JournalInfo.ISSNElectronic.init -> void
-LM.HubSpoke.Models.JournalInfo.ISSNPrint.get -> string?
-LM.HubSpoke.Models.JournalInfo.ISSNPrint.init -> void
-LM.HubSpoke.Models.JournalInfo.Issue.get -> LM.HubSpoke.Models.JournalIssue!
-LM.HubSpoke.Models.JournalInfo.Issue.init -> void
-LM.HubSpoke.Models.JournalInfo.JournalInfo() -> void
-LM.HubSpoke.Models.JournalInfo.NlmUniqueId.get -> string?
-LM.HubSpoke.Models.JournalInfo.NlmUniqueId.init -> void
-LM.HubSpoke.Models.JournalInfo.Title.get -> string!
-LM.HubSpoke.Models.JournalInfo.Title.init -> void
-LM.HubSpoke.Models.JournalIssue
-LM.HubSpoke.Models.JournalIssue.JournalIssue() -> void
-LM.HubSpoke.Models.JournalIssue.Number.get -> string?
-LM.HubSpoke.Models.JournalIssue.Number.init -> void
-LM.HubSpoke.Models.JournalIssue.PubDate.get -> LM.HubSpoke.Models.PartialDate?
-LM.HubSpoke.Models.JournalIssue.PubDate.init -> void
-LM.HubSpoke.Models.JournalIssue.Volume.get -> string?
-LM.HubSpoke.Models.JournalIssue.Volume.init -> void
-LM.HubSpoke.Models.JsonStd
-LM.HubSpoke.Models.LitSearchHook
-LM.HubSpoke.Models.LitSearchHook.CreatedBy.get -> string?
-LM.HubSpoke.Models.LitSearchHook.CreatedBy.init -> void
-LM.HubSpoke.Models.LitSearchHook.CreatedUtc.get -> System.DateTime
-LM.HubSpoke.Models.LitSearchHook.CreatedUtc.init -> void
-LM.HubSpoke.Models.LitSearchHook.From.get -> System.DateTime?
-LM.HubSpoke.Models.LitSearchHook.From.init -> void
-LM.HubSpoke.Models.LitSearchHook.Keywords.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.HubSpoke.Models.LitSearchHook.Keywords.init -> void
-LM.HubSpoke.Models.LitSearchHook.DerivedFromEntryId.get -> string?
-LM.HubSpoke.Models.LitSearchHook.DerivedFromEntryId.init -> void
-LM.HubSpoke.Models.LitSearchHook.LitSearchHook() -> void
-LM.HubSpoke.Models.LitSearchHook.Provider.get -> string!
-LM.HubSpoke.Models.LitSearchHook.Provider.init -> void
-LM.HubSpoke.Models.LitSearchHook.Query.get -> string!
-LM.HubSpoke.Models.LitSearchHook.Query.init -> void
-LM.HubSpoke.Models.LitSearchHook.LegacyNotes.get -> string?
-LM.HubSpoke.Models.LitSearchHook.LegacyNotes.init -> void
-LM.HubSpoke.Models.LitSearchHook.NotesSummary.get -> string?
-LM.HubSpoke.Models.LitSearchHook.NotesSummary.set -> void
-LM.HubSpoke.Models.LitSearchHook.UserNotes.get -> string?
-LM.HubSpoke.Models.LitSearchHook.UserNotes.set -> void
-LM.HubSpoke.Models.LitSearchHook.Runs.get -> System.Collections.Generic.List<LM.HubSpoke.Models.LitSearchRun!>!
-LM.HubSpoke.Models.LitSearchHook.Runs.init -> void
-LM.HubSpoke.Models.LitSearchHook.SchemaVersion.get -> string!
-LM.HubSpoke.Models.LitSearchHook.SchemaVersion.init -> void
-LM.HubSpoke.Models.LitSearchHook.Title.get -> string!
-LM.HubSpoke.Models.LitSearchHook.Title.init -> void
-LM.HubSpoke.Models.LitSearchHook.To.get -> System.DateTime?
-LM.HubSpoke.Models.LitSearchHook.To.init -> void
-LM.HubSpoke.Models.LitSearchRun
-LM.HubSpoke.Models.LitSearchRun.IsFavorite.get -> bool
-LM.HubSpoke.Models.LitSearchRun.IsFavorite.init -> void
-LM.HubSpoke.Models.LitSearchRun.LitSearchRun() -> void
-LM.HubSpoke.Models.LitSearchRun.RawAttachments.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.LitSearchRun.RawAttachments.init -> void
-LM.HubSpoke.Models.LitSearchRun.CheckedEntryIdsPath.get -> string?
-LM.HubSpoke.Models.LitSearchRun.CheckedEntryIdsPath.set -> void
-LM.HubSpoke.Models.LitSearchRun.RunId.get -> string!
-LM.HubSpoke.Models.LitSearchRun.RunId.init -> void
-LM.HubSpoke.Models.LitSearchRun.RunUtc.get -> System.DateTime
-LM.HubSpoke.Models.LitSearchRun.RunUtc.init -> void
-LM.HubSpoke.Models.LitSearchRun.ExecutedBy.get -> string?
-LM.HubSpoke.Models.LitSearchRun.ExecutedBy.init -> void
-LM.HubSpoke.Models.LitSearchRun.From.get -> System.DateTime?
-LM.HubSpoke.Models.LitSearchRun.From.init -> void
-LM.HubSpoke.Models.LitSearchRun.To.get -> System.DateTime?
-LM.HubSpoke.Models.LitSearchRun.To.init -> void
-LM.HubSpoke.Models.LitSearchRun.TotalHits.get -> int
-LM.HubSpoke.Models.LitSearchRun.TotalHits.init -> void
-LM.HubSpoke.Models.MedlineInfo
-LM.HubSpoke.Models.MedlineInfo.CitationSubset.get -> string?
-LM.HubSpoke.Models.MedlineInfo.CitationSubset.init -> void
-LM.HubSpoke.Models.MedlineInfo.MedlineInfo() -> void
-LM.HubSpoke.Models.MedlineInfo.PublicationStatusRaw.get -> string?
-LM.HubSpoke.Models.MedlineInfo.PublicationStatusRaw.init -> void
-LM.HubSpoke.Models.MeshHeading
-LM.HubSpoke.Models.MeshHeading.Descriptor.get -> string!
-LM.HubSpoke.Models.MeshHeading.Descriptor.init -> void
-LM.HubSpoke.Models.MeshHeading.MajorTopic.get -> bool
-LM.HubSpoke.Models.MeshHeading.MajorTopic.init -> void
-LM.HubSpoke.Models.MeshHeading.MeshHeading() -> void
-LM.HubSpoke.Models.MeshHeading.Qualifiers.get -> System.Collections.Generic.List<string!>!
-LM.HubSpoke.Models.MeshHeading.Qualifiers.init -> void
-LM.HubSpoke.Models.NullableUtcDateTimeConverter
-LM.HubSpoke.Models.NullableUtcDateTimeConverter.NullableUtcDateTimeConverter() -> void
-LM.HubSpoke.Models.Pagination
-LM.HubSpoke.Models.Pagination.ArticleNumber.get -> string?
-LM.HubSpoke.Models.Pagination.ArticleNumber.init -> void
-LM.HubSpoke.Models.Pagination.EndPage.get -> string?
-LM.HubSpoke.Models.Pagination.EndPage.init -> void
-LM.HubSpoke.Models.Pagination.Pagination() -> void
-LM.HubSpoke.Models.Pagination.StartPage.get -> string?
-LM.HubSpoke.Models.Pagination.StartPage.init -> void
-LM.HubSpoke.Models.PartialDate
-LM.HubSpoke.Models.PartialDate.Day.get -> int?
-LM.HubSpoke.Models.PartialDate.Day.init -> void
-LM.HubSpoke.Models.PartialDate.Month.get -> int?
-LM.HubSpoke.Models.PartialDate.Month.init -> void
-LM.HubSpoke.Models.PartialDate.PartialDate() -> void
-LM.HubSpoke.Models.PartialDate.ToDateTimeOrNull() -> System.DateTime?
-LM.HubSpoke.Models.PartialDate.Year.get -> int
-LM.HubSpoke.Models.PartialDate.Year.init -> void
-LM.HubSpoke.Models.PersonRef
-LM.HubSpoke.Models.PersonRef.DisplayName.get -> string?
-LM.HubSpoke.Models.PersonRef.DisplayName.init -> void
-LM.HubSpoke.Models.PersonRef.Id.get -> string!
-LM.HubSpoke.Models.PersonRef.Id.init -> void
-LM.HubSpoke.Models.PersonRef.PersonRef() -> void
-LM.HubSpoke.Models.PersonRef.PersonRef(string! Id, string? DisplayName) -> void
-LM.HubSpoke.Models.PersonRef.TimestampUtc.get -> System.DateTime?
-LM.HubSpoke.Models.PersonRef.TimestampUtc.init -> void
-LM.HubSpoke.Models.PublicationHistory
-LM.HubSpoke.Models.PublicationHistory.Accepted.get -> System.DateTimeOffset?
-LM.HubSpoke.Models.PublicationHistory.Accepted.init -> void
-LM.HubSpoke.Models.PublicationHistory.Entrez.get -> System.DateTimeOffset?
-LM.HubSpoke.Models.PublicationHistory.Entrez.init -> void
-LM.HubSpoke.Models.PublicationHistory.Medline.get -> System.DateTimeOffset?
-LM.HubSpoke.Models.PublicationHistory.Medline.init -> void
-LM.HubSpoke.Models.PublicationHistory.PublicationHistory() -> void
-LM.HubSpoke.Models.PublicationHistory.PubMed.get -> System.DateTimeOffset?
-LM.HubSpoke.Models.PublicationHistory.PubMed.init -> void
-LM.HubSpoke.Models.PublicationHistory.Received.get -> System.DateTimeOffset?
-LM.HubSpoke.Models.PublicationHistory.Received.init -> void
-LM.HubSpoke.Models.PublicationHistory.Revised.get -> System.DateTimeOffset?
-LM.HubSpoke.Models.PublicationHistory.Revised.init -> void
-LM.HubSpoke.Models.PubStatus
-LM.HubSpoke.Models.PubStatus.AheadOfPrint = 1 -> LM.HubSpoke.Models.PubStatus
-LM.HubSpoke.Models.PubStatus.EPublish = 2 -> LM.HubSpoke.Models.PubStatus
-LM.HubSpoke.Models.PubStatus.Medline = 4 -> LM.HubSpoke.Models.PubStatus
-LM.HubSpoke.Models.PubStatus.PPublish = 3 -> LM.HubSpoke.Models.PubStatus
-LM.HubSpoke.Models.PubStatus.PubMedNotMedline = 5 -> LM.HubSpoke.Models.PubStatus
-LM.HubSpoke.Models.PubStatus.Unknown = 0 -> LM.HubSpoke.Models.PubStatus
-LM.HubSpoke.Models.PurposeSource
-LM.HubSpoke.Models.PurposeSource.Inferred = 0 -> LM.HubSpoke.Models.PurposeSource
-LM.HubSpoke.Models.PurposeSource.Manual = 1 -> LM.HubSpoke.Models.PurposeSource
-LM.HubSpoke.Models.UtcDateTimeConverter
-LM.HubSpoke.Models.UtcDateTimeConverter.UtcDateTimeConverter() -> void
-LM.HubSpoke.Spokes.ArticleSpokeHandler
-LM.HubSpoke.Spokes.ArticleSpokeHandler.ArticleSpokeHandler() -> void
-LM.HubSpoke.Spokes.ArticleSpokeHandler.BuildHookAsync(LM.Core.Models.Entry! entry, LM.HubSpoke.Abstractions.CasResult primary, System.Collections.Generic.IEnumerable<string!>! attachmentRelPaths, System.Func<string!, System.Threading.CancellationToken, System.Threading.Tasks.Task<LM.HubSpoke.Abstractions.CasResult>!>! moveToCas, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<object?>!
-LM.HubSpoke.Spokes.ArticleSpokeHandler.BuildIndex(LM.HubSpoke.Models.EntryHub! hub, object? hookObj, string? fullText) -> LM.HubSpoke.Abstractions.SpokeIndexContribution
-LM.HubSpoke.Spokes.ArticleSpokeHandler.Handles.get -> LM.Core.Models.EntryType
-LM.HubSpoke.Spokes.ArticleSpokeHandler.HookPath.get -> string!
-LM.HubSpoke.Spokes.ArticleSpokeHandler.LoadHookAsync(LM.Core.Abstractions.IWorkSpaceService! ws, string! entryId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<object?>!
-LM.HubSpoke.Spokes.ArticleSpokeHandler.MapToEntry(LM.HubSpoke.Models.EntryHub! hub, object? hookObj) -> LM.Core.Models.Entry!
-LM.HubSpoke.Spokes.DocumentSpokeHandler
-LM.HubSpoke.Spokes.DocumentSpokeHandler.BuildHookAsync(LM.Core.Models.Entry! entry, LM.HubSpoke.Abstractions.CasResult primary, System.Collections.Generic.IEnumerable<string!>! attachmentRelPaths, System.Func<string!, System.Threading.CancellationToken, System.Threading.Tasks.Task<LM.HubSpoke.Abstractions.CasResult>!>! moveToCas, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<object?>!
-LM.HubSpoke.Spokes.DocumentSpokeHandler.BuildIndex(LM.HubSpoke.Models.EntryHub! hub, object? hookObj, string? fullText) -> LM.HubSpoke.Abstractions.SpokeIndexContribution
-LM.HubSpoke.Spokes.DocumentSpokeHandler.DocumentSpokeHandler() -> void
-LM.HubSpoke.Spokes.DocumentSpokeHandler.Handles.get -> LM.Core.Models.EntryType
-LM.HubSpoke.Spokes.DocumentSpokeHandler.HookPath.get -> string!
-LM.HubSpoke.Spokes.DocumentSpokeHandler.LoadHookAsync(LM.Core.Abstractions.IWorkSpaceService! ws, string! entryId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<object?>!
-LM.HubSpoke.Spokes.DocumentSpokeHandler.MapToEntry(LM.HubSpoke.Models.EntryHub! hub, object? hookObj) -> LM.Core.Models.Entry!
-LM.HubSpoke.Spokes.LitSearchSpokeHandler
-LM.HubSpoke.Spokes.LitSearchSpokeHandler.BuildHookAsync(LM.Core.Models.Entry! entry, LM.HubSpoke.Abstractions.CasResult primary, System.Collections.Generic.IEnumerable<string!>! attachmentRelPaths, System.Func<string!, System.Threading.CancellationToken, System.Threading.Tasks.Task<LM.HubSpoke.Abstractions.CasResult>!>! moveToCas, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<object?>!
-LM.HubSpoke.Spokes.LitSearchSpokeHandler.BuildIndex(LM.HubSpoke.Models.EntryHub! hub, object? hookObj, string? extractedFullText) -> LM.HubSpoke.Abstractions.SpokeIndexContribution
-LM.HubSpoke.Spokes.LitSearchSpokeHandler.Handles.get -> LM.Core.Models.EntryType
-LM.HubSpoke.Spokes.LitSearchSpokeHandler.HookPath.get -> string!
-LM.HubSpoke.Spokes.LitSearchSpokeHandler.LitSearchSpokeHandler(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
-LM.HubSpoke.Spokes.LitSearchSpokeHandler.LoadHookAsync(LM.Core.Abstractions.IWorkSpaceService! ws, string! entryId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<object?>!
-LM.HubSpoke.Spokes.LitSearchSpokeHandler.MapToEntry(LM.HubSpoke.Models.EntryHub! hub, object? hookObj) -> LM.Core.Models.Entry!
-override LM.HubSpoke.Models.NullableUtcDateTimeConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> System.DateTime?
-override LM.HubSpoke.Models.NullableUtcDateTimeConverter.Write(System.Text.Json.Utf8JsonWriter! writer, System.DateTime? value, System.Text.Json.JsonSerializerOptions! options) -> void
-override LM.HubSpoke.Models.UtcDateTimeConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> System.DateTime
-override LM.HubSpoke.Models.UtcDateTimeConverter.Write(System.Text.Json.Utf8JsonWriter! writer, System.DateTime value, System.Text.Json.JsonSerializerOptions! options) -> void
-static LM.HubSpoke.Models.EntryNotesSummary.FromLitSearch(LM.HubSpoke.Models.LitSearchNoteSummary! summary, string? renderedText) -> LM.HubSpoke.Models.EntryNotesSummary!
-static LM.HubSpoke.Models.EntryNotesSummary.FromRawText(string! text) -> LM.HubSpoke.Models.EntryNotesSummary!
-static LM.HubSpoke.Models.PersonRef.Unknown.get -> LM.HubSpoke.Models.PersonRef
-static readonly LM.HubSpoke.Models.JsonStd.Options -> System.Text.Json.JsonSerializerOptions!
----------- LM.Review.Core ----------
-#nullable enable
-LM.Review.Core.Models.ConflictState
-LM.Review.Core.Models.ConflictState.None = 0 -> LM.Review.Core.Models.ConflictState
-LM.Review.Core.Models.ConflictState.Conflict = 1 -> LM.Review.Core.Models.ConflictState
-LM.Review.Core.Models.ConflictState.Escalated = 2 -> LM.Review.Core.Models.ConflictState
-LM.Review.Core.Models.ConflictState.Resolved = 3 -> LM.Review.Core.Models.ConflictState
-LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ScreeningStatus.Pending = 0 -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ScreeningStatus.InProgress = 1 -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ScreeningStatus.Included = 2 -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ScreeningStatus.Excluded = 3 -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ScreeningStatus.Escalated = 4 -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ReviewerRole
-LM.Review.Core.Models.ReviewerRole.Primary = 0 -> LM.Review.Core.Models.ReviewerRole
-LM.Review.Core.Models.ReviewerRole.Secondary = 1 -> LM.Review.Core.Models.ReviewerRole
-LM.Review.Core.Models.ReviewerRole.TieBreaker = 2 -> LM.Review.Core.Models.ReviewerRole
-LM.Review.Core.Models.ReviewerRole.Arbitrator = 3 -> LM.Review.Core.Models.ReviewerRole
-LM.Review.Core.Models.ReviewStageType
-LM.Review.Core.Models.ReviewStageType.TitleScreening = 0 -> LM.Review.Core.Models.ReviewStageType
-LM.Review.Core.Models.ReviewStageType.FullTextReview = 1 -> LM.Review.Core.Models.ReviewStageType
-LM.Review.Core.Models.ReviewStageType.ConsensusMeeting = 2 -> LM.Review.Core.Models.ReviewStageType
-LM.Review.Core.Models.ReviewStageType.QualityAssurance = 3 -> LM.Review.Core.Models.ReviewStageType
-LM.Review.Core.Models.ReviewerDecision
-LM.Review.Core.Models.ReviewerDecision.AssignmentId.get -> string!
-static LM.Review.Core.Models.ReviewerDecision.Create(string! assignmentId, string! reviewerId, LM.Review.Core.Models.ScreeningStatus decision, System.DateTimeOffset decidedAtUtc, string? notes = null) -> LM.Review.Core.Models.ReviewerDecision!
-LM.Review.Core.Models.ReviewerDecision.DecidedAt.get -> System.DateTimeOffset
-LM.Review.Core.Models.ReviewerDecision.Decision.get -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ReviewerDecision.Notes.get -> string?
-LM.Review.Core.Models.ReviewerDecision.ReviewerId.get -> string!
-LM.Review.Core.Models.ConsensusOutcome
-LM.Review.Core.Models.ConsensusOutcome.Approved.get -> bool
-static LM.Review.Core.Models.ConsensusOutcome.Create(string! stageId, bool approved, LM.Review.Core.Models.ConflictState resultingState, System.DateTimeOffset resolvedAtUtc, string? notes = null, string? resolvedBy = null) -> LM.Review.Core.Models.ConsensusOutcome!
-LM.Review.Core.Models.ConsensusOutcome.Notes.get -> string?
-LM.Review.Core.Models.ConsensusOutcome.ResolvedAt.get -> System.DateTimeOffset
-LM.Review.Core.Models.ConsensusOutcome.ResolvedBy.get -> string?
-LM.Review.Core.Models.ConsensusOutcome.ResultingState.get -> LM.Review.Core.Models.ConflictState
-LM.Review.Core.Models.ConsensusOutcome.StageId.get -> string!
-LM.Review.Core.Models.ReviewAuditTrail
-LM.Review.Core.Models.ReviewAuditTrail.Append(LM.Review.Core.Models.ReviewAuditTrail.AuditEntry! entry) -> LM.Review.Core.Models.ReviewAuditTrail!
-static LM.Review.Core.Models.ReviewAuditTrail.Create(System.Collections.Generic.IEnumerable<LM.Review.Core.Models.ReviewAuditTrail.AuditEntry!>? entries = null) -> LM.Review.Core.Models.ReviewAuditTrail!
-LM.Review.Core.Models.ReviewAuditTrail.Entries.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.ReviewAuditTrail.AuditEntry!>!
-LM.Review.Core.Models.ReviewAuditTrail.AuditEntry
-LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Action.get -> string!
-LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Actor.get -> string!
-static LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Create(string! id, string! actor, string! action, System.DateTimeOffset occurredAtUtc, string? details = null) -> LM.Review.Core.Models.ReviewAuditTrail.AuditEntry!
-LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Details.get -> string?
-LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Id.get -> string!
-LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.OccurredAt.get -> System.DateTimeOffset
-LM.Review.Core.Models.ReviewProject
-LM.Review.Core.Models.ReviewProject.AuditTrail.get -> LM.Review.Core.Models.ReviewAuditTrail!
-static LM.Review.Core.Models.ReviewProject.Create(string! id, string! name, System.DateTimeOffset createdAtUtc, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.StageDefinition!>! stageDefinitions, LM.Review.Core.Models.ReviewAuditTrail? auditTrail = null) -> LM.Review.Core.Models.ReviewProject!
-LM.Review.Core.Models.ReviewProject.CreatedAt.get -> System.DateTimeOffset
-LM.Review.Core.Models.ReviewProject.Id.get -> string!
-LM.Review.Core.Models.ReviewProject.Name.get -> string!
-LM.Review.Core.Models.ReviewProject.StageDefinitions.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.StageDefinition!>!
-LM.Review.Core.Models.ReviewStage
-LM.Review.Core.Models.ReviewStage.ActivatedAt.get -> System.DateTimeOffset
-LM.Review.Core.Models.ReviewStage.Assignments.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.ScreeningAssignment!>!
-LM.Review.Core.Models.ReviewStage.CompletedAt.get -> System.DateTimeOffset?
-LM.Review.Core.Models.ReviewStage.Consensus.get -> LM.Review.Core.Models.ConsensusOutcome?
-LM.Review.Core.Models.ReviewStage.ConflictState.get -> LM.Review.Core.Models.ConflictState
-static LM.Review.Core.Models.ReviewStage.Create(string! id, string! projectId, LM.Review.Core.Models.StageDefinition! definition, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.ScreeningAssignment!>! assignments, LM.Review.Core.Models.ConflictState conflictState, System.DateTimeOffset activatedAtUtc, System.DateTimeOffset? completedAtUtc = null, LM.Review.Core.Models.ConsensusOutcome? consensus = null) -> LM.Review.Core.Models.ReviewStage!
-LM.Review.Core.Models.ReviewStage.Definition.get -> LM.Review.Core.Models.StageDefinition!
-LM.Review.Core.Models.ReviewStage.Id.get -> string!
-LM.Review.Core.Models.ReviewStage.IsComplete.get -> bool
-LM.Review.Core.Models.ReviewStage.ProjectId.get -> string!
-LM.Review.Core.Models.StageDefinition
-LM.Review.Core.Models.StageDefinition.ConsensusPolicy.get -> LM.Review.Core.Models.StageConsensusPolicy!
-static LM.Review.Core.Models.StageDefinition.Create(string! id, string! name, LM.Review.Core.Models.ReviewStageType stageType, LM.Review.Core.Models.ReviewerRequirement! reviewerRequirement, LM.Review.Core.Models.StageConsensusPolicy! consensusPolicy) -> LM.Review.Core.Models.StageDefinition!
-LM.Review.Core.Models.StageDefinition.Id.get -> string!
-LM.Review.Core.Models.StageDefinition.Name.get -> string!
-LM.Review.Core.Models.StageDefinition.ReviewerRequirement.get -> LM.Review.Core.Models.ReviewerRequirement!
-LM.Review.Core.Models.StageDefinition.StageType.get -> LM.Review.Core.Models.ReviewStageType
-LM.Review.Core.Models.StageConsensusPolicy
-LM.Review.Core.Models.StageConsensusPolicy.ArbitrationRole.get -> LM.Review.Core.Models.ReviewerRole?
-static LM.Review.Core.Models.StageConsensusPolicy.Disabled() -> LM.Review.Core.Models.StageConsensusPolicy!
-LM.Review.Core.Models.StageConsensusPolicy.EscalateOnDisagreement.get -> bool
-LM.Review.Core.Models.StageConsensusPolicy.MinimumAgreements.get -> int
-static LM.Review.Core.Models.StageConsensusPolicy.RequireAgreement(int minimumAgreements, bool escalateOnDisagreement, LM.Review.Core.Models.ReviewerRole? arbitrationRole) -> LM.Review.Core.Models.StageConsensusPolicy!
-LM.Review.Core.Models.StageConsensusPolicy.RequiresConsensus.get -> bool
-LM.Review.Core.Models.ReviewerRequirement
-static LM.Review.Core.Models.ReviewerRequirement.Create(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<LM.Review.Core.Models.ReviewerRole, int>>! requirements) -> LM.Review.Core.Models.ReviewerRequirement!
-LM.Review.Core.Models.ReviewerRequirement.GetRequirement(LM.Review.Core.Models.ReviewerRole role) -> int
-LM.Review.Core.Models.ReviewerRequirement.Requirements.get -> System.Collections.Generic.IReadOnlyDictionary<LM.Review.Core.Models.ReviewerRole, int>!
-LM.Review.Core.Models.ReviewerRequirement.TotalRequired.get -> int
-LM.Review.Core.Models.ScreeningAssignment
-LM.Review.Core.Models.ScreeningAssignment.AssignedAt.get -> System.DateTimeOffset
-LM.Review.Core.Models.ScreeningAssignment.CompletedAt.get -> System.DateTimeOffset?
-static LM.Review.Core.Models.ScreeningAssignment.Create(string! id, string! stageId, string! reviewerId, LM.Review.Core.Models.ReviewerRole role, LM.Review.Core.Models.ScreeningStatus status, System.DateTimeOffset assignedAtUtc, System.DateTimeOffset? completedAtUtc = null, LM.Review.Core.Models.ReviewerDecision? decision = null) -> LM.Review.Core.Models.ScreeningAssignment!
-LM.Review.Core.Models.ScreeningAssignment.Decision.get -> LM.Review.Core.Models.ReviewerDecision?
-LM.Review.Core.Models.ScreeningAssignment.Id.get -> string!
-LM.Review.Core.Models.ScreeningAssignment.ReviewerId.get -> string!
-LM.Review.Core.Models.ScreeningAssignment.Role.get -> LM.Review.Core.Models.ReviewerRole
-LM.Review.Core.Models.ScreeningAssignment.StageId.get -> string!
-LM.Review.Core.Models.ScreeningAssignment.Status.get -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.Forms.ExtractionForm
-LM.Review.Core.Models.Forms.ExtractionForm.Category.get -> string?
-static LM.Review.Core.Models.Forms.ExtractionForm.Create(string! id, string! name, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Forms.FormSection!>! sections, string? description = null, string? category = null) -> LM.Review.Core.Models.Forms.ExtractionForm!
-LM.Review.Core.Models.Forms.ExtractionForm.Description.get -> string?
-LM.Review.Core.Models.Forms.ExtractionForm.Id.get -> string!
-LM.Review.Core.Models.Forms.ExtractionForm.Name.get -> string!
-LM.Review.Core.Models.Forms.ExtractionForm.Sections.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Forms.FormSection!>!
-LM.Review.Core.Models.Forms.FormField
-LM.Review.Core.Models.Forms.FormField.AllowFreeTextFallback.get -> bool
-LM.Review.Core.Models.Forms.FormField.Description.get -> string?
-LM.Review.Core.Models.Forms.FormField.FieldType.get -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormField.Id.get -> string!
-LM.Review.Core.Models.Forms.FormField.Options.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Forms.FormFieldOption!>!
-LM.Review.Core.Models.Forms.FormField.Title.get -> string!
-LM.Review.Core.Models.Forms.FormField.Validation.get -> LM.Review.Core.Models.Forms.FormFieldValidation?
-LM.Review.Core.Models.Forms.FormField.Visibility.get -> LM.Review.Core.Models.Forms.FormVisibilityRule?
-static LM.Review.Core.Models.Forms.FormField.Create(string! id, string! title, LM.Review.Core.Models.Forms.FormFieldType fieldType, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Forms.FormFieldOption!>? options = null, string? description = null, LM.Review.Core.Models.Forms.FormFieldValidation? validation = null, LM.Review.Core.Models.Forms.FormVisibilityRule? visibility = null, bool allowFreeTextFallback = false) -> LM.Review.Core.Models.Forms.FormField!
-LM.Review.Core.Models.Forms.FormFieldOption
-LM.Review.Core.Models.Forms.FormFieldOption.Description.get -> string?
-LM.Review.Core.Models.Forms.FormFieldOption.Id.get -> string!
-LM.Review.Core.Models.Forms.FormFieldOption.IsDefault.get -> bool
-LM.Review.Core.Models.Forms.FormFieldOption.Label.get -> string!
-static LM.Review.Core.Models.Forms.FormFieldOption.Create(string! id, string! label, string? description = null, bool isDefault = false) -> LM.Review.Core.Models.Forms.FormFieldOption!
-LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldType.SingleSelect = 0 -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldType.MultiSelect = 1 -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldType.Text = 2 -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldType.Numeric = 3 -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldType.Date = 4 -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldType.Reference = 5 -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldValidation
-LM.Review.Core.Models.Forms.FormFieldValidation.Expression.get -> string?
-LM.Review.Core.Models.Forms.FormFieldValidation.Maximum.get -> decimal?
-LM.Review.Core.Models.Forms.FormFieldValidation.MaximumDateUtc.get -> System.DateTime?
-LM.Review.Core.Models.Forms.FormFieldValidation.Minimum.get -> decimal?
-LM.Review.Core.Models.Forms.FormFieldValidation.MinimumDateUtc.get -> System.DateTime?
-LM.Review.Core.Models.Forms.FormFieldValidation.Mode.get -> LM.Review.Core.Models.Forms.FormValidationMode
-static LM.Review.Core.Models.Forms.FormFieldValidation.CreateDateRange(System.DateTime? minimumUtc, System.DateTime? maximumUtc) -> LM.Review.Core.Models.Forms.FormFieldValidation!
-static LM.Review.Core.Models.Forms.FormFieldValidation.CreateNumericRange(decimal? minimum, decimal? maximum) -> LM.Review.Core.Models.Forms.FormFieldValidation!
-static LM.Review.Core.Models.Forms.FormFieldValidation.CreateRegex(string! pattern) -> LM.Review.Core.Models.Forms.FormFieldValidation!
-static LM.Review.Core.Models.Forms.FormFieldValidation.CreateRequired() -> LM.Review.Core.Models.Forms.FormFieldValidation!
-LM.Review.Core.Models.Forms.FormIdentifier
-static bool LM.Review.Core.Models.Forms.FormIdentifier.IsNormalized(string! identifier) -> bool
-static string LM.Review.Core.Models.Forms.FormIdentifier.Normalize(string! identifier) -> string!
-LM.Review.Core.Models.Forms.FormSection
-LM.Review.Core.Models.Forms.FormSection.Children.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Forms.FormSection!>!
-LM.Review.Core.Models.Forms.FormSection.Description.get -> string?
-LM.Review.Core.Models.Forms.FormSection.Fields.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Forms.FormField!>!
-LM.Review.Core.Models.Forms.FormSection.Id.get -> string!
-LM.Review.Core.Models.Forms.FormSection.IsRepeatable.get -> bool
-LM.Review.Core.Models.Forms.FormSection.Title.get -> string!
-LM.Review.Core.Models.Forms.FormSection.Visibility.get -> LM.Review.Core.Models.Forms.FormVisibilityRule?
-static LM.Review.Core.Models.Forms.FormSection.Create(string! id, string! title, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Forms.FormField!>! fields, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Forms.FormSection!>? children = null, bool isRepeatable = false, string? description = null, LM.Review.Core.Models.Forms.FormVisibilityRule? visibility = null) -> LM.Review.Core.Models.Forms.FormSection!
-LM.Review.Core.Models.Forms.FormValidationMode
-LM.Review.Core.Models.Forms.FormValidationMode.Required = 0 -> LM.Review.Core.Models.Forms.FormValidationMode
-LM.Review.Core.Models.Forms.FormValidationMode.Range = 1 -> LM.Review.Core.Models.Forms.FormValidationMode
-LM.Review.Core.Models.Forms.FormValidationMode.Regex = 2 -> LM.Review.Core.Models.Forms.FormValidationMode
-LM.Review.Core.Models.Forms.FormVisibilityRule
-LM.Review.Core.Models.Forms.FormVisibilityRule.ExpectedValues.get -> System.Collections.Generic.IReadOnlyList<string>!
-LM.Review.Core.Models.Forms.FormVisibilityRule.IsVisibleWhenMatches.get -> bool
-LM.Review.Core.Models.Forms.FormVisibilityRule.SourceFieldId.get -> string!
-static LM.Review.Core.Models.Forms.FormVisibilityRule.Create(string! sourceFieldId, System.Collections.Generic.IEnumerable<string>? expectedValues = null, bool isVisibleWhenMatches = true) -> LM.Review.Core.Models.Forms.FormVisibilityRule!
-LM.Review.Core.Models.Forms.ExtractionFormSnapshot
-LM.Review.Core.Models.Forms.ExtractionFormSnapshot.CapturedBy.get -> string!
-LM.Review.Core.Models.Forms.ExtractionFormSnapshot.CapturedUtc.get -> System.DateTime
-LM.Review.Core.Models.Forms.ExtractionFormSnapshot.FormId.get -> string!
-LM.Review.Core.Models.Forms.ExtractionFormSnapshot.Values.get -> System.Collections.Generic.IReadOnlyDictionary<string, object?>!
-LM.Review.Core.Models.Forms.ExtractionFormSnapshot.VersionId.get -> string!
-static LM.Review.Core.Models.Forms.ExtractionFormSnapshot.Create(string! formId, string! versionId, System.Collections.Generic.IDictionary<string, object?>! values, string? capturedBy = null, System.DateTime? capturedUtc = null) -> LM.Review.Core.Models.Forms.ExtractionFormSnapshot!
-LM.Review.Core.Models.Forms.ExtractionFormVersion
-LM.Review.Core.Models.Forms.ExtractionFormVersion.CreatedBy.get -> string!
-LM.Review.Core.Models.Forms.ExtractionFormVersion.CreatedUtc.get -> System.DateTime
-LM.Review.Core.Models.Forms.ExtractionFormVersion.Form.get -> LM.Review.Core.Models.Forms.ExtractionForm!
-LM.Review.Core.Models.Forms.ExtractionFormVersion.Metadata.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>!
-LM.Review.Core.Models.Forms.ExtractionFormVersion.VersionId.get -> string!
-static LM.Review.Core.Models.Forms.ExtractionFormVersion.Create(string! versionId, LM.Review.Core.Models.Forms.ExtractionForm! form, System.Collections.Generic.IDictionary<string, string>? metadata = null, string? createdBy = null, System.DateTime? createdUtc = null) -> LM.Review.Core.Models.Forms.ExtractionFormVersion!
-LM.Review.Core.Validation.FormSchemaIssue
-LM.Review.Core.Validation.FormSchemaIssue.Code.get -> string!
-LM.Review.Core.Validation.FormSchemaIssue.FieldId.get -> string?
-LM.Review.Core.Validation.FormSchemaIssue.Message.get -> string!
-LM.Review.Core.Validation.FormSchemaIssue.SectionId.get -> string?
-LM.Review.Core.Validation.FormSchemaIssue.Severity.get -> LM.Review.Core.Validation.FormSchemaSeverity
-static LM.Review.Core.Validation.FormSchemaIssue.Error(string! code, string! message, string? sectionId = null, string? fieldId = null) -> LM.Review.Core.Validation.FormSchemaIssue!
-static LM.Review.Core.Validation.FormSchemaIssue.Warning(string! code, string! message, string? sectionId = null, string? fieldId = null) -> LM.Review.Core.Validation.FormSchemaIssue!
-LM.Review.Core.Validation.FormSchemaSeverity
-LM.Review.Core.Validation.FormSchemaSeverity.Warning = 0 -> LM.Review.Core.Validation.FormSchemaSeverity
-LM.Review.Core.Validation.FormSchemaSeverity.Error = 1 -> LM.Review.Core.Validation.FormSchemaSeverity
-LM.Review.Core.Validation.FormSchemaValidator
-LM.Review.Core.Validation.FormSchemaValidator.Validate(LM.Review.Core.Models.Forms.ExtractionForm! form) -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Validation.FormSchemaIssue!>!
-LM.Review.Core.Validation.FormSchemaValidator.Validate(LM.Review.Core.Models.Forms.ExtractionFormSnapshot! snapshot, LM.Review.Core.Models.Forms.ExtractionFormVersion! version) -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Validation.FormSchemaIssue!>!
-LM.Review.Core.Validation.FormSchemaValidator.Validate(LM.Review.Core.Models.Forms.ExtractionFormVersion! version) -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Validation.FormSchemaIssue!>!
-#nullable enable
-LM.Review.Core.DataExtraction.TableVocabulary
-LM.Review.Core.DataExtraction.TableVocabulary.ClassifyColumnHeader(string? header) -> LM.Core.Models.DataExtraction.TableColumnRole
-LM.Review.Core.DataExtraction.TableVocabulary.ClassifyRowLabel(string? label) -> LM.Core.Models.DataExtraction.TableRowRole
-LM.Review.Core.DataExtraction.TableVocabulary.ClassifyTitle(string? title) -> LM.Core.Models.DataExtraction.TableClassificationKind
-LM.Review.Core.DataExtraction.TableVocabulary.NormalizeHeader(string header) -> string!
-LM.Review.Core.DataExtraction.TableVocabulary.TryDetectEndpoint(string? token) -> string?
-LM.Review.Core.DataExtraction.TableVocabulary.TryDetectPopulation(string? token) -> string?
----------- LM.Infrastructure ----------
 #nullable enable
 #nullable enable
 LM.Infrastructure.Content.CompositeContentExtractor
@@ -1670,13 +688,16 @@ LM.Infrastructure.Metadata.CompositeMetadataExtractor.CompositeMetadataExtractor
 LM.Infrastructure.Metadata.CompositeMetadataExtractor.ExtractAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.FileMetadata!>!
 LM.Infrastructure.Metadata.EvidenceExtraction.DataExtractionPreprocessor
 LM.Infrastructure.Metadata.EvidenceExtraction.DataExtractionPreprocessor.DataExtractionPreprocessor(LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.Infrastructure.Metadata.EvidenceExtraction.DataExtractionPreprocessor.DataExtractionPreprocessor(LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Infrastructure.Metadata.EvidenceExtraction.Tables.IPdfTableExtractor! tableExtractor) -> void
 LM.Infrastructure.Metadata.EvidenceExtraction.DataExtractionPreprocessor.PreprocessAsync(LM.Core.Models.DataExtraction.DataExtractionPreprocessRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.DataExtraction.DataExtractionPreprocessResult!>!
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.IPdfTableExtractor
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.IPdfTableExtractor.ExtractAsync(UglyToad.PdfPig.PdfDocument! document, string! pdfPath, string! tablesRoot, string! hash, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.PreprocessedTable!>!>!
 LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaSharpTableExtractor
-LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaSharpTableExtractor.TabulaSharpTableExtractor(LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter! imageWriter) -> void
 LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaSharpTableExtractor.ExtractAsync(UglyToad.PdfPig.PdfDocument! document, string! pdfPath, string! tablesRoot, string! hash, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.PreprocessedTable!>!>!
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaSharpTableExtractor.TabulaSharpTableExtractor(LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter! imageWriter) -> void
 LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter
-LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter.TabulaTableImageWriter(double scalingFactor = 2) -> void
 LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter.CreateDocumentReader(string! pdfPath) -> Docnet.Core.Readers.IDocReader!
+LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter.TabulaTableImageWriter(double scalingFactor = 2) -> void
 LM.Infrastructure.Metadata.EvidenceExtraction.Tables.TabulaTableImageWriter.WriteAsync(Docnet.Core.Readers.IDocReader! docReader, int pageNumber, string! tablesRoot, string! fileStem, LM.Core.Models.DataExtraction.TableRegion! region, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<string!>!
 LM.Infrastructure.Review.ReviewHookContextFactory
 LM.Infrastructure.Review.ReviewHookContextFactory.CreateAssignmentUpdated(LM.Review.Core.Models.ReviewStage! stage, LM.Review.Core.Models.ScreeningAssignment! assignment) -> LM.Review.Core.Services.IReviewHookContext!
@@ -1949,629 +970,6 @@ LM.Review.Core.DataExtraction.TableVocabulary.ClassifyTitle(string? title) -> LM
 LM.Review.Core.DataExtraction.TableVocabulary.NormalizeHeader(string header) -> string!
 LM.Review.Core.DataExtraction.TableVocabulary.TryDetectEndpoint(string? token) -> string?
 LM.Review.Core.DataExtraction.TableVocabulary.TryDetectPopulation(string? token) -> string?
----------- LM.Core ----------
-#nullable enable
-LM.Core.Models.DataExtraction.TablePageLocation
-LM.Core.Models.DataExtraction.TablePageLocation.TablePageLocation() -> void
-LM.Core.Models.DataExtraction.TablePageLocation.Height.get -> double
-LM.Core.Models.DataExtraction.TablePageLocation.Height.init -> void
-LM.Core.Models.DataExtraction.TablePageLocation.Left.get -> double
-LM.Core.Models.DataExtraction.TablePageLocation.Left.init -> void
-LM.Core.Models.DataExtraction.TablePageLocation.PageHeight.get -> double
-LM.Core.Models.DataExtraction.TablePageLocation.PageHeight.init -> void
-LM.Core.Models.DataExtraction.TablePageLocation.PageNumber.get -> int
-LM.Core.Models.DataExtraction.TablePageLocation.PageNumber.init -> void
-LM.Core.Models.DataExtraction.TablePageLocation.PageWidth.get -> double
-LM.Core.Models.DataExtraction.TablePageLocation.PageWidth.init -> void
-LM.Core.Models.DataExtraction.TablePageLocation.Top.get -> double
-LM.Core.Models.DataExtraction.TablePageLocation.Top.init -> void
-LM.Core.Models.DataExtraction.TablePageLocation.Width.get -> double
-LM.Core.Models.DataExtraction.TablePageLocation.Width.init -> void
-LM.Core.Models.DataExtraction.TableRegion
-LM.Core.Models.DataExtraction.TableRegion.TableRegion() -> void
-LM.Core.Models.DataExtraction.TableRegion.Height.get -> double
-LM.Core.Models.DataExtraction.TableRegion.Height.init -> void
-LM.Core.Models.DataExtraction.TableRegion.Label.get -> string?
-LM.Core.Models.DataExtraction.TableRegion.Label.init -> void
-LM.Core.Models.DataExtraction.TableRegion.PageNumber.get -> int
-LM.Core.Models.DataExtraction.TableRegion.PageNumber.init -> void
-LM.Core.Models.DataExtraction.TableRegion.Width.get -> double
-LM.Core.Models.DataExtraction.TableRegion.Width.init -> void
-#nullable enable
-IPublicationLookup
-IPublicationLookup.TryGetByDoiAsync(string! doi, bool includeCitedBy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<LM.Core.Models.PublicationRecord?>!
-LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore
-LM.Core.Abstractions.IContentExtractor
-LM.Core.Abstractions.IContentExtractor.ExtractTextAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
-LM.Core.Abstractions.IDataExtractionExcelExporter.CanExportAsync(string! entryId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
-LM.Core.Abstractions.IDataExtractionExcelExporter.ExportAsync(string! entryId, string! outputPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
-LM.Core.Abstractions.IDataExtractionPowerPointExporter.CanExportAsync(string! entryId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
-LM.Core.Abstractions.IDataExtractionPowerPointExporter.ExportAsync(string! entryId, string! outputPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
-LM.Core.Abstractions.IDataExtractionPreprocessor
-LM.Core.Abstractions.IDataExtractionPreprocessor.PreprocessAsync(LM.Core.Models.DataExtraction.DataExtractionPreprocessRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.DataExtraction.DataExtractionPreprocessResult!>!
-LM.Core.Abstractions.IDataExtractionWordExporter.CanExportAsync(string! entryId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
-LM.Core.Abstractions.IDataExtractionWordExporter.ExportAsync(string! entryId, string! outputPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
-LM.Core.Abstractions.IEntryStore
-LM.Core.Abstractions.IEntryStore.EnumerateAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<LM.Core.Models.Entry!>!
-LM.Core.Abstractions.IEntryStore.FindByHashAsync(string! sha256, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
-LM.Core.Abstractions.IEntryStore.FindByIdsAsync(string? doi, string? pmid, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
-LM.Core.Abstractions.IEntryStore.FindSimilarByNameYearAsync(string! title, int? year, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
-LM.Core.Abstractions.IEntryStore.GetByIdAsync(string! id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Entry?>!
-LM.Core.Abstractions.IEntryStore.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-LM.Core.Abstractions.IEntryStore.SaveAsync(LM.Core.Models.Entry! entry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-LM.Core.Abstractions.IEntryStore.SearchAsync(LM.Core.Models.Filters.EntryFilter! filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Entry!>!>!
-LM.Core.Abstractions.IFullTextSearchService
-LM.Core.Abstractions.IFullTextSearchService.SearchAsync(LM.Core.Models.Search.FullTextSearchQuery! query, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.Search.FullTextSearchHit!>!>!
-LM.Core.Abstractions.Search.ISearchExecutionService
-LM.Core.Abstractions.Search.ISearchExecutionService.ExecuteAsync(LM.Core.Models.Search.SearchExecutionRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Search.SearchExecutionResult!>!
-LM.Core.Abstractions.Search.ISearchProvider
-LM.Core.Abstractions.Search.ISearchProvider.Database.get -> LM.Core.Models.SearchDatabase
-LM.Core.Abstractions.Search.ISearchProvider.SearchAsync(string! query, System.DateTime? from, System.DateTime? to, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.Core.Models.SearchHit!>!>!
-LM.Core.Abstractions.IFileStorageRepository
-LM.Core.Abstractions.IFileStorageRepository.SaveNewAsync(string! sourcePath, string! relativeTargetDir, string? preferredFileName = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
-LM.Core.Abstractions.IHasher
-LM.Core.Abstractions.IHasher.ComputeSha256Async(string! filePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
-LM.Core.Abstractions.IMetadataDebugSlideExporter
-LM.Core.Abstractions.IMetadataDebugSlideExporter.ExportAsync(System.Collections.Generic.IEnumerable<LM.Core.Models.FileMetadata!>! items, string! outputPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
-LM.Core.Abstractions.IMetadataExtractor
-LM.Core.Abstractions.IMetadataExtractor.ExtractAsync(string! absolutePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.FileMetadata!>!
-LM.Core.Abstractions.IPmidNormalizer
-LM.Core.Abstractions.IPmidNormalizer.Normalize(string? raw) -> string?
-LM.Core.Abstractions.ISimilarityService
-LM.Core.Abstractions.ISimilarityService.ComputeFileSimilarityAsync(string! filePathA, string! filePathB, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<double>!
-LM.Core.Abstractions.ITagVocabularyProvider
-LM.Core.Abstractions.ITagVocabularyProvider.GetAllTagsAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
-LM.Core.Abstractions.IWorkSpaceService
-LM.Core.Abstractions.IWorkSpaceService.EnsureWorkspaceAsync(string! absoluteWorkspacePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-LM.Core.Abstractions.IWorkSpaceService.GetAbsolutePath(string! relativePath) -> string!
-LM.Core.Abstractions.IWorkSpaceService.GetLocalDbPath() -> string!
-LM.Core.Abstractions.IWorkSpaceService.GetWorkspaceRoot() -> string!
-LM.Core.Abstractions.IWorkSpaceService.WorkspacePath.get -> string?
-LM.Core.Abstractions.IDoiNormalizer
-LM.Core.Abstractions.IDoiNormalizer.Normalize(string? raw) -> string?
-LM.Core.Models.AbstractSection
-LM.Core.Models.AbstractSection.Label.get -> string?
-LM.Core.Models.AbstractSection.Label.init -> void
-LM.Core.Models.AbstractSection.Text.get -> string?
-LM.Core.Models.AbstractSection.Text.init -> void
-LM.Core.Models.Attachment
-LM.Core.Models.Attachment.Attachment() -> void
-LM.Core.Models.Attachment.Id.get -> string!
-LM.Core.Models.Attachment.Id.set -> void
-LM.Core.Models.Attachment.Notes.get -> string?
-LM.Core.Models.Attachment.Notes.set -> void
-LM.Core.Models.Attachment.RelativePath.get -> string!
-LM.Core.Models.Attachment.RelativePath.set -> void
-LM.Core.Models.Attachment.Tags.get -> System.Collections.Generic.List<string!>!
-LM.Core.Models.Attachment.Tags.set -> void
-LM.Core.Models.Attachment.Title.get -> string!
-LM.Core.Models.Attachment.Title.set -> void
-LM.Core.Models.Attachment.Kind.get -> LM.Core.Models.AttachmentKind
-LM.Core.Models.Attachment.Kind.set -> void
-LM.Core.Models.Attachment.AddedBy.get -> string!
-LM.Core.Models.Attachment.AddedBy.set -> void
-LM.Core.Models.Attachment.AddedUtc.get -> System.DateTime
-LM.Core.Models.Attachment.AddedUtc.set -> void
-LM.Core.Models.AttachmentKind
-LM.Core.Models.AttachmentKind.Supplement = 0 -> LM.Core.Models.AttachmentKind
-LM.Core.Models.AttachmentKind.Version = 1 -> LM.Core.Models.AttachmentKind
-LM.Core.Models.AttachmentKind.Presentation = 2 -> LM.Core.Models.AttachmentKind
-LM.Core.Models.AttachmentKind.ExternalNotes = 3 -> LM.Core.Models.AttachmentKind
-LM.Core.Models.AuthorName
-LM.Core.Models.AuthorName.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.Core.Models.AuthorName.Affiliations.init -> void
-LM.Core.Models.AuthorName.CollectiveName.get -> string?
-LM.Core.Models.AuthorName.CollectiveName.init -> void
-LM.Core.Models.AuthorName.Family.get -> string?
-LM.Core.Models.AuthorName.Family.init -> void
-LM.Core.Models.AuthorName.Given.get -> string?
-LM.Core.Models.AuthorName.Given.init -> void
-LM.Core.Models.AuthorName.LastFromLiteral() -> string?
-LM.Core.Models.AuthorName.Literal.get -> string?
-LM.Core.Models.AuthorName.Literal.init -> void
-LM.Core.Models.AuthorName.Orcid.get -> string?
-LM.Core.Models.AuthorName.Orcid.init -> void
-LM.Core.Models.AuthorName.ToCsvPart() -> string!
-LM.Core.Models.DataExtraction.DataExtractionPreprocessRequest
-LM.Core.Models.DataExtraction.DataExtractionPreprocessRequest.DataExtractionPreprocessRequest(string! sourcePdfPath) -> void
-LM.Core.Models.DataExtraction.DataExtractionPreprocessRequest.PreferredCacheKey.get -> string?
-LM.Core.Models.DataExtraction.DataExtractionPreprocessRequest.PreferredCacheKey.init -> void
-LM.Core.Models.DataExtraction.DataExtractionPreprocessRequest.SourcePdfPath.get -> string!
-LM.Core.Models.DataExtraction.DataExtractionPreprocessRequest.SourceXmlPath.get -> string?
-LM.Core.Models.DataExtraction.DataExtractionPreprocessRequest.SourceXmlPath.init -> void
-LM.Core.Models.DataExtraction.DataExtractionPreprocessResult
-LM.Core.Models.DataExtraction.DataExtractionPreprocessResult.DataExtractionPreprocessResult() -> void
-LM.Core.Models.DataExtraction.DataExtractionPreprocessResult.Figures.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.PreprocessedFigure!>!
-LM.Core.Models.DataExtraction.DataExtractionPreprocessResult.Figures.init -> void
-LM.Core.Models.DataExtraction.DataExtractionPreprocessResult.IsEmpty.get -> bool
-LM.Core.Models.DataExtraction.DataExtractionPreprocessResult.Provenance.get -> LM.Core.Models.DataExtraction.EvidenceProvenance!
-LM.Core.Models.DataExtraction.DataExtractionPreprocessResult.Provenance.init -> void
-LM.Core.Models.DataExtraction.DataExtractionPreprocessResult.Sections.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.StructuredSection!>!
-LM.Core.Models.DataExtraction.DataExtractionPreprocessResult.Sections.init -> void
-LM.Core.Models.DataExtraction.DataExtractionPreprocessResult.Tables.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.PreprocessedTable!>!
-LM.Core.Models.DataExtraction.DataExtractionPreprocessResult.Tables.init -> void
-LM.Core.Models.DataExtraction.DataExtractionPreprocessResult.WithProvenance(LM.Core.Models.DataExtraction.EvidenceProvenance! provenance) -> LM.Core.Models.DataExtraction.DataExtractionPreprocessResult!
-LM.Core.Models.DataExtraction.EvidenceProvenance
-LM.Core.Models.DataExtraction.EvidenceProvenance.AdditionalMetadata.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
-LM.Core.Models.DataExtraction.EvidenceProvenance.AdditionalMetadata.init -> void
-LM.Core.Models.DataExtraction.EvidenceProvenance.EvidenceProvenance() -> void
-LM.Core.Models.DataExtraction.EvidenceProvenance.ExtractedAtUtc.get -> System.DateTime
-LM.Core.Models.DataExtraction.EvidenceProvenance.ExtractedAtUtc.init -> void
-LM.Core.Models.DataExtraction.EvidenceProvenance.ExtractedBy.get -> string!
-LM.Core.Models.DataExtraction.EvidenceProvenance.ExtractedBy.init -> void
-LM.Core.Models.DataExtraction.EvidenceProvenance.SourceFileName.get -> string!
-LM.Core.Models.DataExtraction.EvidenceProvenance.SourceFileName.init -> void
-LM.Core.Models.DataExtraction.EvidenceProvenance.SourceSha256.get -> string!
-LM.Core.Models.DataExtraction.EvidenceProvenance.SourceSha256.init -> void
-LM.Core.Models.DataExtraction.PreprocessedFigure
-LM.Core.Models.DataExtraction.PreprocessedFigure.Caption.get -> string!
-LM.Core.Models.DataExtraction.PreprocessedFigure.Caption.init -> void
-LM.Core.Models.DataExtraction.PreprocessedFigure.Id.get -> string!
-LM.Core.Models.DataExtraction.PreprocessedFigure.Id.init -> void
-LM.Core.Models.DataExtraction.PreprocessedFigure.PageNumbers.get -> System.Collections.Generic.IReadOnlyList<int>!
-LM.Core.Models.DataExtraction.PreprocessedFigure.PageNumbers.init -> void
-LM.Core.Models.DataExtraction.PreprocessedFigure.PreprocessedFigure() -> void
-LM.Core.Models.DataExtraction.PreprocessedFigure.ProvenanceHash.get -> string!
-LM.Core.Models.DataExtraction.PreprocessedFigure.ProvenanceHash.init -> void
-LM.Core.Models.DataExtraction.PreprocessedFigure.ThumbnailRelativePath.get -> string!
-LM.Core.Models.DataExtraction.PreprocessedFigure.ThumbnailRelativePath.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable
-LM.Core.Models.DataExtraction.PreprocessedTable.Classification.get -> LM.Core.Models.DataExtraction.TableClassificationKind
-LM.Core.Models.DataExtraction.PreprocessedTable.Classification.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.Columns.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.TableColumnMapping!>!
-LM.Core.Models.DataExtraction.PreprocessedTable.Columns.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.CsvRelativePath.get -> string!
-LM.Core.Models.DataExtraction.PreprocessedTable.CsvRelativePath.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.FriendlyName.get -> string!
-LM.Core.Models.DataExtraction.PreprocessedTable.FriendlyName.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.ImageProvenanceHash.get -> string!
-LM.Core.Models.DataExtraction.PreprocessedTable.ImageProvenanceHash.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.ImageRelativePath.get -> string!
-LM.Core.Models.DataExtraction.PreprocessedTable.ImageRelativePath.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.DetectedEndpoints.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.Core.Models.DataExtraction.PreprocessedTable.DetectedEndpoints.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.DetectedPopulations.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.Core.Models.DataExtraction.PreprocessedTable.DetectedPopulations.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.Id.get -> string!
-LM.Core.Models.DataExtraction.PreprocessedTable.Id.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.PageLocations.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.TablePageLocation!>!
-LM.Core.Models.DataExtraction.PreprocessedTable.PageLocations.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.PageNumbers.get -> System.Collections.Generic.IReadOnlyList<int>!
-LM.Core.Models.DataExtraction.PreprocessedTable.PageNumbers.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.PreprocessedTable() -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.ProvenanceHash.get -> string!
-LM.Core.Models.DataExtraction.PreprocessedTable.ProvenanceHash.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.Regions.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.TableRegion!>!
-LM.Core.Models.DataExtraction.PreprocessedTable.Regions.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.Rows.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.TableRowMapping!>!
-LM.Core.Models.DataExtraction.PreprocessedTable.Rows.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.Title.get -> string!
-LM.Core.Models.DataExtraction.PreprocessedTable.Title.init -> void
-LM.Core.Models.DataExtraction.PreprocessedTable.Tags.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.Core.Models.DataExtraction.PreprocessedTable.Tags.init -> void
-LM.Core.Models.DataExtraction.StructuredSection
-LM.Core.Models.DataExtraction.StructuredSection.Body.get -> string!
-LM.Core.Models.DataExtraction.StructuredSection.Body.init -> void
-LM.Core.Models.DataExtraction.StructuredSection.Heading.get -> string!
-LM.Core.Models.DataExtraction.StructuredSection.Heading.init -> void
-LM.Core.Models.DataExtraction.StructuredSection.Level.get -> int
-LM.Core.Models.DataExtraction.StructuredSection.Level.init -> void
-LM.Core.Models.DataExtraction.StructuredSection.PageNumbers.get -> System.Collections.Generic.IReadOnlyList<int>!
-LM.Core.Models.DataExtraction.StructuredSection.PageNumbers.init -> void
-LM.Core.Models.DataExtraction.StructuredSection.StructuredSection() -> void
-LM.Core.Models.DataExtraction.TableClassificationKind
-LM.Core.Models.DataExtraction.TableClassificationKind.Baseline = 1 -> LM.Core.Models.DataExtraction.TableClassificationKind
-LM.Core.Models.DataExtraction.TableClassificationKind.Mixed = 3 -> LM.Core.Models.DataExtraction.TableClassificationKind
-LM.Core.Models.DataExtraction.TableClassificationKind.Outcome = 2 -> LM.Core.Models.DataExtraction.TableClassificationKind
-LM.Core.Models.DataExtraction.TableClassificationKind.Unknown = 0 -> LM.Core.Models.DataExtraction.TableClassificationKind
-LM.Core.Models.DataExtraction.TableColumnMapping
-LM.Core.Models.DataExtraction.TableColumnMapping.ColumnIndex.get -> int
-LM.Core.Models.DataExtraction.TableColumnMapping.ColumnIndex.init -> void
-LM.Core.Models.DataExtraction.TableColumnMapping.Header.get -> string!
-LM.Core.Models.DataExtraction.TableColumnMapping.Header.init -> void
-LM.Core.Models.DataExtraction.TableColumnMapping.NormalizedHeader.get -> string!
-LM.Core.Models.DataExtraction.TableColumnMapping.NormalizedHeader.init -> void
-LM.Core.Models.DataExtraction.TableColumnMapping.Role.get -> LM.Core.Models.DataExtraction.TableColumnRole
-LM.Core.Models.DataExtraction.TableColumnMapping.Role.init -> void
-LM.Core.Models.DataExtraction.TableColumnMapping.TableColumnMapping() -> void
-LM.Core.Models.DataExtraction.TableColumnRole
-LM.Core.Models.DataExtraction.TableColumnRole.Intervention = 2 -> LM.Core.Models.DataExtraction.TableColumnRole
-LM.Core.Models.DataExtraction.TableColumnRole.Measure = 6 -> LM.Core.Models.DataExtraction.TableColumnRole
-LM.Core.Models.DataExtraction.TableColumnRole.Outcome = 3 -> LM.Core.Models.DataExtraction.TableColumnRole
-LM.Core.Models.DataExtraction.TableColumnRole.Population = 1 -> LM.Core.Models.DataExtraction.TableColumnRole
-LM.Core.Models.DataExtraction.TableColumnRole.Timepoint = 4 -> LM.Core.Models.DataExtraction.TableColumnRole
-LM.Core.Models.DataExtraction.TableColumnRole.Unknown = 0 -> LM.Core.Models.DataExtraction.TableColumnRole
-LM.Core.Models.DataExtraction.TableColumnRole.Value = 5 -> LM.Core.Models.DataExtraction.TableColumnRole
-LM.Core.Models.DataExtraction.TableRowMapping
-LM.Core.Models.DataExtraction.TableRowMapping.Label.get -> string!
-LM.Core.Models.DataExtraction.TableRowMapping.Label.init -> void
-LM.Core.Models.DataExtraction.TableRowMapping.Role.get -> LM.Core.Models.DataExtraction.TableRowRole
-LM.Core.Models.DataExtraction.TableRowMapping.Role.init -> void
-LM.Core.Models.DataExtraction.TableRowMapping.RowIndex.get -> int
-LM.Core.Models.DataExtraction.TableRowMapping.RowIndex.init -> void
-LM.Core.Models.DataExtraction.TableRowMapping.TableRowMapping() -> void
-LM.Core.Models.DataExtraction.TableRegion.X.get -> double
-LM.Core.Models.DataExtraction.TableRegion.X.init -> void
-LM.Core.Models.DataExtraction.TableRegion.Y.get -> double
-LM.Core.Models.DataExtraction.TableRegion.Y.init -> void
-LM.Core.Models.DataExtraction.TableRowRole
-LM.Core.Models.DataExtraction.TableRowRole.Baseline = 2 -> LM.Core.Models.DataExtraction.TableRowRole
-LM.Core.Models.DataExtraction.TableRowRole.Footnote = 4 -> LM.Core.Models.DataExtraction.TableRowRole
-LM.Core.Models.DataExtraction.TableRowRole.Header = 1 -> LM.Core.Models.DataExtraction.TableRowRole
-LM.Core.Models.DataExtraction.TableRowRole.Outcome = 3 -> LM.Core.Models.DataExtraction.TableRowRole
-LM.Core.Models.DataExtraction.TableRowRole.Unknown = 0 -> LM.Core.Models.DataExtraction.TableRowRole
-LM.Core.Models.Entry
-LM.Core.Models.Entry.AddedBy.get -> string?
-LM.Core.Models.Entry.AddedBy.set -> void
-LM.Core.Models.Entry.AddedOnUtc.get -> System.DateTime
-LM.Core.Models.Entry.AddedOnUtc.set -> void
-LM.Core.Models.Entry.Attachments.get -> System.Collections.Generic.List<LM.Core.Models.Attachment!>!
-LM.Core.Models.Entry.Attachments.set -> void
-LM.Core.Models.Entry.Authors.get -> System.Collections.Generic.List<string!>!
-LM.Core.Models.Entry.Authors.set -> void
-LM.Core.Models.Entry.DisplayName.get -> string?
-LM.Core.Models.Entry.DisplayName.set -> void
-LM.Core.Models.Entry.Doi.get -> string?
-LM.Core.Models.Entry.Doi.set -> void
-LM.Core.Models.Entry.Entry() -> void
-LM.Core.Models.Entry.Id.get -> string!
-LM.Core.Models.Entry.Id.set -> void
-LM.Core.Models.Entry.InternalId.get -> string?
-LM.Core.Models.Entry.InternalId.set -> void
-LM.Core.Models.Entry.IsInternal.get -> bool
-LM.Core.Models.Entry.IsInternal.set -> void
-LM.Core.Models.Entry.Links.get -> System.Collections.Generic.List<string!>!
-LM.Core.Models.Entry.Links.set -> void
-LM.Core.Models.Entry.MainFileHashSha256.get -> string?
-LM.Core.Models.Entry.MainFileHashSha256.set -> void
-LM.Core.Models.Entry.MainFilePath.get -> string!
-LM.Core.Models.Entry.MainFilePath.set -> void
-LM.Core.Models.Entry.Nct.get -> string?
-LM.Core.Models.Entry.Nct.set -> void
-LM.Core.Models.Entry.Notes.get -> string?
-LM.Core.Models.Entry.Notes.set -> void
-LM.Core.Models.Entry.UserNotes.get -> string?
-LM.Core.Models.Entry.UserNotes.set -> void
-LM.Core.Models.Entry.OriginalFileName.get -> string?
-LM.Core.Models.Entry.OriginalFileName.set -> void
-LM.Core.Models.Entry.Pmid.get -> string?
-LM.Core.Models.Entry.Pmid.set -> void
-LM.Core.Models.Entry.Relations.get -> System.Collections.Generic.List<LM.Core.Models.Relation!>!
-LM.Core.Models.Entry.Relations.set -> void
-LM.Core.Models.Entry.ShortTitle.get -> string?
-LM.Core.Models.Entry.ShortTitle.set -> void
-LM.Core.Models.Entry.Source.get -> string?
-LM.Core.Models.Entry.Source.set -> void
-LM.Core.Models.Entry.Tags.get -> System.Collections.Generic.List<string!>!
-LM.Core.Models.Entry.Tags.set -> void
-LM.Core.Models.Entry.Title.get -> string!
-LM.Core.Models.Entry.Title.set -> void
-LM.Core.Models.Entry.Type.get -> LM.Core.Models.EntryType
-LM.Core.Models.Entry.Type.set -> void
-LM.Core.Models.Entry.Version.get -> int
-LM.Core.Models.Entry.Version.set -> void
-LM.Core.Models.Entry.Year.get -> int?
-LM.Core.Models.Entry.Year.set -> void
-LM.Core.Models.EntryDocument
-LM.Core.Models.EntryDocument.Authors.get -> System.Collections.Generic.List<string!>!
-LM.Core.Models.EntryDocument.Authors.set -> void
-LM.Core.Models.EntryDocument.CreatedUtc.get -> System.DateTimeOffset
-LM.Core.Models.EntryDocument.CreatedUtc.set -> void
-LM.Core.Models.EntryDocument.Doi.get -> string?
-LM.Core.Models.EntryDocument.Doi.set -> void
-LM.Core.Models.EntryDocument.EntryDocument() -> void
-LM.Core.Models.EntryDocument.Files.get -> System.Collections.Generic.List<LM.Core.Models.EntryFile!>!
-LM.Core.Models.EntryDocument.Files.set -> void
-LM.Core.Models.EntryDocument.Id.get -> string!
-LM.Core.Models.EntryDocument.Id.set -> void
-LM.Core.Models.EntryDocument.Internal.get -> bool
-LM.Core.Models.EntryDocument.Internal.set -> void
-LM.Core.Models.EntryDocument.Pmid.get -> string?
-LM.Core.Models.EntryDocument.Pmid.set -> void
-LM.Core.Models.EntryDocument.Source.get -> string?
-LM.Core.Models.EntryDocument.Source.set -> void
-LM.Core.Models.EntryDocument.Tags.get -> System.Collections.Generic.List<string!>!
-LM.Core.Models.EntryDocument.Tags.set -> void
-LM.Core.Models.EntryDocument.Title.get -> string?
-LM.Core.Models.EntryDocument.Title.set -> void
-LM.Core.Models.EntryDocument.UpdatedUtc.get -> System.DateTimeOffset
-LM.Core.Models.EntryDocument.UpdatedUtc.set -> void
-LM.Core.Models.EntryDocument.Year.get -> int?
-LM.Core.Models.EntryDocument.Year.set -> void
-LM.Core.Models.EntryFile
-LM.Core.Models.EntryFile.EntryFile() -> void
-LM.Core.Models.EntryFile.Hash.get -> string!
-LM.Core.Models.EntryFile.Hash.set -> void
-LM.Core.Models.EntryFile.MimeType.get -> string!
-LM.Core.Models.EntryFile.MimeType.set -> void
-LM.Core.Models.EntryFile.OriginalFileName.get -> string!
-LM.Core.Models.EntryFile.OriginalFileName.set -> void
-LM.Core.Models.EntryFile.RelativePath.get -> string!
-LM.Core.Models.EntryFile.RelativePath.set -> void
-LM.Core.Models.EntryFile.SizeBytes.get -> long
-LM.Core.Models.EntryFile.SizeBytes.set -> void
-LM.Core.Models.EntryFile.StoredFileName.get -> string!
-LM.Core.Models.EntryFile.StoredFileName.set -> void
-LM.Core.Models.EntryType
-LM.Core.Models.EntryType.LitSearch = 6 -> LM.Core.Models.EntryType
-LM.Core.Models.EntryType.Other = 5 -> LM.Core.Models.EntryType
-LM.Core.Models.EntryType.Presentation = 1 -> LM.Core.Models.EntryType
-LM.Core.Models.EntryType.Publication = 0 -> LM.Core.Models.EntryType
-LM.Core.Models.EntryType.Report = 4 -> LM.Core.Models.EntryType
-LM.Core.Models.EntryType.SlideDeck = 3 -> LM.Core.Models.EntryType
-LM.Core.Models.EntryType.WhitePaper = 2 -> LM.Core.Models.EntryType
-LM.Core.Models.FileMetadata
-LM.Core.Models.FileMetadata.Authors.get -> System.Collections.Generic.List<string!>!
-LM.Core.Models.FileMetadata.Authors.set -> void
-LM.Core.Models.FileMetadata.Doi.get -> string?
-LM.Core.Models.FileMetadata.Doi.set -> void
-LM.Core.Models.FileMetadata.FileMetadata() -> void
-LM.Core.Models.FileMetadata.Pmid.get -> string?
-LM.Core.Models.FileMetadata.Pmid.set -> void
-LM.Core.Models.FileMetadata.Source.get -> string?
-LM.Core.Models.FileMetadata.Source.set -> void
-LM.Core.Models.FileMetadata.Tags.get -> System.Collections.Generic.List<string!>!
-LM.Core.Models.FileMetadata.Tags.set -> void
-LM.Core.Models.FileMetadata.Title.get -> string?
-LM.Core.Models.FileMetadata.Title.set -> void
-LM.Core.Models.FileMetadata.Year.get -> int?
-LM.Core.Models.FileMetadata.Year.set -> void
-LM.Core.Models.Filters.EntryFilter
-LM.Core.Models.Filters.EntryFilter.AuthorContains.get -> string?
-LM.Core.Models.Filters.EntryFilter.AuthorContains.set -> void
-LM.Core.Models.Filters.EntryFilter.EntryFilter() -> void
-LM.Core.Models.Filters.EntryFilter.IsInternal.get -> bool?
-LM.Core.Models.Filters.EntryFilter.IsInternal.set -> void
-LM.Core.Models.Filters.EntryFilter.TagMatchMode.get -> LM.Core.Models.Filters.TagMatchMode
-LM.Core.Models.Filters.EntryFilter.TagMatchMode.set -> void
-LM.Core.Models.Filters.EntryFilter.Tags.get -> System.Collections.Generic.List<string!>!
-LM.Core.Models.Filters.EntryFilter.Tags.set -> void
-LM.Core.Models.Filters.TagMatchMode
-LM.Core.Models.Filters.TagMatchMode.Any = 0 -> LM.Core.Models.Filters.TagMatchMode
-LM.Core.Models.Filters.TagMatchMode.All = 1 -> LM.Core.Models.Filters.TagMatchMode
-LM.Core.Models.Filters.TagMatchMode.Not = 2 -> LM.Core.Models.Filters.TagMatchMode
-LM.Core.Models.Filters.EntryFilter.TitleContains.get -> string?
-LM.Core.Models.Filters.EntryFilter.TitleContains.set -> void
-LM.Core.Models.Filters.EntryFilter.TypesAny.get -> LM.Core.Models.EntryType[]?
-LM.Core.Models.Filters.EntryFilter.TypesAny.set -> void
-LM.Core.Models.Filters.EntryFilter.YearFrom.get -> int?
-LM.Core.Models.Filters.EntryFilter.YearFrom.set -> void
-LM.Core.Models.Filters.EntryFilter.YearTo.get -> int?
-LM.Core.Models.Filters.EntryFilter.YearTo.set -> void
-LM.Core.Models.Filters.EntryFilter.SourceContains.get -> string?
-LM.Core.Models.Filters.EntryFilter.SourceContains.set -> void
-LM.Core.Models.Filters.EntryFilter.InternalIdContains.get -> string?
-LM.Core.Models.Filters.EntryFilter.InternalIdContains.set -> void
-LM.Core.Models.Filters.EntryFilter.DoiContains.get -> string?
-LM.Core.Models.Filters.EntryFilter.DoiContains.set -> void
-LM.Core.Models.Filters.EntryFilter.PmidContains.get -> string?
-LM.Core.Models.Filters.EntryFilter.PmidContains.set -> void
-LM.Core.Models.Filters.EntryFilter.NctContains.get -> string?
-LM.Core.Models.Filters.EntryFilter.NctContains.set -> void
-LM.Core.Models.Filters.EntryFilter.AddedByContains.get -> string?
-LM.Core.Models.Filters.EntryFilter.AddedByContains.set -> void
-LM.Core.Models.Filters.EntryFilter.AddedOnFromUtc.get -> System.DateTime?
-LM.Core.Models.Filters.EntryFilter.AddedOnFromUtc.set -> void
-LM.Core.Models.Filters.EntryFilter.AddedOnToUtc.get -> System.DateTime?
-LM.Core.Models.Filters.EntryFilter.AddedOnToUtc.set -> void
-LM.Core.Models.GrantInfo
-LM.Core.Models.GrantInfo.Agency.get -> string?
-LM.Core.Models.GrantInfo.Agency.init -> void
-LM.Core.Models.GrantInfo.Country.get -> string?
-LM.Core.Models.GrantInfo.Country.init -> void
-LM.Core.Models.GrantInfo.GrantId.get -> string?
-LM.Core.Models.GrantInfo.GrantId.init -> void
-LM.Core.Models.PublicationRecord
-LM.Core.Models.PublicationRecord.AbstractPlain.get -> string?
-LM.Core.Models.PublicationRecord.AbstractPlain.init -> void
-LM.Core.Models.PublicationRecord.AbstractSections.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AbstractSection!>!
-LM.Core.Models.PublicationRecord.AbstractSections.init -> void
-LM.Core.Models.PublicationRecord.Affiliations.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.Core.Models.PublicationRecord.Affiliations.init -> void
-LM.Core.Models.PublicationRecord.Authors.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.AuthorName!>!
-LM.Core.Models.PublicationRecord.Authors.init -> void
-LM.Core.Models.PublicationRecord.AuthorsCsv.get -> string!
-LM.Core.Models.PublicationRecord.CitedByCount.get -> int?
-LM.Core.Models.PublicationRecord.CitedByCount.init -> void
-LM.Core.Models.PublicationRecord.CitedByPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.Core.Models.PublicationRecord.CitedByPmids.init -> void
-LM.Core.Models.PublicationRecord.CommentsCorrections.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.Core.Models.PublicationRecord.CommentsCorrections.init -> void
-LM.Core.Models.PublicationRecord.Country.get -> string?
-LM.Core.Models.PublicationRecord.Country.init -> void
-LM.Core.Models.PublicationRecord.Doi.get -> string?
-LM.Core.Models.PublicationRecord.Doi.init -> void
-LM.Core.Models.PublicationRecord.FirstAuthorLast.get -> string!
-LM.Core.Models.PublicationRecord.Grants.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.GrantInfo!>!
-LM.Core.Models.PublicationRecord.Grants.init -> void
-LM.Core.Models.PublicationRecord.Issue.get -> string?
-LM.Core.Models.PublicationRecord.Issue.init -> void
-LM.Core.Models.PublicationRecord.JournalIsoAbbrev.get -> string?
-LM.Core.Models.PublicationRecord.JournalIsoAbbrev.init -> void
-LM.Core.Models.PublicationRecord.JournalTitle.get -> string?
-LM.Core.Models.PublicationRecord.JournalTitle.init -> void
-LM.Core.Models.PublicationRecord.Keywords.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.Core.Models.PublicationRecord.Keywords.init -> void
-LM.Core.Models.PublicationRecord.Language.get -> string?
-LM.Core.Models.PublicationRecord.Language.init -> void
-LM.Core.Models.PublicationRecord.MeshHeadings.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.Core.Models.PublicationRecord.MeshHeadings.init -> void
-LM.Core.Models.PublicationRecord.Pages.get -> string?
-LM.Core.Models.PublicationRecord.Pages.init -> void
-LM.Core.Models.PublicationRecord.Pmcid.get -> string?
-LM.Core.Models.PublicationRecord.Pmcid.init -> void
-LM.Core.Models.PublicationRecord.Pmid.get -> string?
-LM.Core.Models.PublicationRecord.Pmid.init -> void
-LM.Core.Models.PublicationRecord.PublicationTypes.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.Core.Models.PublicationRecord.PublicationTypes.init -> void
-LM.Core.Models.PublicationRecord.PublishedEpub.get -> System.DateOnly?
-LM.Core.Models.PublicationRecord.PublishedEpub.init -> void
-LM.Core.Models.PublicationRecord.PublishedPrint.get -> System.DateOnly?
-LM.Core.Models.PublicationRecord.PublishedPrint.init -> void
-LM.Core.Models.PublicationRecord.ReferencedPmids.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.Core.Models.PublicationRecord.ReferencedPmids.init -> void
-LM.Core.Models.PublicationRecord.Title.get -> string?
-LM.Core.Models.PublicationRecord.Title.init -> void
-LM.Core.Models.PublicationRecord.UrlPubMed.get -> string?
-LM.Core.Models.PublicationRecord.UrlPubMed.init -> void
-LM.Core.Models.PublicationRecord.Volume.get -> string?
-LM.Core.Models.PublicationRecord.Volume.init -> void
-LM.Core.Models.PublicationRecord.Year.get -> int?
-LM.Core.Models.PublicationRecord.Year.init -> void
-LM.Core.Models.Relation
-LM.Core.Models.Relation.Relation() -> void
-LM.Core.Models.Relation.TargetEntryId.get -> string!
-LM.Core.Models.Relation.TargetEntryId.set -> void
-LM.Core.Models.Relation.Type.get -> string!
-LM.Core.Models.Relation.Type.set -> void
-LM.Core.Models.Search.FullTextSearchHit.EntryId.init -> void
-LM.Core.Models.Search.FullTextSearchHit.Highlight.init -> void
-LM.Core.Models.Search.FullTextSearchHit.Score.init -> void
-LM.Core.Models.Search.FullTextSearchQuery.TypesAny.get -> LM.Core.Models.EntryType[]?
-LM.Core.Models.SearchDatabase
-LM.Core.Models.SearchDatabase.ClinicalTrialsGov = 1 -> LM.Core.Models.SearchDatabase
-LM.Core.Models.SearchDatabase.PubMed = 0 -> LM.Core.Models.SearchDatabase
-LM.Core.Models.Search.FullTextSearchField
-LM.Core.Models.Search.FullTextSearchField.Abstract = 2 -> LM.Core.Models.Search.FullTextSearchField
-LM.Core.Models.Search.FullTextSearchField.Content = 4 -> LM.Core.Models.Search.FullTextSearchField
-LM.Core.Models.Search.FullTextSearchField.None = 0 -> LM.Core.Models.Search.FullTextSearchField
-LM.Core.Models.Search.FullTextSearchField.Title = 1 -> LM.Core.Models.Search.FullTextSearchField
-LM.Core.Models.Search.FullTextSearchHit
-LM.Core.Models.Search.FullTextSearchHit.EntryId.get -> string!
-LM.Core.Models.Search.FullTextSearchHit.FullTextSearchHit(string! EntryId, double Score, string? Highlight) -> void
-LM.Core.Models.Search.FullTextSearchHit.Highlight.get -> string?
-LM.Core.Models.Search.FullTextSearchHit.Score.get -> double
-LM.Core.Models.Search.FullTextSearchQuery
-LM.Core.Models.Search.FullTextSearchQuery.Fields.get -> LM.Core.Models.Search.FullTextSearchField
-LM.Core.Models.Search.FullTextSearchQuery.Fields.set -> void
-LM.Core.Models.Search.FullTextSearchQuery.FullTextSearchQuery() -> void
-LM.Core.Models.Search.FullTextSearchQuery.IsInternal.get -> bool?
-LM.Core.Models.Search.FullTextSearchQuery.IsInternal.set -> void
-LM.Core.Models.Search.FullTextSearchQuery.Limit.get -> int
-LM.Core.Models.Search.FullTextSearchQuery.Limit.set -> void
-LM.Core.Models.Search.FullTextSearchQuery.Text.get -> string?
-LM.Core.Models.Search.FullTextSearchQuery.Text.set -> void
-LM.Core.Models.Search.FullTextSearchQuery.TypesAny.set -> void
-LM.Core.Models.Search.FullTextSearchQuery.YearFrom.get -> int?
-LM.Core.Models.Search.FullTextSearchQuery.YearFrom.set -> void
-LM.Core.Models.Search.FullTextSearchQuery.YearTo.get -> int?
-LM.Core.Models.Search.FullTextSearchQuery.YearTo.set -> void
-LM.Core.Models.SearchHit
-LM.Core.Models.SearchHit.AlreadyInDb.get -> bool
-LM.Core.Models.SearchHit.AlreadyInDb.set -> void
-LM.Core.Models.SearchHit.Authors.get -> string!
-LM.Core.Models.SearchHit.Authors.init -> void
-LM.Core.Models.SearchHit.Doi.get -> string?
-LM.Core.Models.SearchHit.Doi.init -> void
-LM.Core.Models.SearchHit.ExternalId.get -> string!
-LM.Core.Models.SearchHit.ExternalId.init -> void
-LM.Core.Models.SearchHit.ExistingEntryId.get -> string?
-LM.Core.Models.SearchHit.ExistingEntryId.set -> void
-LM.Core.Models.SearchHit.JournalOrSource.get -> string?
-LM.Core.Models.SearchHit.JournalOrSource.init -> void
-LM.Core.Models.SearchHit.SearchHit() -> void
-LM.Core.Models.SearchHit.Selected.get -> bool
-LM.Core.Models.SearchHit.Selected.set -> void
-LM.Core.Models.SearchHit.Source.get -> LM.Core.Models.SearchDatabase
-LM.Core.Models.SearchHit.Source.init -> void
-LM.Core.Models.SearchHit.Title.get -> string!
-LM.Core.Models.SearchHit.Title.init -> void
-LM.Core.Models.SearchHit.Url.get -> string?
-LM.Core.Models.SearchHit.Url.init -> void
-LM.Core.Models.SearchHit.Year.get -> int?
-LM.Core.Models.SearchHit.Year.init -> void
-LM.Core.Models.SearchHit.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
-LM.Core.Models.WatchedFolderState.WatchedFolderState(string! Path, System.DateTimeOffset? LastScanUtc, string? AggregatedHash, bool LastScanWasUnchanged) -> void
-LM.Core.Utils.Hashes
-LM.Core.Utils.IdGen
-LM.Core.Utils.JsonEx
-LM.Core.Utils.NullDataExtractionPreprocessor
-LM.Core.Utils.NullDataExtractionPreprocessor.PreprocessAsync(LM.Core.Models.DataExtraction.DataExtractionPreprocessRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.DataExtraction.DataExtractionPreprocessResult!>!
-LM.Core.Utils.SystemUser
-static LM.Core.Models.DataExtraction.DataExtractionPreprocessResult.Empty.get -> LM.Core.Models.DataExtraction.DataExtractionPreprocessResult!
-static LM.Core.Utils.Hashes.Sha1(string! input) -> string!
-static LM.Core.Utils.Hashes.Sha256File(string! path) -> string!
-static LM.Core.Utils.IdGen.NewId() -> string!
-static LM.Core.Utils.JsonEx.Deserialize<T>(string! s) -> T?
-static LM.Core.Utils.JsonEx.Serialize<T>(T v) -> string!
-static LM.Core.Utils.SystemUser.GetCurrent() -> string!
-LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.WatchedFolderSettings!>!
-LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore.SaveAsync(LM.Core.Models.WatchedFolderSettings! settings, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-LM.Core.Abstractions.Configuration.ISearchHistoryStore
-LM.Core.Abstractions.Configuration.ISearchHistoryStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.Search.SearchHistoryDocument!>!
-LM.Core.Abstractions.Configuration.ISearchHistoryStore.SaveAsync(LM.Core.Models.Search.SearchHistoryDocument! document, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-LM.Core.Abstractions.Configuration.IUserPreferencesStore
-LM.Core.Abstractions.Configuration.IUserPreferencesStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.UserPreferences!>!
-LM.Core.Abstractions.Configuration.IUserPreferencesStore.SaveAsync(LM.Core.Models.UserPreferences! preferences, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-LM.Core.Models.Search.SearchHistoryDocument
-LM.Core.Models.Search.SearchHistoryDocument.Entries.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.Search.SearchHistoryEntry!>!
-LM.Core.Models.Search.SearchHistoryDocument.Entries.init -> void
-LM.Core.Models.Search.SearchHistoryEntry
-LM.Core.Models.Search.SearchHistoryEntry.Database.get -> LM.Core.Models.SearchDatabase
-LM.Core.Models.Search.SearchHistoryEntry.Database.init -> void
-LM.Core.Models.Search.SearchHistoryEntry.ExecutedUtc.get -> System.DateTimeOffset
-LM.Core.Models.Search.SearchHistoryEntry.ExecutedUtc.init -> void
-LM.Core.Models.Search.SearchHistoryEntry.From.get -> System.DateTime?
-LM.Core.Models.Search.SearchHistoryEntry.From.init -> void
-LM.Core.Models.Search.SearchHistoryEntry.Query.get -> string!
-LM.Core.Models.Search.SearchHistoryEntry.Query.init -> void
-LM.Core.Models.Search.SearchHistoryEntry.To.get -> System.DateTime?
-LM.Core.Models.Search.SearchHistoryEntry.To.init -> void
-LM.Core.Models.Search.SearchExecutionRequest
-LM.Core.Models.Search.SearchExecutionRequest.Database.get -> LM.Core.Models.SearchDatabase
-LM.Core.Models.Search.SearchExecutionRequest.Database.init -> void
-LM.Core.Models.Search.SearchExecutionRequest.From.get -> System.DateTime?
-LM.Core.Models.Search.SearchExecutionRequest.From.init -> void
-LM.Core.Models.Search.SearchExecutionRequest.Query.get -> string!
-LM.Core.Models.Search.SearchExecutionRequest.Query.init -> void
-LM.Core.Models.Search.SearchExecutionRequest.To.get -> System.DateTime?
-LM.Core.Models.Search.SearchExecutionRequest.To.init -> void
-LM.Core.Models.Search.SearchExecutionResult
-LM.Core.Models.Search.SearchExecutionResult.ExecutedUtc.get -> System.DateTimeOffset
-LM.Core.Models.Search.SearchExecutionResult.ExecutedUtc.init -> void
-LM.Core.Models.Search.SearchExecutionResult.Hits.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.SearchHit!>!
-LM.Core.Models.Search.SearchExecutionResult.Hits.init -> void
-LM.Core.Models.Search.SearchExecutionResult.Request.get -> LM.Core.Models.Search.SearchExecutionRequest!
-LM.Core.Models.Search.SearchExecutionResult.Request.init -> void
-LM.Core.Models.UserPreferences
-LM.Core.Models.UserPreferences.Search.get -> LM.Core.Models.SearchPreferences!
-LM.Core.Models.UserPreferences.Search.init -> void
-LM.Core.Models.UserPreferences.Library.get -> LM.Core.Models.LibraryPreferences!
-LM.Core.Models.UserPreferences.Library.init -> void
-LM.Core.Models.SearchPreferences
-LM.Core.Models.SearchPreferences.LastSelectedDatabase.get -> LM.Core.Models.SearchDatabase
-LM.Core.Models.SearchPreferences.LastSelectedDatabase.init -> void
-LM.Core.Models.SearchPreferences.LastUpdatedUtc.get -> System.DateTimeOffset
-LM.Core.Models.SearchPreferences.LastUpdatedUtc.init -> void
-LM.Core.Models.LibraryPreferences
-LM.Core.Models.LibraryPreferences.VisibleColumns.get -> string![]!
-LM.Core.Models.LibraryPreferences.VisibleColumns.init -> void
-LM.Core.Models.LibraryPreferences.LastUpdatedUtc.get -> System.DateTimeOffset
-LM.Core.Models.LibraryPreferences.LastUpdatedUtc.init -> void
-LM.Core.Models.WatchedFolderSettings
-LM.Core.Models.WatchedFolderSettings.Folders.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.WatchedFolderSettingsFolder!>!
-LM.Core.Models.WatchedFolderSettings.Folders.init -> void
-LM.Core.Models.WatchedFolderSettings.States.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.WatchedFolderState!>!
-LM.Core.Models.WatchedFolderSettings.States.init -> void
-LM.Core.Models.WatchedFolderSettingsFolder
-LM.Core.Models.WatchedFolderSettingsFolder.IsEnabled.get -> bool
-LM.Core.Models.WatchedFolderSettingsFolder.IsEnabled.init -> void
-LM.Core.Models.WatchedFolderSettingsFolder.Path.get -> string!
-LM.Core.Models.WatchedFolderSettingsFolder.Path.init -> void
-LM.Core.Models.WatchedFolderState
-LM.Core.Models.WatchedFolderState.AggregatedHash.get -> string?
-LM.Core.Models.WatchedFolderState.AggregatedHash.init -> void
-LM.Core.Models.WatchedFolderState.LastScanUtc.get -> System.DateTimeOffset?
-LM.Core.Models.WatchedFolderState.LastScanUtc.init -> void
-LM.Core.Models.WatchedFolderState.LastScanWasUnchanged.get -> bool
-LM.Core.Models.WatchedFolderState.LastScanWasUnchanged.init -> void
-LM.Core.Models.WatchedFolderState.Path.get -> string!
-LM.Core.Models.WatchedFolderState.Path.init -> void
-static LM.Core.Utils.NullDataExtractionPreprocessor.Instance.get -> LM.Core.Utils.NullDataExtractionPreprocessor!
-static readonly LM.Core.Utils.JsonEx.Options -> System.Text.Json.JsonSerializerOptions!
-LM.Core.Abstractions.IDataExtractionPowerPointExporter
-LM.Core.Abstractions.IDataExtractionExcelExporter
-LM.Core.Abstractions.IDataExtractionWordExporter
 ---------- LM.HubSpoke ----------
 #nullable enable
 #nullable enable
@@ -3359,198 +1757,709 @@ static LM.HubSpoke.Models.EntryNotesSummary.FromLitSearch(LM.HubSpoke.Models.Lit
 static LM.HubSpoke.Models.EntryNotesSummary.FromRawText(string! text) -> LM.HubSpoke.Models.EntryNotesSummary!
 static LM.HubSpoke.Models.PersonRef.Unknown.get -> LM.HubSpoke.Models.PersonRef
 static readonly LM.HubSpoke.Models.JsonStd.Options -> System.Text.Json.JsonSerializerOptions!
----------- LM.Review.Core ----------
+---------- LM.App.Wpf ----------
 #nullable enable
-LM.Review.Core.Models.ConflictState
-LM.Review.Core.Models.ConflictState.None = 0 -> LM.Review.Core.Models.ConflictState
-LM.Review.Core.Models.ConflictState.Conflict = 1 -> LM.Review.Core.Models.ConflictState
-LM.Review.Core.Models.ConflictState.Escalated = 2 -> LM.Review.Core.Models.ConflictState
-LM.Review.Core.Models.ConflictState.Resolved = 3 -> LM.Review.Core.Models.ConflictState
-LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ScreeningStatus.Pending = 0 -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ScreeningStatus.InProgress = 1 -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ScreeningStatus.Included = 2 -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ScreeningStatus.Excluded = 3 -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ScreeningStatus.Escalated = 4 -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ReviewerRole
-LM.Review.Core.Models.ReviewerRole.Primary = 0 -> LM.Review.Core.Models.ReviewerRole
-LM.Review.Core.Models.ReviewerRole.Secondary = 1 -> LM.Review.Core.Models.ReviewerRole
-LM.Review.Core.Models.ReviewerRole.TieBreaker = 2 -> LM.Review.Core.Models.ReviewerRole
-LM.Review.Core.Models.ReviewerRole.Arbitrator = 3 -> LM.Review.Core.Models.ReviewerRole
-LM.Review.Core.Models.ReviewStageType
-LM.Review.Core.Models.ReviewStageType.TitleScreening = 0 -> LM.Review.Core.Models.ReviewStageType
-LM.Review.Core.Models.ReviewStageType.FullTextReview = 1 -> LM.Review.Core.Models.ReviewStageType
-LM.Review.Core.Models.ReviewStageType.ConsensusMeeting = 2 -> LM.Review.Core.Models.ReviewStageType
-LM.Review.Core.Models.ReviewStageType.QualityAssurance = 3 -> LM.Review.Core.Models.ReviewStageType
-LM.Review.Core.Models.ReviewerDecision
-LM.Review.Core.Models.ReviewerDecision.AssignmentId.get -> string!
-static LM.Review.Core.Models.ReviewerDecision.Create(string! assignmentId, string! reviewerId, LM.Review.Core.Models.ScreeningStatus decision, System.DateTimeOffset decidedAtUtc, string? notes = null) -> LM.Review.Core.Models.ReviewerDecision!
-LM.Review.Core.Models.ReviewerDecision.DecidedAt.get -> System.DateTimeOffset
-LM.Review.Core.Models.ReviewerDecision.Decision.get -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.ReviewerDecision.Notes.get -> string?
-LM.Review.Core.Models.ReviewerDecision.ReviewerId.get -> string!
-LM.Review.Core.Models.ConsensusOutcome
-LM.Review.Core.Models.ConsensusOutcome.Approved.get -> bool
-static LM.Review.Core.Models.ConsensusOutcome.Create(string! stageId, bool approved, LM.Review.Core.Models.ConflictState resultingState, System.DateTimeOffset resolvedAtUtc, string? notes = null, string? resolvedBy = null) -> LM.Review.Core.Models.ConsensusOutcome!
-LM.Review.Core.Models.ConsensusOutcome.Notes.get -> string?
-LM.Review.Core.Models.ConsensusOutcome.ResolvedAt.get -> System.DateTimeOffset
-LM.Review.Core.Models.ConsensusOutcome.ResolvedBy.get -> string?
-LM.Review.Core.Models.ConsensusOutcome.ResultingState.get -> LM.Review.Core.Models.ConflictState
-LM.Review.Core.Models.ConsensusOutcome.StageId.get -> string!
-LM.Review.Core.Models.ReviewAuditTrail
-LM.Review.Core.Models.ReviewAuditTrail.Append(LM.Review.Core.Models.ReviewAuditTrail.AuditEntry! entry) -> LM.Review.Core.Models.ReviewAuditTrail!
-static LM.Review.Core.Models.ReviewAuditTrail.Create(System.Collections.Generic.IEnumerable<LM.Review.Core.Models.ReviewAuditTrail.AuditEntry!>? entries = null) -> LM.Review.Core.Models.ReviewAuditTrail!
-LM.Review.Core.Models.ReviewAuditTrail.Entries.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.ReviewAuditTrail.AuditEntry!>!
-LM.Review.Core.Models.ReviewAuditTrail.AuditEntry
-LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Action.get -> string!
-LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Actor.get -> string!
-static LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Create(string! id, string! actor, string! action, System.DateTimeOffset occurredAtUtc, string? details = null) -> LM.Review.Core.Models.ReviewAuditTrail.AuditEntry!
-LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Details.get -> string?
-LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.Id.get -> string!
-LM.Review.Core.Models.ReviewAuditTrail.AuditEntry.OccurredAt.get -> System.DateTimeOffset
-LM.Review.Core.Models.ReviewProject
-LM.Review.Core.Models.ReviewProject.AuditTrail.get -> LM.Review.Core.Models.ReviewAuditTrail!
-static LM.Review.Core.Models.ReviewProject.Create(string! id, string! name, System.DateTimeOffset createdAtUtc, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.StageDefinition!>! stageDefinitions, LM.Review.Core.Models.ReviewAuditTrail? auditTrail = null) -> LM.Review.Core.Models.ReviewProject!
-LM.Review.Core.Models.ReviewProject.CreatedAt.get -> System.DateTimeOffset
-LM.Review.Core.Models.ReviewProject.Id.get -> string!
-LM.Review.Core.Models.ReviewProject.Name.get -> string!
-LM.Review.Core.Models.ReviewProject.StageDefinitions.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.StageDefinition!>!
-LM.Review.Core.Models.ReviewStage
-LM.Review.Core.Models.ReviewStage.ActivatedAt.get -> System.DateTimeOffset
-LM.Review.Core.Models.ReviewStage.Assignments.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.ScreeningAssignment!>!
-LM.Review.Core.Models.ReviewStage.CompletedAt.get -> System.DateTimeOffset?
-LM.Review.Core.Models.ReviewStage.Consensus.get -> LM.Review.Core.Models.ConsensusOutcome?
-LM.Review.Core.Models.ReviewStage.ConflictState.get -> LM.Review.Core.Models.ConflictState
-static LM.Review.Core.Models.ReviewStage.Create(string! id, string! projectId, LM.Review.Core.Models.StageDefinition! definition, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.ScreeningAssignment!>! assignments, LM.Review.Core.Models.ConflictState conflictState, System.DateTimeOffset activatedAtUtc, System.DateTimeOffset? completedAtUtc = null, LM.Review.Core.Models.ConsensusOutcome? consensus = null) -> LM.Review.Core.Models.ReviewStage!
-LM.Review.Core.Models.ReviewStage.Definition.get -> LM.Review.Core.Models.StageDefinition!
-LM.Review.Core.Models.ReviewStage.Id.get -> string!
-LM.Review.Core.Models.ReviewStage.IsComplete.get -> bool
-LM.Review.Core.Models.ReviewStage.ProjectId.get -> string!
-LM.Review.Core.Models.StageDefinition
-LM.Review.Core.Models.StageDefinition.ConsensusPolicy.get -> LM.Review.Core.Models.StageConsensusPolicy!
-static LM.Review.Core.Models.StageDefinition.Create(string! id, string! name, LM.Review.Core.Models.ReviewStageType stageType, LM.Review.Core.Models.ReviewerRequirement! reviewerRequirement, LM.Review.Core.Models.StageConsensusPolicy! consensusPolicy) -> LM.Review.Core.Models.StageDefinition!
-LM.Review.Core.Models.StageDefinition.Id.get -> string!
-LM.Review.Core.Models.StageDefinition.Name.get -> string!
-LM.Review.Core.Models.StageDefinition.ReviewerRequirement.get -> LM.Review.Core.Models.ReviewerRequirement!
-LM.Review.Core.Models.StageDefinition.StageType.get -> LM.Review.Core.Models.ReviewStageType
-LM.Review.Core.Models.StageConsensusPolicy
-LM.Review.Core.Models.StageConsensusPolicy.ArbitrationRole.get -> LM.Review.Core.Models.ReviewerRole?
-static LM.Review.Core.Models.StageConsensusPolicy.Disabled() -> LM.Review.Core.Models.StageConsensusPolicy!
-LM.Review.Core.Models.StageConsensusPolicy.EscalateOnDisagreement.get -> bool
-LM.Review.Core.Models.StageConsensusPolicy.MinimumAgreements.get -> int
-static LM.Review.Core.Models.StageConsensusPolicy.RequireAgreement(int minimumAgreements, bool escalateOnDisagreement, LM.Review.Core.Models.ReviewerRole? arbitrationRole) -> LM.Review.Core.Models.StageConsensusPolicy!
-LM.Review.Core.Models.StageConsensusPolicy.RequiresConsensus.get -> bool
-LM.Review.Core.Models.ReviewerRequirement
-static LM.Review.Core.Models.ReviewerRequirement.Create(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<LM.Review.Core.Models.ReviewerRole, int>>! requirements) -> LM.Review.Core.Models.ReviewerRequirement!
-LM.Review.Core.Models.ReviewerRequirement.GetRequirement(LM.Review.Core.Models.ReviewerRole role) -> int
-LM.Review.Core.Models.ReviewerRequirement.Requirements.get -> System.Collections.Generic.IReadOnlyDictionary<LM.Review.Core.Models.ReviewerRole, int>!
-LM.Review.Core.Models.ReviewerRequirement.TotalRequired.get -> int
-LM.Review.Core.Models.ScreeningAssignment
-LM.Review.Core.Models.ScreeningAssignment.AssignedAt.get -> System.DateTimeOffset
-LM.Review.Core.Models.ScreeningAssignment.CompletedAt.get -> System.DateTimeOffset?
-static LM.Review.Core.Models.ScreeningAssignment.Create(string! id, string! stageId, string! reviewerId, LM.Review.Core.Models.ReviewerRole role, LM.Review.Core.Models.ScreeningStatus status, System.DateTimeOffset assignedAtUtc, System.DateTimeOffset? completedAtUtc = null, LM.Review.Core.Models.ReviewerDecision? decision = null) -> LM.Review.Core.Models.ScreeningAssignment!
-LM.Review.Core.Models.ScreeningAssignment.Decision.get -> LM.Review.Core.Models.ReviewerDecision?
-LM.Review.Core.Models.ScreeningAssignment.Id.get -> string!
-LM.Review.Core.Models.ScreeningAssignment.ReviewerId.get -> string!
-LM.Review.Core.Models.ScreeningAssignment.Role.get -> LM.Review.Core.Models.ReviewerRole
-LM.Review.Core.Models.ScreeningAssignment.StageId.get -> string!
-LM.Review.Core.Models.ScreeningAssignment.Status.get -> LM.Review.Core.Models.ScreeningStatus
-LM.Review.Core.Models.Forms.ExtractionForm
-LM.Review.Core.Models.Forms.ExtractionForm.Category.get -> string?
-static LM.Review.Core.Models.Forms.ExtractionForm.Create(string! id, string! name, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Forms.FormSection!>! sections, string? description = null, string? category = null) -> LM.Review.Core.Models.Forms.ExtractionForm!
-LM.Review.Core.Models.Forms.ExtractionForm.Description.get -> string?
-LM.Review.Core.Models.Forms.ExtractionForm.Id.get -> string!
-LM.Review.Core.Models.Forms.ExtractionForm.Name.get -> string!
-LM.Review.Core.Models.Forms.ExtractionForm.Sections.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Forms.FormSection!>!
-LM.Review.Core.Models.Forms.FormField
-LM.Review.Core.Models.Forms.FormField.AllowFreeTextFallback.get -> bool
-LM.Review.Core.Models.Forms.FormField.Description.get -> string?
-LM.Review.Core.Models.Forms.FormField.FieldType.get -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormField.Id.get -> string!
-LM.Review.Core.Models.Forms.FormField.Options.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Forms.FormFieldOption!>!
-LM.Review.Core.Models.Forms.FormField.Title.get -> string!
-LM.Review.Core.Models.Forms.FormField.Validation.get -> LM.Review.Core.Models.Forms.FormFieldValidation?
-LM.Review.Core.Models.Forms.FormField.Visibility.get -> LM.Review.Core.Models.Forms.FormVisibilityRule?
-static LM.Review.Core.Models.Forms.FormField.Create(string! id, string! title, LM.Review.Core.Models.Forms.FormFieldType fieldType, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Forms.FormFieldOption!>? options = null, string? description = null, LM.Review.Core.Models.Forms.FormFieldValidation? validation = null, LM.Review.Core.Models.Forms.FormVisibilityRule? visibility = null, bool allowFreeTextFallback = false) -> LM.Review.Core.Models.Forms.FormField!
-LM.Review.Core.Models.Forms.FormFieldOption
-LM.Review.Core.Models.Forms.FormFieldOption.Description.get -> string?
-LM.Review.Core.Models.Forms.FormFieldOption.Id.get -> string!
-LM.Review.Core.Models.Forms.FormFieldOption.IsDefault.get -> bool
-LM.Review.Core.Models.Forms.FormFieldOption.Label.get -> string!
-static LM.Review.Core.Models.Forms.FormFieldOption.Create(string! id, string! label, string? description = null, bool isDefault = false) -> LM.Review.Core.Models.Forms.FormFieldOption!
-LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldType.SingleSelect = 0 -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldType.MultiSelect = 1 -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldType.Text = 2 -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldType.Numeric = 3 -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldType.Date = 4 -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldType.Reference = 5 -> LM.Review.Core.Models.Forms.FormFieldType
-LM.Review.Core.Models.Forms.FormFieldValidation
-LM.Review.Core.Models.Forms.FormFieldValidation.Expression.get -> string?
-LM.Review.Core.Models.Forms.FormFieldValidation.Maximum.get -> decimal?
-LM.Review.Core.Models.Forms.FormFieldValidation.MaximumDateUtc.get -> System.DateTime?
-LM.Review.Core.Models.Forms.FormFieldValidation.Minimum.get -> decimal?
-LM.Review.Core.Models.Forms.FormFieldValidation.MinimumDateUtc.get -> System.DateTime?
-LM.Review.Core.Models.Forms.FormFieldValidation.Mode.get -> LM.Review.Core.Models.Forms.FormValidationMode
-static LM.Review.Core.Models.Forms.FormFieldValidation.CreateDateRange(System.DateTime? minimumUtc, System.DateTime? maximumUtc) -> LM.Review.Core.Models.Forms.FormFieldValidation!
-static LM.Review.Core.Models.Forms.FormFieldValidation.CreateNumericRange(decimal? minimum, decimal? maximum) -> LM.Review.Core.Models.Forms.FormFieldValidation!
-static LM.Review.Core.Models.Forms.FormFieldValidation.CreateRegex(string! pattern) -> LM.Review.Core.Models.Forms.FormFieldValidation!
-static LM.Review.Core.Models.Forms.FormFieldValidation.CreateRequired() -> LM.Review.Core.Models.Forms.FormFieldValidation!
-LM.Review.Core.Models.Forms.FormIdentifier
-static bool LM.Review.Core.Models.Forms.FormIdentifier.IsNormalized(string! identifier) -> bool
-static string LM.Review.Core.Models.Forms.FormIdentifier.Normalize(string! identifier) -> string!
-LM.Review.Core.Models.Forms.FormSection
-LM.Review.Core.Models.Forms.FormSection.Children.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Forms.FormSection!>!
-LM.Review.Core.Models.Forms.FormSection.Description.get -> string?
-LM.Review.Core.Models.Forms.FormSection.Fields.get -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Models.Forms.FormField!>!
-LM.Review.Core.Models.Forms.FormSection.Id.get -> string!
-LM.Review.Core.Models.Forms.FormSection.IsRepeatable.get -> bool
-LM.Review.Core.Models.Forms.FormSection.Title.get -> string!
-LM.Review.Core.Models.Forms.FormSection.Visibility.get -> LM.Review.Core.Models.Forms.FormVisibilityRule?
-static LM.Review.Core.Models.Forms.FormSection.Create(string! id, string! title, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Forms.FormField!>! fields, System.Collections.Generic.IEnumerable<LM.Review.Core.Models.Forms.FormSection!>? children = null, bool isRepeatable = false, string? description = null, LM.Review.Core.Models.Forms.FormVisibilityRule? visibility = null) -> LM.Review.Core.Models.Forms.FormSection!
-LM.Review.Core.Models.Forms.FormValidationMode
-LM.Review.Core.Models.Forms.FormValidationMode.Required = 0 -> LM.Review.Core.Models.Forms.FormValidationMode
-LM.Review.Core.Models.Forms.FormValidationMode.Range = 1 -> LM.Review.Core.Models.Forms.FormValidationMode
-LM.Review.Core.Models.Forms.FormValidationMode.Regex = 2 -> LM.Review.Core.Models.Forms.FormValidationMode
-LM.Review.Core.Models.Forms.FormVisibilityRule
-LM.Review.Core.Models.Forms.FormVisibilityRule.ExpectedValues.get -> System.Collections.Generic.IReadOnlyList<string>!
-LM.Review.Core.Models.Forms.FormVisibilityRule.IsVisibleWhenMatches.get -> bool
-LM.Review.Core.Models.Forms.FormVisibilityRule.SourceFieldId.get -> string!
-static LM.Review.Core.Models.Forms.FormVisibilityRule.Create(string! sourceFieldId, System.Collections.Generic.IEnumerable<string>? expectedValues = null, bool isVisibleWhenMatches = true) -> LM.Review.Core.Models.Forms.FormVisibilityRule!
-LM.Review.Core.Models.Forms.ExtractionFormSnapshot
-LM.Review.Core.Models.Forms.ExtractionFormSnapshot.CapturedBy.get -> string!
-LM.Review.Core.Models.Forms.ExtractionFormSnapshot.CapturedUtc.get -> System.DateTime
-LM.Review.Core.Models.Forms.ExtractionFormSnapshot.FormId.get -> string!
-LM.Review.Core.Models.Forms.ExtractionFormSnapshot.Values.get -> System.Collections.Generic.IReadOnlyDictionary<string, object?>!
-LM.Review.Core.Models.Forms.ExtractionFormSnapshot.VersionId.get -> string!
-static LM.Review.Core.Models.Forms.ExtractionFormSnapshot.Create(string! formId, string! versionId, System.Collections.Generic.IDictionary<string, object?>! values, string? capturedBy = null, System.DateTime? capturedUtc = null) -> LM.Review.Core.Models.Forms.ExtractionFormSnapshot!
-LM.Review.Core.Models.Forms.ExtractionFormVersion
-LM.Review.Core.Models.Forms.ExtractionFormVersion.CreatedBy.get -> string!
-LM.Review.Core.Models.Forms.ExtractionFormVersion.CreatedUtc.get -> System.DateTime
-LM.Review.Core.Models.Forms.ExtractionFormVersion.Form.get -> LM.Review.Core.Models.Forms.ExtractionForm!
-LM.Review.Core.Models.Forms.ExtractionFormVersion.Metadata.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>!
-LM.Review.Core.Models.Forms.ExtractionFormVersion.VersionId.get -> string!
-static LM.Review.Core.Models.Forms.ExtractionFormVersion.Create(string! versionId, LM.Review.Core.Models.Forms.ExtractionForm! form, System.Collections.Generic.IDictionary<string, string>? metadata = null, string? createdBy = null, System.DateTime? createdUtc = null) -> LM.Review.Core.Models.Forms.ExtractionFormVersion!
-LM.Review.Core.Validation.FormSchemaIssue
-LM.Review.Core.Validation.FormSchemaIssue.Code.get -> string!
-LM.Review.Core.Validation.FormSchemaIssue.FieldId.get -> string?
-LM.Review.Core.Validation.FormSchemaIssue.Message.get -> string!
-LM.Review.Core.Validation.FormSchemaIssue.SectionId.get -> string?
-LM.Review.Core.Validation.FormSchemaIssue.Severity.get -> LM.Review.Core.Validation.FormSchemaSeverity
-static LM.Review.Core.Validation.FormSchemaIssue.Error(string! code, string! message, string? sectionId = null, string? fieldId = null) -> LM.Review.Core.Validation.FormSchemaIssue!
-static LM.Review.Core.Validation.FormSchemaIssue.Warning(string! code, string! message, string? sectionId = null, string? fieldId = null) -> LM.Review.Core.Validation.FormSchemaIssue!
-LM.Review.Core.Validation.FormSchemaSeverity
-LM.Review.Core.Validation.FormSchemaSeverity.Warning = 0 -> LM.Review.Core.Validation.FormSchemaSeverity
-LM.Review.Core.Validation.FormSchemaSeverity.Error = 1 -> LM.Review.Core.Validation.FormSchemaSeverity
-LM.Review.Core.Validation.FormSchemaValidator
-LM.Review.Core.Validation.FormSchemaValidator.Validate(LM.Review.Core.Models.Forms.ExtractionForm! form) -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Validation.FormSchemaIssue!>!
-LM.Review.Core.Validation.FormSchemaValidator.Validate(LM.Review.Core.Models.Forms.ExtractionFormSnapshot! snapshot, LM.Review.Core.Models.Forms.ExtractionFormVersion! version) -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Validation.FormSchemaIssue!>!
-LM.Review.Core.Validation.FormSchemaValidator.Validate(LM.Review.Core.Models.Forms.ExtractionFormVersion! version) -> System.Collections.Generic.IReadOnlyList<LM.Review.Core.Validation.FormSchemaIssue!>!
+LM.App.Wpf.Views.Behaviors.DataGridColumnVisibilityBehavior.ColumnKeyProperty -> System.Windows.DependencyProperty!
+LM.App.Wpf.Views.Behaviors.DataGridColumnVisibilityBehavior.GetColumnKey(System.Windows.DependencyObject! element) -> string?
+LM.App.Wpf.Views.Behaviors.DataGridColumnVisibilityBehavior.SetColumnKey(System.Windows.DependencyObject! element, string? value) -> void
 #nullable enable
-LM.Review.Core.DataExtraction.TableVocabulary
-LM.Review.Core.DataExtraction.TableVocabulary.ClassifyColumnHeader(string? header) -> LM.Core.Models.DataExtraction.TableColumnRole
-LM.Review.Core.DataExtraction.TableVocabulary.ClassifyRowLabel(string? label) -> LM.Core.Models.DataExtraction.TableRowRole
-LM.Review.Core.DataExtraction.TableVocabulary.ClassifyTitle(string? title) -> LM.Core.Models.DataExtraction.TableClassificationKind
-LM.Review.Core.DataExtraction.TableVocabulary.NormalizeHeader(string header) -> string!
-LM.Review.Core.DataExtraction.TableVocabulary.TryDetectEndpoint(string? token) -> string?
-LM.Review.Core.DataExtraction.TableVocabulary.TryDetectPopulation(string? token) -> string?
+const LM.App.Wpf.ViewModels.StagingItem.DuplicateThreshold = 0.999 -> double
+const LM.App.Wpf.ViewModels.StagingItem.NearThreshold = 0.75 -> double
+LM.App.Wpf.App
+LM.App.Wpf.App.App() -> void
+LM.App.Wpf.App.InitializeComponent() -> void
+LM.App.Wpf.Common.AsyncRelayCommand
+LM.App.Wpf.Common.AsyncRelayCommand.AsyncRelayCommand(System.Func<object?, System.Threading.Tasks.Task!>! execute, System.Func<object?, bool>? canExecute = null) -> void
+LM.App.Wpf.Common.AsyncRelayCommand.AsyncRelayCommand(System.Func<System.Threading.Tasks.Task!>! execute, System.Func<bool>? canExecute = null) -> void
+LM.App.Wpf.Common.AsyncRelayCommand.CanExecute(object? parameter) -> bool
+LM.App.Wpf.Common.AsyncRelayCommand.CanExecuteChanged -> System.EventHandler?
+LM.App.Wpf.Common.AsyncRelayCommand.Execute(object? parameter) -> void
+LM.App.Wpf.Common.AsyncRelayCommand.RaiseCanExecuteChanged() -> void
+LM.App.Wpf.Common.BooleanToOpacityConverter
+LM.App.Wpf.Common.BooleanToOpacityConverter.BooleanToOpacityConverter() -> void
+LM.App.Wpf.Common.BooleanToOpacityConverter.Convert(object! value, System.Type! targetType, object! parameter, System.Globalization.CultureInfo! culture) -> object!
+LM.App.Wpf.Common.BooleanToOpacityConverter.ConvertBack(object! value, System.Type! targetType, object! parameter, System.Globalization.CultureInfo! culture) -> object!
+LM.App.Wpf.Common.BooleanToOpacityConverter.FalseOpacity.get -> double
+LM.App.Wpf.Common.BooleanToOpacityConverter.FalseOpacity.set -> void
+LM.App.Wpf.Common.BooleanToOpacityConverter.TrueOpacity.get -> double
+LM.App.Wpf.Common.BooleanToOpacityConverter.TrueOpacity.set -> void
+LM.App.Wpf.Common.Dialogs.FileSavePickerOptions
+LM.App.Wpf.Common.Dialogs.FileSavePickerOptions.DefaultFileName.get -> string?
+LM.App.Wpf.Common.Dialogs.FileSavePickerOptions.DefaultFileName.init -> void
+LM.App.Wpf.Common.Dialogs.FileSavePickerOptions.Filter.get -> string?
+LM.App.Wpf.Common.Dialogs.FileSavePickerOptions.Filter.init -> void
+LM.App.Wpf.Common.Dialogs.IDialogService.ShowSaveFileDialog(LM.App.Wpf.Common.Dialogs.FileSavePickerOptions! options) -> string?
+LM.App.Wpf.Common.Dialogs.WpfDialogService.ShowSaveFileDialog(LM.App.Wpf.Common.Dialogs.FileSavePickerOptions! options) -> string?
+LM.App.Wpf.Common.NullableIntConverter
+LM.App.Wpf.Common.NullableIntConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
+LM.App.Wpf.Common.NullableIntConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
+LM.App.Wpf.Common.NullableIntConverter.NullableIntConverter() -> void
+LM.App.Wpf.ViewModels.AddPipeline.AddPipeline(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.ISimilarityService! similarity, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IMetadataExtractor! metadata, IPublicationLookup! publicationLookup, LM.Core.Abstractions.IDoiNormalizer! doiNormalizer, LM.Infrastructure.Hooks.HookOrchestrator! orchestrator, LM.Core.Abstractions.IPmidNormalizer! pmidNormalizer, LM.Core.Abstractions.IDataExtractionPreprocessor! preprocessor, LM.HubSpoke.Abstractions.ISimilarityLog? simLog = null) -> void
+LM.App.Wpf.ViewModels.AddViewModel.AddViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.ISimilarityService! similarity, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IMetadataExtractor! metadata, IPublicationLookup! publicationLookup, LM.Core.Abstractions.IDoiNormalizer! doiNormalizer, LM.Infrastructure.Hooks.HookOrchestrator! orchestrator, LM.Core.Abstractions.IPmidNormalizer! pmidNormalizer, LM.Core.Abstractions.IDataExtractionPreprocessor! preprocessor, LM.HubSpoke.Abstractions.ISimilarityLog? simLog = null) -> void
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.ExportExtractionToExcelCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.ExportExtractionToPowerPointCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.ExportExtractionToWordCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.LibraryResultsViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.App.Wpf.Library.ILibraryEntryEditor! entryEditor, LM.App.Wpf.Library.ILibraryDocumentService! documentService, LM.App.Wpf.Library.IAttachmentMetadataPrompt! attachmentPrompt, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Infrastructure.Hooks.HookOrchestrator! hookOrchestrator, LM.App.Wpf.Common.Dialogs.IDialogService! dialogs, LM.Core.Abstractions.IDataExtractionPowerPointExporter! powerPointExporter, LM.Core.Abstractions.IDataExtractionWordExporter! wordExporter, LM.Core.Abstractions.IDataExtractionExcelExporter! excelExporter) -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview
+LM.App.Wpf.ViewModels.StagingEvidencePreview.FigurePreview
+LM.App.Wpf.ViewModels.StagingEvidencePreview.FigurePreview.Caption.get -> string!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.FigurePreview.Caption.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.FigurePreview.FigurePreview() -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.FigurePreview.Pages.get -> System.Collections.Generic.IReadOnlyList<int>!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.FigurePreview.Pages.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.FigurePreview.ThumbnailPath.get -> string!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.FigurePreview.ThumbnailPath.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.Figures.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingEvidencePreview.FigurePreview!>!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.Figures.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.Provenance.get -> LM.Core.Models.DataExtraction.EvidenceProvenance!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.Provenance.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.SectionPreview
+LM.App.Wpf.ViewModels.StagingEvidencePreview.SectionPreview.Body.get -> string!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.SectionPreview.Body.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.SectionPreview.Heading.get -> string!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.SectionPreview.Heading.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.SectionPreview.Pages.get -> System.Collections.Generic.IReadOnlyList<int>!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.SectionPreview.Pages.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.SectionPreview.SectionPreview() -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.Sections.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingEvidencePreview.SectionPreview!>!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.Sections.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.StagingEvidencePreview() -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.Classification.get -> LM.Core.Models.DataExtraction.TableClassificationKind
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.Classification.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.Endpoints.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.Endpoints.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.Pages.get -> System.Collections.Generic.IReadOnlyList<int>!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.Pages.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.Populations.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.Populations.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.Regions.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.DataExtraction.TableRegion!>!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.Regions.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.TablePreview() -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.Title.get -> string!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview.Title.init -> void
+LM.App.Wpf.ViewModels.StagingEvidencePreview.Tables.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingEvidencePreview.TablePreview!>!
+LM.App.Wpf.ViewModels.StagingEvidencePreview.Tables.init -> void
+LM.App.Wpf.ViewModels.StagingItem.DataExtractionHook.get -> LM.HubSpoke.Models.DataExtractionHook?
+LM.App.Wpf.ViewModels.StagingItem.DataExtractionHook.set -> void
+LM.App.Wpf.ViewModels.StagingItem.EvidencePreview.get -> LM.App.Wpf.ViewModels.StagingEvidencePreview?
+LM.App.Wpf.ViewModels.StagingItem.EvidencePreview.set -> void
+LM.App.Wpf.ViewModels.StagingItem.PendingChangeLogEvents.get -> System.Collections.Generic.List<LM.HubSpoke.Models.EntryChangeLogEvent!>!
+LM.App.Wpf.Views.Converters.EnumEqualsConverter
+LM.App.Wpf.Views.Converters.EnumEqualsConverter.Convert(object! value, System.Type! targetType, object! parameter, System.Globalization.CultureInfo! culture) -> object!
+LM.App.Wpf.Views.Converters.EnumEqualsConverter.ConvertBack(object! value, System.Type! targetType, object! parameter, System.Globalization.CultureInfo! culture) -> object!
+LM.App.Wpf.Views.Converters.EnumEqualsConverter.EnumEqualsConverter() -> void
+LM.App.Wpf.Common.Dialogs.DialogCloseRequestedEventArgs
+LM.App.Wpf.Common.Dialogs.DialogCloseRequestedEventArgs.DialogCloseRequestedEventArgs(bool? dialogResult) -> void
+LM.App.Wpf.Common.Dialogs.DialogCloseRequestedEventArgs.DialogResult.get -> bool?
+LM.App.Wpf.Common.Dialogs.DialogViewModelBase
+LM.App.Wpf.Common.Dialogs.DialogViewModelBase.CloseRequested -> System.EventHandler<LM.App.Wpf.Common.Dialogs.DialogCloseRequestedEventArgs!>?
+LM.App.Wpf.Common.Dialogs.DialogViewModelBase.DialogViewModelBase() -> void
+LM.App.Wpf.Common.Dialogs.DialogViewModelBase.RequestClose(bool? dialogResult) -> void
+LM.App.Wpf.Common.Dialogs.IDialogService.ShowOpenFileDialog(LM.App.Wpf.Common.Dialogs.FilePickerOptions! options) -> string![]?
+LM.App.Wpf.Common.Dialogs.WpfDialogService.ShowOpenFileDialog(LM.App.Wpf.Common.Dialogs.FilePickerOptions! options) -> string![]?
+LM.App.Wpf.Common.Dialogs.WpfDialogService.WpfDialogService(System.IServiceProvider! services) -> void
+LM.App.Wpf.Common.ILibraryPresetPrompt
+LM.App.Wpf.Common.ILibraryPresetPrompt.RequestSaveAsync(LM.App.Wpf.Common.LibraryPresetSaveContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.LibraryPresetSaveResult?>!
+LM.App.Wpf.Common.ILibraryPresetPrompt.RequestSelectionAsync(LM.App.Wpf.Common.LibraryPresetSelectionContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.LibraryPresetSelectionResult?>!
+LM.App.Wpf.Common.IClipboardService
+LM.App.Wpf.Common.IClipboardService.SetText(string! text) -> void
+LM.App.Wpf.Common.ClipboardService
+LM.App.Wpf.Common.ClipboardService.ClipboardService() -> void
+LM.App.Wpf.Common.ClipboardService.SetText(string! text) -> void
+LM.App.Wpf.Common.IFileExplorerService
+LM.App.Wpf.Common.IFileExplorerService.RevealInExplorer(string! path) -> void
+LM.App.Wpf.Common.FileExplorerService
+LM.App.Wpf.Common.FileExplorerService.FileExplorerService() -> void
+LM.App.Wpf.Common.FileExplorerService.RevealInExplorer(string! path) -> void
+LM.App.Wpf.Common.ISearchSavePrompt
+LM.App.Wpf.Common.ISearchSavePrompt.RequestAsync(LM.App.Wpf.Common.SearchSavePromptContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.SearchSavePromptResult?>!
+LM.App.Wpf.Common.SearchSavePromptContext
+LM.App.Wpf.Common.SearchSavePromptContext.Database.init -> void
+LM.App.Wpf.Common.SearchSavePromptContext.DefaultName.init -> void
+LM.App.Wpf.Common.SearchSavePromptContext.DefaultNotes.init -> void
+LM.App.Wpf.Common.SearchSavePromptContext.DefaultTags.init -> void
+LM.App.Wpf.Common.SearchSavePromptContext.From.init -> void
+LM.App.Wpf.Common.SearchSavePromptContext.Query.init -> void
+LM.App.Wpf.Common.SearchSavePromptContext.SearchSavePromptContext(string! Query, LM.Core.Models.SearchDatabase Database, System.DateTime? From, System.DateTime? To, string! DefaultName, string! DefaultNotes, System.Collections.Generic.IReadOnlyList<string!>! DefaultTags) -> void
+LM.App.Wpf.Common.SearchSavePromptContext.Database.get -> LM.Core.Models.SearchDatabase
+LM.App.Wpf.Common.SearchSavePromptContext.DefaultName.get -> string!
+LM.App.Wpf.Common.SearchSavePromptContext.DefaultNotes.get -> string!
+LM.App.Wpf.Common.SearchSavePromptContext.DefaultTags.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.Common.SearchSavePromptContext.From.get -> System.DateTime?
+LM.App.Wpf.Common.SearchSavePromptContext.Query.get -> string!
+LM.App.Wpf.Common.SearchSavePromptContext.To.get -> System.DateTime?
+LM.App.Wpf.Common.SearchSavePromptContext.To.init -> void
+LM.App.Wpf.Common.SearchSavePromptResult
+LM.App.Wpf.Common.SearchSavePromptResult.Name.init -> void
+LM.App.Wpf.Common.SearchSavePromptResult.Notes.init -> void
+LM.App.Wpf.Common.SearchSavePromptResult.Tags.init -> void
+LM.App.Wpf.Common.SearchSavePromptResult.SearchSavePromptResult(string! Name, string! Notes, string! Tags) -> void
+LM.App.Wpf.Common.SearchSavePromptResult.Name.get -> string!
+LM.App.Wpf.Common.SearchSavePromptResult.Notes.get -> string!
+LM.App.Wpf.Common.SearchSavePromptResult.Tags.get -> string!
+LM.App.Wpf.Common.LibraryPresetSaveContext
+LM.App.Wpf.Common.LibraryPresetSaveContext.DefaultName.get -> string!
+LM.App.Wpf.Common.LibraryPresetSaveContext.DefaultName.init -> void
+LM.App.Wpf.Common.LibraryPresetSaveContext.ExistingNames.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+LM.App.Wpf.Common.LibraryPresetSaveContext.ExistingNames.init -> void
+LM.App.Wpf.Common.LibraryPresetSaveContext.LibraryPresetSaveContext(string! DefaultName, System.Collections.Generic.IReadOnlyCollection<string!>! ExistingNames) -> void
+LM.App.Wpf.Common.LibraryPresetSaveResult
+LM.App.Wpf.Common.LibraryPresetSaveResult.LibraryPresetSaveResult(string! Name) -> void
+LM.App.Wpf.Common.LibraryPresetSaveResult.Name.get -> string!
+LM.App.Wpf.Common.LibraryPresetSaveResult.Name.init -> void
+LM.App.Wpf.Common.LibraryPresetSelectionContext
+LM.App.Wpf.Common.LibraryPresetSelectionContext.AllowLoad.get -> bool
+LM.App.Wpf.Common.LibraryPresetSelectionContext.AllowLoad.init -> void
+LM.App.Wpf.Common.LibraryPresetSelectionContext.LibraryPresetSelectionContext(System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Common.LibraryPresetSummary!>! Presets, bool AllowLoad, string! Title) -> void
+LM.App.Wpf.Common.LibraryPresetSelectionContext.Presets.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Common.LibraryPresetSummary!>!
+LM.App.Wpf.Common.LibraryPresetSelectionContext.Presets.init -> void
+LM.App.Wpf.Common.LibraryPresetSelectionContext.Title.get -> string!
+LM.App.Wpf.Common.LibraryPresetSelectionContext.Title.init -> void
+LM.App.Wpf.Common.LibraryPresetSelectionResult
+LM.App.Wpf.Common.LibraryPresetSelectionResult.DeletedPresetNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.Common.LibraryPresetSelectionResult.DeletedPresetNames.init -> void
+LM.App.Wpf.Common.LibraryPresetSelectionResult.LibraryPresetSelectionResult(string? SelectedPresetName, System.Collections.Generic.IReadOnlyList<string!>! DeletedPresetNames) -> void
+LM.App.Wpf.Common.LibraryPresetSelectionResult.SelectedPresetName.get -> string?
+LM.App.Wpf.Common.LibraryPresetSelectionResult.SelectedPresetName.init -> void
+LM.App.Wpf.Common.LibraryPresetSummary
+LM.App.Wpf.Common.LibraryPresetSummary.LibraryPresetSummary(string! Name, System.DateTime SavedUtc) -> void
+LM.App.Wpf.Common.LibraryPresetSummary.Name.get -> string!
+LM.App.Wpf.Common.LibraryPresetSummary.Name.init -> void
+LM.App.Wpf.Common.LibraryPresetSummary.SavedUtc.get -> System.DateTime
+LM.App.Wpf.Common.LibraryPresetSummary.SavedUtc.init -> void
+LM.App.Wpf.Common.RelayCommand
+LM.App.Wpf.Common.RelayCommand.CanExecute(object? parameter) -> bool
+LM.App.Wpf.Common.RelayCommand.CanExecuteChanged -> System.EventHandler?
+LM.App.Wpf.Common.RelayCommand.Execute(object? parameter) -> void
+LM.App.Wpf.Common.RelayCommand.RaiseCanExecuteChanged() -> void
+LM.App.Wpf.Common.RelayCommand.RelayCommand(System.Action<object?>! exec, System.Func<object?, bool>? can = null) -> void
+LM.App.Wpf.Common.Dialogs.FilePickerOptions
+LM.App.Wpf.Common.Dialogs.FilePickerOptions.AllowMultiple.get -> bool
+LM.App.Wpf.Common.Dialogs.FilePickerOptions.AllowMultiple.init -> void
+LM.App.Wpf.Common.Dialogs.FilePickerOptions.Filter.get -> string?
+LM.App.Wpf.Common.Dialogs.FilePickerOptions.Filter.init -> void
+LM.App.Wpf.Common.Dialogs.FolderPickerOptions
+LM.App.Wpf.Common.Dialogs.FolderPickerOptions.Description.get -> string?
+LM.App.Wpf.Common.Dialogs.FolderPickerOptions.Description.init -> void
+LM.App.Wpf.Common.Dialogs.IDialogService
+LM.App.Wpf.Common.Dialogs.IDialogService.ShowFolderBrowserDialog(LM.App.Wpf.Common.Dialogs.FolderPickerOptions! options) -> string?
+LM.App.Wpf.Common.Dialogs.IDialogService.ShowStagingEditor(LM.App.Wpf.ViewModels.StagingListViewModel! stagingList) -> bool?
+LM.App.Wpf.Common.Dialogs.IDialogService.ShowDataExtractionWorkspace(LM.App.Wpf.ViewModels.StagingItem! stagingItem) -> bool?
+LM.App.Wpf.Common.Dialogs.WpfDialogService
+LM.App.Wpf.Common.Dialogs.WpfDialogService.ShowFolderBrowserDialog(LM.App.Wpf.Common.Dialogs.FolderPickerOptions! options) -> string?
+LM.App.Wpf.Common.Dialogs.WpfDialogService.ShowStagingEditor(LM.App.Wpf.ViewModels.StagingListViewModel! stagingList) -> bool?
+LM.App.Wpf.Common.Dialogs.WpfDialogService.ShowDataExtractionWorkspace(LM.App.Wpf.ViewModels.StagingItem! stagingItem) -> bool?
+LM.App.Wpf.Common.StringJoinConverter
+LM.App.Wpf.Common.StringJoinConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
+LM.App.Wpf.Common.StringJoinConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
+LM.App.Wpf.Common.StringJoinConverter.StringJoinConverter() -> void
+LM.App.Wpf.Common.ViewModelBase
+LM.App.Wpf.Common.ViewModelBase.ViewModelBase() -> void
+LM.App.Wpf.Library.LibraryFilterPreset
+LM.App.Wpf.Library.LibraryFilterPreset.LibraryFilterPreset() -> void
+LM.App.Wpf.Library.LibraryFilterPreset.Name.get -> string!
+LM.App.Wpf.Library.LibraryFilterPreset.Name.set -> void
+LM.App.Wpf.Library.LibraryFilterPreset.SavedUtc.get -> System.DateTime
+LM.App.Wpf.Library.LibraryFilterPreset.SavedUtc.set -> void
+LM.App.Wpf.Library.LibraryFilterPreset.State.get -> LM.App.Wpf.Library.LibraryFilterState!
+LM.App.Wpf.Library.LibraryFilterPreset.State.set -> void
+LM.App.Wpf.Library.LibraryFilterPresetStore
+LM.App.Wpf.Library.LibraryFilterPresetStore.DeletePresetAsync(string! name, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.LibraryFilterPresetStore.LibraryFilterPresetStore(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.App.Wpf.Library.LibraryFilterPresetStore.ListPresetsAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Library.LibraryFilterPreset!>!>!
+LM.App.Wpf.Library.LibraryFilterPresetStore.SavePresetAsync(LM.App.Wpf.Library.LibraryFilterPreset! preset, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.LibraryFilterPresetStore.TryGetPresetAsync(string! name, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.LibraryFilterPreset?>!
+LM.App.Wpf.Library.ILibraryEntryEditor
+LM.App.Wpf.Library.ILibraryEntryEditor.EditEntryAsync(LM.Core.Models.Entry! entry) -> System.Threading.Tasks.Task<System.Boolean>!
+LM.App.Wpf.Library.LibraryFilterState
+LM.App.Wpf.Library.LibraryFilterState.LibraryFilterState() -> void
+LM.App.Wpf.Library.LibraryFilterState.UseFullTextSearch.get -> bool
+LM.App.Wpf.Library.LibraryFilterState.UseFullTextSearch.set -> void
+LM.App.Wpf.Library.LibraryFilterState.UnifiedQuery.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.UnifiedQuery.set -> void
+LM.App.Wpf.Library.LibraryFilterState.FullTextQuery.get -> string?
+LM.App.Wpf.Library.LibraryFilterState.FullTextQuery.set -> void
+LM.App.Wpf.Library.LibraryFilterState.FullTextInTitle.get -> bool
+LM.App.Wpf.Library.LibraryFilterState.FullTextInTitle.set -> void
+LM.App.Wpf.Library.LibraryFilterState.FullTextInAbstract.get -> bool
+LM.App.Wpf.Library.LibraryFilterState.FullTextInAbstract.set -> void
+LM.App.Wpf.Library.LibraryFilterState.FullTextInContent.get -> bool
+LM.App.Wpf.Library.LibraryFilterState.FullTextInContent.set -> void
+LM.App.Wpf.ViewModels.AddPipeline
+LM.App.Wpf.ViewModels.AddPipeline.AddPipeline(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.ISimilarityService! similarity, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IMetadataExtractor! metadata, LM.HubSpoke.Abstractions.ISimilarityLog? simLog = null) -> void
+LM.App.Wpf.ViewModels.AddPipeline.CommitAsync(System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.StagingItem!>! selectedRows, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!>!
+LM.App.Wpf.ViewModels.AddPipeline.StagePathsAsync(System.Collections.Generic.IEnumerable<string!>! paths, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!>!
+LM.App.Wpf.ViewModels.AddViewModel
+LM.App.Wpf.ViewModels.AddViewModel.AddFilesCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.AddViewModel(LM.App.Wpf.ViewModels.IAddPipeline! pipeline, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.App.Wpf.ViewModels.WatchedFolderScanner? scanner = null, LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore? watchedFolderSettings = null, LM.App.Wpf.ViewModels.StagingListViewModel? stagingList = null, LM.App.Wpf.ViewModels.WatchedFoldersViewModel? watchedFolders = null, LM.App.Wpf.Common.Dialogs.IDialogService? dialogService = null) -> void
+LM.App.Wpf.ViewModels.AddViewModel.AddViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IHasher! hasher, LM.Core.Abstractions.ISimilarityService! similarity, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IMetadataExtractor! metadata, IPublicationLookup! publicationLookup, LM.Core.Abstractions.IDoiNormalizer! doiNormalizer, LM.HubSpoke.Abstractions.ISimilarityLog? simLog = null) -> void
+LM.App.Wpf.ViewModels.AddViewModel.AddWatchedFolderCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.BulkAddFolderCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.ClearCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.CommitSelectedCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.Current.get -> LM.App.Wpf.ViewModels.StagingItem?
+LM.App.Wpf.ViewModels.AddViewModel.Current.set -> void
+LM.App.Wpf.ViewModels.AddViewModel.Dispose() -> void
+LM.App.Wpf.ViewModels.AddViewModel.EntryTypes.get -> System.Array!
+LM.App.Wpf.ViewModels.AddViewModel.IndexLabel.get -> string!
+LM.App.Wpf.ViewModels.AddViewModel.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.AddViewModel.IsBusy.get -> bool
+LM.App.Wpf.ViewModels.AddViewModel.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.App.Wpf.ViewModels.AddViewModel.ReviewStagedCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.OpenTabulaSharpPlaygroundCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.RemoveWatchedFolderCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.ScanWatchedFolderCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.ScanAllWatchedFoldersCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.SelectByOffset(int delta) -> void
+LM.App.Wpf.ViewModels.AddViewModel.SelectedType.get -> LM.Core.Models.EntryType
+LM.App.Wpf.ViewModels.AddViewModel.SelectedType.set -> void
+LM.App.Wpf.ViewModels.AddViewModel.Staging.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.StagingItem!>!
+LM.App.Wpf.ViewModels.AddViewModel.StagingListViewModel.get -> LM.App.Wpf.ViewModels.StagingListViewModel!
+LM.App.Wpf.ViewModels.AddViewModel.WatchedFolders.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.WatchedFolder!>!
+LM.App.Wpf.ViewModels.AddViewModel.WatchedFoldersViewModel.get -> LM.App.Wpf.ViewModels.WatchedFoldersViewModel!
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel.DeletedPresetNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel.Initialize(LM.App.Wpf.Common.LibraryPresetSelectionContext! context) -> void
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel.LibraryPresetPickerDialogViewModel() -> void
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel.Presets.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.Common.LibraryPresetSummary!>!
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel.SelectedPresetName.get -> string?
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel.Initialize(LM.App.Wpf.Common.LibraryPresetSaveContext! context) -> void
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel.LibraryPresetSaveDialogViewModel() -> void
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel.ResultName.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel.Title.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel
+LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel.Initialize(LM.App.Wpf.Common.SearchSavePromptContext! context) -> void
+LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel.ResultName.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel.ResultNotes.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel.ResultTags.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel.SearchSaveDialogViewModel() -> void
+LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel.Title.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.WorkspaceChooserViewModel
+LM.App.Wpf.ViewModels.Dialogs.WorkspaceChooserViewModel.SelectedWorkspacePath.get -> string?
+LM.App.Wpf.ViewModels.Dialogs.WorkspaceChooserViewModel.Title.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.WorkspaceChooserViewModel.WorkspaceChooserViewModel(LM.App.Wpf.Common.Dialogs.IDialogService! dialogService) -> void
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.CanAcceptFileDrop(System.Collections.Generic.IEnumerable<string!>? filePaths, LM.App.Wpf.ViewModels.LibrarySearchResult? dropTarget = null) -> bool
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.HandleFileDropAsync(System.Collections.Generic.IEnumerable<string!>? filePaths, LM.App.Wpf.ViewModels.LibrarySearchResult? dropTarget = null) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.LibrarySearchResult
+LM.App.Wpf.ViewModels.LibrarySearchResult.Entry.get -> LM.Core.Models.Entry!
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasAttachments.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasDoi.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasIdentifiers.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasInternalId.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasLinks.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasNct.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasNotes.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasPmid.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasRelations.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasSource.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasUserNotes.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.Highlight.get -> string?
+LM.App.Wpf.ViewModels.LibrarySearchResult.HighlightDisplay.get -> string?
+LM.App.Wpf.ViewModels.LibrarySearchResult.IsFullText.get -> bool
+LM.App.Wpf.ViewModels.LibrarySearchResult.LibrarySearchResult(LM.Core.Models.Entry! entry, double? score, string? highlight) -> void
+LM.App.Wpf.ViewModels.LibrarySearchResult.Score.get -> double?
+LM.App.Wpf.ViewModels.LibrarySearchResult.ScoreDisplay.get -> string?
+LM.App.Wpf.ViewModels.Library.LibraryLinkItem
+LM.App.Wpf.ViewModels.Library.LibraryLinkItem.LibraryLinkItem(string! DisplayText, string! Target, LM.App.Wpf.ViewModels.Library.LinkItemKind Kind) -> void
+LM.App.Wpf.ViewModels.Library.LibraryLinkItem.DisplayText.get -> string!
+LM.App.Wpf.ViewModels.Library.LibraryLinkItem.DisplayText.init -> void
+LM.App.Wpf.ViewModels.Library.LibraryLinkItem.Target.get -> string!
+LM.App.Wpf.ViewModels.Library.LibraryLinkItem.Target.init -> void
+LM.App.Wpf.ViewModels.Library.LibraryLinkItem.Kind.get -> LM.App.Wpf.ViewModels.Library.LinkItemKind
+LM.App.Wpf.ViewModels.Library.LibraryLinkItem.Kind.init -> void
+LM.App.Wpf.ViewModels.Library.LinkItemKind
+LM.App.Wpf.ViewModels.Library.LinkItemKind.Url = 0 -> LM.App.Wpf.ViewModels.Library.LinkItemKind
+LM.App.Wpf.ViewModels.Library.LinkItemKind.File = 1 -> LM.App.Wpf.ViewModels.Library.LinkItemKind
+LM.App.Wpf.ViewModels.Library.LinkItemKind.Folder = 2 -> LM.App.Wpf.ViewModels.Library.LinkItemKind
+LM.App.Wpf.ViewModels.StagingListViewModel
+LM.App.Wpf.ViewModels.StagingListViewModel.AddStagedItemsAsync(System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>! items) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.StagingListViewModel.Clear() -> void
+LM.App.Wpf.ViewModels.StagingListViewModel.CommitSelectedAsync(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.StagingListViewModel.CommitAsync(System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.StagingItem!>! items, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.StagingListViewModel.Current.get -> LM.App.Wpf.ViewModels.StagingItem?
+LM.App.Wpf.ViewModels.StagingListViewModel.Current.set -> void
+LM.App.Wpf.ViewModels.StagingListViewModel.Dispose() -> void
+LM.App.Wpf.ViewModels.StagingListViewModel.EntryTypes.get -> System.Array!
+LM.App.Wpf.ViewModels.StagingListViewModel.HasItems.get -> bool
+LM.App.Wpf.ViewModels.StagingListViewModel.HasSelectedItems.get -> bool
+LM.App.Wpf.ViewModels.StagingListViewModel.IndexLabel.get -> string!
+LM.App.Wpf.ViewModels.StagingListViewModel.Items.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.StagingItem!>!
+LM.App.Wpf.ViewModels.StagingListViewModel.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.App.Wpf.ViewModels.StagingListViewModel.SelectByOffset(int delta) -> void
+LM.App.Wpf.ViewModels.StagingListViewModel.SelectedType.get -> LM.Core.Models.EntryType
+LM.App.Wpf.ViewModels.StagingListViewModel.SelectedType.set -> void
+LM.App.Wpf.ViewModels.StagingListViewModel.StagePathsAsync(System.Collections.Generic.IEnumerable<string!>! paths, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.StagingListViewModel.StagingListViewModel(LM.App.Wpf.ViewModels.IAddPipeline! pipeline) -> void
+LM.App.Wpf.ViewModels.WatchedFoldersViewModel
+LM.App.Wpf.ViewModels.WatchedFoldersViewModel.AddWatchedFolderCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.WatchedFoldersViewModel.Dispose() -> void
+LM.App.Wpf.ViewModels.WatchedFoldersViewModel.Folders.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.WatchedFolder!>!
+LM.App.Wpf.ViewModels.WatchedFoldersViewModel.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.WatchedFoldersViewModel.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.App.Wpf.ViewModels.WatchedFoldersViewModel.RemoveWatchedFolderCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.WatchedFoldersViewModel.ScanAllWatchedFoldersCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.WatchedFoldersViewModel.ScanWatchedFolderCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.WatchedFoldersViewModel.SetCommandGuard(System.Func<System.Func<System.Threading.Tasks.Task!>!, System.Threading.Tasks.Task!>! guard) -> void
+LM.App.Wpf.ViewModels.WatchedFoldersViewModel.UpdateParentBusy(bool isBusy) -> void
+LM.App.Wpf.ViewModels.WatchedFoldersViewModel.WatchedFoldersViewModel(LM.App.Wpf.ViewModels.StagingListViewModel! stagingList, LM.App.Wpf.ViewModels.WatchedFolderScanner! scanner, LM.Core.Abstractions.Configuration.IWatchedFolderSettingsStore! settingsStore, LM.App.Wpf.Common.Dialogs.IDialogService! dialogService) -> void
+LM.App.Wpf.ViewModels.WatchedFolder
+LM.App.Wpf.ViewModels.WatchedFolder.IsEnabled.get -> bool
+LM.App.Wpf.ViewModels.WatchedFolder.IsEnabled.set -> void
+LM.App.Wpf.ViewModels.WatchedFolder.LastScanDisplay.get -> string!
+LM.App.Wpf.ViewModels.WatchedFolder.LastScanUtc.get -> System.DateTimeOffset?
+LM.App.Wpf.ViewModels.WatchedFolder.LastScanWasUnchanged.get -> bool?
+LM.App.Wpf.ViewModels.WatchedFolder.Path.get -> string!
+LM.App.Wpf.ViewModels.WatchedFolder.Path.set -> void
+LM.App.Wpf.ViewModels.WatchedFolder.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.App.Wpf.ViewModels.WatchedFolder.ResetScanState() -> void
+LM.App.Wpf.ViewModels.WatchedFolder.ScanStatusLabel.get -> string!
+LM.App.Wpf.ViewModels.WatchedFolder.ScanStatusToolTip.get -> string!
+LM.App.Wpf.ViewModels.WatchedFolder.WatchedFolder() -> void
+LM.App.Wpf.ViewModels.WatchedFolderConfig.GetState(LM.App.Wpf.ViewModels.WatchedFolder! folder) -> LM.Core.Models.WatchedFolderState?
+LM.App.Wpf.ViewModels.WatchedFolderConfig.GetState(string! path) -> LM.Core.Models.WatchedFolderState?
+LM.App.Wpf.ViewModels.WatchedFolderConfig
+LM.App.Wpf.ViewModels.WatchedFolderConfig.ApplyState(LM.App.Wpf.ViewModels.WatchedFolder! folder) -> void
+LM.App.Wpf.ViewModels.WatchedFolderConfig.ClearState(LM.App.Wpf.ViewModels.WatchedFolder! folder) -> void
+LM.App.Wpf.ViewModels.WatchedFolderConfig.Folders.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.WatchedFolder!>!
+LM.App.Wpf.ViewModels.WatchedFolderConfig.CreateSnapshot() -> LM.Core.Models.WatchedFolderSettings!
+LM.App.Wpf.ViewModels.WatchedFolderConfig.Load(LM.Core.Models.WatchedFolderSettings! settings) -> void
+LM.App.Wpf.ViewModels.WatchedFolderConfig.StoreState(LM.App.Wpf.ViewModels.WatchedFolder! folder, LM.Core.Models.WatchedFolderState! state) -> void
+LM.App.Wpf.ViewModels.WatchedFolderConfig.WatchedFolderConfig() -> void
+LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs
+LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs.Folder.get -> LM.App.Wpf.ViewModels.WatchedFolder!
+LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs.Items.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!
+LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs.WatchedFolderScanEventArgs(LM.App.Wpf.ViewModels.WatchedFolder! folder, System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>! items) -> void
+LM.App.Wpf.ViewModels.WatchedFolderScanner
+LM.App.Wpf.ViewModels.WatchedFolderScanner.Attach(LM.App.Wpf.ViewModels.WatchedFolderConfig! config) -> void
+LM.App.Wpf.ViewModels.WatchedFolderScanner.Dispose() -> void
+LM.App.Wpf.ViewModels.WatchedFolderScanner.ItemsStaged -> System.EventHandler<LM.App.Wpf.ViewModels.WatchedFolderScanEventArgs!>?
+LM.App.Wpf.ViewModels.WatchedFolderScanner.ScanAsync(LM.App.Wpf.ViewModels.WatchedFolder? folder, System.Threading.CancellationToken ct, bool force = false) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.WatchedFolderScanner.WatchedFolderScanner(LM.App.Wpf.ViewModels.IAddPipeline! pipeline) -> void
+LM.App.Wpf.ViewModels.IAddPipeline
+LM.App.Wpf.ViewModels.IAddPipeline.CommitAsync(System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.StagingItem!>! selectedRows, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!>!
+LM.App.Wpf.ViewModels.IAddPipeline.StagePathsAsync(System.Collections.Generic.IEnumerable<string!>! paths, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!>!
+LM.App.Wpf.Library.ILibraryDocumentService
+LM.App.Wpf.Library.ILibraryDocumentService.OpenEntry(LM.Core.Models.Entry! entry) -> void
+LM.App.Wpf.Library.ILibraryDocumentService.OpenAttachment(LM.Core.Models.Attachment! attachment) -> void
+LM.App.Wpf.Library.LibraryDocumentService
+LM.App.Wpf.Library.LibraryDocumentService.LibraryDocumentService(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.App.Wpf.Library.LibraryDocumentService.OpenEntry(LM.Core.Models.Entry! entry) -> void
+LM.App.Wpf.Library.LibraryDocumentService.OpenAttachment(LM.Core.Models.Attachment! attachment) -> void
+LM.App.Wpf.Library.IAttachmentMetadataPrompt
+LM.App.Wpf.Library.IAttachmentMetadataPrompt.RequestMetadataAsync(LM.App.Wpf.Library.AttachmentMetadataPromptContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.AttachmentMetadataPromptResult?>!
+LM.App.Wpf.Library.AttachmentMetadataPromptContext
+LM.App.Wpf.Library.AttachmentMetadataPromptContext.EntryTitle.get -> string!
+LM.App.Wpf.Library.AttachmentMetadataPromptContext.EntryTitle.init -> void
+LM.App.Wpf.Library.AttachmentMetadataPromptContext.FilePaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.Library.AttachmentMetadataPromptContext.FilePaths.init -> void
+LM.App.Wpf.Library.AttachmentMetadataPromptContext.AttachmentMetadataPromptContext(string! EntryTitle, System.Collections.Generic.IReadOnlyList<string!>! FilePaths) -> void
+LM.App.Wpf.Library.AttachmentMetadataPromptResult
+LM.App.Wpf.Library.AttachmentMetadataPromptResult.Attachments.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Library.AttachmentMetadataSelection!>!
+LM.App.Wpf.Library.AttachmentMetadataPromptResult.Attachments.init -> void
+LM.App.Wpf.Library.AttachmentMetadataPromptResult.AttachmentMetadataPromptResult(System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Library.AttachmentMetadataSelection!>! Attachments) -> void
+LM.App.Wpf.Library.AttachmentMetadataSelection
+LM.App.Wpf.Library.AttachmentMetadataSelection.AttachmentMetadataSelection(string! SourcePath, string! Title, LM.Core.Models.AttachmentKind Kind, System.Collections.Generic.IReadOnlyList<string!>! Tags) -> void
+LM.App.Wpf.Library.AttachmentMetadataSelection.Kind.get -> LM.Core.Models.AttachmentKind
+LM.App.Wpf.Library.AttachmentMetadataSelection.Kind.init -> void
+LM.App.Wpf.Library.AttachmentMetadataSelection.SourcePath.get -> string!
+LM.App.Wpf.Library.AttachmentMetadataSelection.SourcePath.init -> void
+LM.App.Wpf.Library.AttachmentMetadataSelection.Tags.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.Library.AttachmentMetadataSelection.Tags.init -> void
+LM.App.Wpf.Library.AttachmentMetadataSelection.Title.get -> string!
+LM.App.Wpf.Library.AttachmentMetadataSelection.Title.init -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.LibraryFiltersViewModel(LM.App.Wpf.Library.LibraryFilterPresetStore! presetStore, LM.App.Wpf.Common.ILibraryPresetPrompt! presetPrompt, LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.ApplyPresetAsync(LM.App.Wpf.Common.LibraryPresetSummary! summary, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.ApplyState(LM.App.Wpf.Library.LibraryFilterState! state) -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.CaptureState() -> LM.App.Wpf.Library.LibraryFilterState!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.Clear() -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.KeywordTooltip.get -> string!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.KeywordTokens.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.LeftPanelWidth.get -> System.Windows.GridLength
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.LeftPanelWidth.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.BuildFullTextQuery(string! normalizedQuery) -> LM.Core.Models.Search.FullTextSearchQuery!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextInAbstract.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextInAbstract.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextInContent.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextInContent.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextInTitle.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextInTitle.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextQuery.get -> string?
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.FullTextQuery.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.HasSavedPresets.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.GetNormalizedFullTextQuery() -> string!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.NavigationRoots.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel!>!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.RefreshNavigationAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.SavedPresets.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Common.LibraryPresetSummary!>!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.RightPanelWidth.get -> System.Windows.GridLength
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.RightPanelWidth.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.IsLeftPanelCollapsed.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.IsLeftPanelCollapsed.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.IsRightPanelCollapsed.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.IsRightPanelCollapsed.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.ToggleLeftPanelCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.ToggleRightPanelCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.UnifiedQuery.get -> string?
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.UnifiedQuery.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.UseFullTextSearch.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.UseFullTextSearch.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind.Category = 0 -> LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind.SavedSearch = 1 -> LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind.LitSearchEntry = 2 -> LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind.LitSearchRun = 3 -> LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.LibraryNavigationNodeViewModel(string! name, LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind kind) -> void
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Children.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel!>!
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.HasChildren.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Kind.get -> LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeKind
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Name.get -> string!
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Payload.get -> object?
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Payload.init -> void
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Subtitle.get -> string?
+LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel.Subtitle.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryColumnOption
+LM.App.Wpf.ViewModels.Library.LibraryColumnOption.DisplayName.get -> string!
+LM.App.Wpf.ViewModels.Library.LibraryColumnOption.IsVisible.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryColumnOption.IsVisible.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryColumnOption.Key.get -> string!
+LM.App.Wpf.ViewModels.Library.LibraryColumnOption.LibraryColumnOption(string! key, string! displayName, bool isVisible) -> void
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility.this[string! key].get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility.this[string! key].set -> void
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility.LibraryColumnVisibility() -> void
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility.LoadFrom(System.Collections.Generic.IReadOnlyDictionary<string!, bool>! source) -> void
+LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility.Snapshot() -> System.Collections.Generic.IReadOnlyDictionary<string!, bool>!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.Clear() -> void
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.Items.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.LibrarySearchResult!>!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.LoadFullTextResultsAsync(System.Collections.Generic.IReadOnlyList<LM.Core.Models.Search.FullTextSearchHit!>! hits) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.LoadMetadataResults(System.Collections.Generic.IEnumerable<LM.Core.Models.Entry!>! entries) -> void
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.MarkAsMetadataResults() -> void
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.ResultsAreFullText.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.Selected.get -> LM.App.Wpf.ViewModels.LibrarySearchResult?
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.Selected.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.HasLinkItems.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.HasLinkItems.set -> void
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.LinkItems.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.Library.LibraryLinkItem!>!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.EditEntryAsync(LM.App.Wpf.ViewModels.LibrarySearchResult? target) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.HasSelection.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectedItems.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.LibrarySearchResult!>!
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectionChanged -> System.EventHandler?
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.HasSelectedAbstract.get -> bool
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectedAbstract.get -> string?
+LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectedAbstract.set -> void
+LM.App.Wpf.ViewModels.LibrarySearchResult.HasPrimaryAttachment.get -> bool
+LM.App.Wpf.Views.Library.Controls.LibrarySearchQueryBox
+LM.App.Wpf.Views.Library.Controls.LibrarySearchQueryBox.LibrarySearchQueryBox() -> void
+LM.App.Wpf.Views.Library.Controls.LibrarySearchQueryBox.Text.get -> string!
+LM.App.Wpf.Views.Library.Controls.LibrarySearchQueryBox.Text.set -> void
+LM.App.Wpf.ViewModels.LibraryViewModel
+LM.App.Wpf.ViewModels.LibraryViewModel.Filters.get -> LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel!
+LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel! filters, LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel! results, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.Configuration.IUserPreferencesStore! preferencesStore, LM.App.Wpf.Common.IClipboardService! clipboard, LM.App.Wpf.Common.IFileExplorerService! fileExplorer, LM.App.Wpf.Library.ILibraryDocumentService! documentService) -> void
+LM.App.Wpf.ViewModels.LibraryViewModel.Results.get -> LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel!
+LM.App.Wpf.ViewModels.LibraryViewModel.ColumnOptions.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.Library.LibraryColumnOption!>!
+LM.App.Wpf.ViewModels.LibraryViewModel.ColumnVisibility.get -> LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility!
+LM.App.Wpf.ViewModels.LibraryViewModel.CopyMetadataCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.LibraryViewModel.CopyWorkspacePathCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.LibraryViewModel.EditEntryCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.LibraryViewModel.OpenContainingFolderCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.LibraryViewModel.OpenEntryCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.SearchItemViewModel
+LM.App.Wpf.ViewModels.SearchItemViewModel.Header.get -> string!
+LM.App.Wpf.ViewModels.SearchItemViewModel.SearchItemViewModel(string! header, LM.App.Wpf.ViewModels.LibraryViewModel! vm) -> void
+LM.App.Wpf.ViewModels.SearchItemViewModel.Vm.get -> LM.App.Wpf.ViewModels.LibraryViewModel!
+LM.App.Wpf.ViewModels.SearchViewModel
+LM.App.Wpf.ViewModels.SearchViewModel.Databases.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.SearchDatabaseOption!>!
+LM.App.Wpf.ViewModels.SearchViewModel.ExportSearchCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.SearchViewModel.From.get -> System.DateTime?
+LM.App.Wpf.ViewModels.SearchViewModel.From.set -> void
+LM.App.Wpf.ViewModels.SearchViewModel.IsBusy.get -> bool
+LM.App.Wpf.ViewModels.SearchViewModel.LoadSearchCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.SearchViewModel.PreviousRuns.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.PreviousSearchSummary!>!
+LM.App.Wpf.ViewModels.SearchViewModel.RecentSearchHistory.get -> System.Collections.ObjectModel.ReadOnlyObservableCollection<LM.Core.Models.Search.SearchHistoryEntry!>!
+LM.App.Wpf.ViewModels.SearchViewModel.PreviousRunsCount.get -> int
+LM.App.Wpf.ViewModels.SearchViewModel.Query.get -> string!
+LM.App.Wpf.ViewModels.SearchViewModel.Query.set -> void
+LM.App.Wpf.ViewModels.SearchViewModel.Results.get -> System.Collections.ObjectModel.ObservableCollection<LM.Core.Models.SearchHit!>!
+LM.App.Wpf.ViewModels.SearchViewModel.RunSearchCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.SearchViewModel.SaveSearchCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.SearchViewModel.SearchViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFileStorageRepository! storage, LM.Core.Abstractions.IWorkSpaceService! ws, LM.App.Wpf.Common.ISearchSavePrompt! savePrompt, LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel! providers, LM.App.Wpf.ViewModels.Search.SearchHistoryViewModel! history, LM.Infrastructure.Search.PubMedSearchProvider! pubMedProvider, LM.Core.Abstractions.Configuration.IUserPreferencesStore? preferencesStore = null) -> void
+LM.App.Wpf.ViewModels.SearchViewModel.SelectedDatabase.get -> LM.Core.Models.SearchDatabase
+LM.App.Wpf.ViewModels.SearchViewModel.SelectedDatabase.set -> void
+LM.App.Wpf.ViewModels.SearchViewModel.SelectedPreviousRun.get -> LM.App.Wpf.ViewModels.PreviousSearchSummary?
+LM.App.Wpf.ViewModels.SearchViewModel.SelectedPreviousRun.set -> void
+LM.App.Wpf.ViewModels.SearchViewModel.StartPreviousRunCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.SearchViewModel.ShowRunDetailsCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.SearchViewModel.ToggleFavoriteCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.SearchViewModel.To.get -> System.DateTime?
+LM.App.Wpf.ViewModels.SearchViewModel.To.set -> void
+LM.App.Wpf.ViewModels.SearchViewModel.History.get -> LM.App.Wpf.ViewModels.Search.SearchHistoryViewModel!
+LM.App.Wpf.ViewModels.SearchViewModel.Providers.get -> LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel!
+LM.App.Wpf.ViewModels.Search.SearchHistoryViewModel
+LM.App.Wpf.ViewModels.Search.SearchHistoryViewModel.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.Search.SearchHistoryViewModel.RecordExecutionAsync(LM.Core.Models.Search.SearchExecutionResult! result, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.Search.SearchHistoryViewModel.RecentSearchHistory.get -> System.Collections.ObjectModel.ReadOnlyObservableCollection<LM.Core.Models.Search.SearchHistoryEntry!>!
+LM.App.Wpf.ViewModels.Search.SearchHistoryViewModel.SearchHistoryViewModel(LM.Core.Abstractions.Configuration.ISearchHistoryStore! store) -> void
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.Databases.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.SearchDatabaseOption!>!
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.From.get -> System.DateTime?
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.From.set -> void
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.IsBusy.get -> bool
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.Query.get -> string!
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.Query.set -> void
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.Results.get -> System.Collections.ObjectModel.ObservableCollection<LM.Core.Models.SearchHit!>!
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.ExecuteSearchAsync() -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.RunSearchCommand.get -> LM.App.Wpf.Common.AsyncRelayCommand!
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.SearchExecuted -> System.EventHandler<LM.App.Wpf.ViewModels.Search.SearchExecutedEventArgs!>?
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.SearchProvidersViewModel(LM.Core.Abstractions.Search.ISearchExecutionService! executionService) -> void
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.SelectedDatabase.get -> LM.Core.Models.SearchDatabase
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.SelectedDatabase.set -> void
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.To.get -> System.DateTime?
+LM.App.Wpf.ViewModels.Search.SearchProvidersViewModel.To.set -> void
+LM.App.Wpf.ViewModels.Search.SearchExecutedEventArgs
+LM.App.Wpf.ViewModels.Search.SearchExecutedEventArgs.Result.get -> LM.Core.Models.Search.SearchExecutionResult!
+LM.App.Wpf.ViewModels.Search.SearchExecutedEventArgs.SearchExecutedEventArgs(LM.Core.Models.Search.SearchExecutionResult! result) -> void
+LM.App.Wpf.ViewModels.PreviousSearchSummary
+LM.App.Wpf.ViewModels.PreviousSearchSummary.DisplayName.get -> string!
+LM.App.Wpf.ViewModels.PreviousSearchSummary.EntryId.get -> string!
+LM.App.Wpf.ViewModels.PreviousSearchSummary.FavoriteRunId.get -> string?
+LM.App.Wpf.ViewModels.PreviousSearchSummary.IsFavorite.get -> bool
+LM.App.Wpf.ViewModels.PreviousSearchSummary.LastFrom.get -> System.DateTime?
+LM.App.Wpf.ViewModels.PreviousSearchSummary.LastRunUtc.get -> System.DateTime
+LM.App.Wpf.ViewModels.PreviousSearchSummary.LastTo.get -> System.DateTime?
+LM.App.Wpf.ViewModels.PreviousSearchSummary.Provider.get -> string!
+LM.App.Wpf.ViewModels.PreviousSearchSummary.Query.get -> string!
+LM.App.Wpf.ViewModels.PreviousSearchSummary.RunCount.get -> int
+LM.App.Wpf.ViewModels.PreviousSearchSummary.RunId.get -> string!
+LM.App.Wpf.ViewModels.PreviousSearchSummary.TotalHits.get -> int
+LM.App.Wpf.ViewModels.PreviousSearchSummary.Tags.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.ViewModels.PreviousSearchSummary.TagsDisplay.get -> string!
+LM.App.Wpf.ViewModels.SearchDatabaseOption
+LM.App.Wpf.ViewModels.SearchDatabaseOption.DisplayName.get -> string!
+LM.App.Wpf.ViewModels.SearchDatabaseOption.SearchDatabaseOption(LM.Core.Models.SearchDatabase value, string! displayName) -> void
+LM.App.Wpf.ViewModels.SearchDatabaseOption.Value.get -> LM.Core.Models.SearchDatabase
+LM.App.Wpf.ViewModels.StagingItem
+LM.App.Wpf.ViewModels.StagingItem.ArticleHook.get -> LM.HubSpoke.Models.ArticleHook?
+LM.App.Wpf.ViewModels.StagingItem.ArticleHook.set -> void
+LM.App.Wpf.ViewModels.StagingItem.AttachToEntryId.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.AttachToEntryId.set -> void
+LM.App.Wpf.ViewModels.StagingItem.AttachToTitle.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.AttachToTitle.set -> void
+LM.App.Wpf.ViewModels.StagingItem.CommitMetadataOnly.get -> bool
+LM.App.Wpf.ViewModels.StagingItem.CommitMetadataOnly.set -> void
+LM.App.Wpf.ViewModels.StagingItem.AuthorsCsv.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.AuthorsCsv.set -> void
+LM.App.Wpf.ViewModels.StagingItem.DisplayName.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.DisplayName.set -> void
+LM.App.Wpf.ViewModels.StagingItem.Doi.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.Doi.set -> void
+LM.App.Wpf.ViewModels.StagingItem.FilePath.get -> string!
+LM.App.Wpf.ViewModels.StagingItem.FilePath.set -> void
+LM.App.Wpf.ViewModels.StagingItem.Internal.get -> bool
+LM.App.Wpf.ViewModels.StagingItem.Internal.set -> void
+LM.App.Wpf.ViewModels.StagingItem.InternalId.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.InternalId.set -> void
+LM.App.Wpf.ViewModels.StagingItem.IsDuplicate.get -> bool
+LM.App.Wpf.ViewModels.StagingItem.IsInternal.get -> bool
+LM.App.Wpf.ViewModels.StagingItem.IsInternal.set -> void
+LM.App.Wpf.ViewModels.StagingItem.IsNearMatch.get -> bool
+LM.App.Wpf.ViewModels.StagingItem.MatchedTitle.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.MatchedTitle.set -> void
+LM.App.Wpf.ViewModels.StagingItem.Notes.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.Notes.set -> void
+LM.App.Wpf.ViewModels.StagingItem.OriginalFileName.get -> string!
+LM.App.Wpf.ViewModels.StagingItem.Pmid.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.Pmid.set -> void
+LM.App.Wpf.ViewModels.StagingItem.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
+LM.App.Wpf.ViewModels.StagingItem.Selected.get -> bool
+LM.App.Wpf.ViewModels.StagingItem.Selected.set -> void
+LM.App.Wpf.ViewModels.StagingItem.Similarity.get -> double
+LM.App.Wpf.ViewModels.StagingItem.Similarity.set -> void
+LM.App.Wpf.ViewModels.StagingItem.SimilarToEntryId.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.SimilarToEntryId.set -> void
+LM.App.Wpf.ViewModels.StagingItem.SimilarToTitle.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.SimilarToTitle.set -> void
+LM.App.Wpf.ViewModels.StagingItem.Source.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.Source.set -> void
+LM.App.Wpf.ViewModels.StagingItem.StagingItem() -> void
+LM.App.Wpf.ViewModels.StagingItem.SuggestedAction.get -> string!
+LM.App.Wpf.ViewModels.StagingItem.SuggestedAction.set -> void
+LM.App.Wpf.ViewModels.StagingItem.TagsCsv.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.TagsCsv.set -> void
+LM.App.Wpf.ViewModels.StagingItem.Title.get -> string?
+LM.App.Wpf.ViewModels.StagingItem.Title.set -> void
+LM.App.Wpf.ViewModels.StagingItem.Type.get -> LM.Core.Models.EntryType
+LM.App.Wpf.ViewModels.StagingItem.Type.set -> void
+LM.App.Wpf.ViewModels.StagingItem.Year.get -> int?
+LM.App.Wpf.ViewModels.StagingItem.Year.set -> void
+LM.App.Wpf.Views.AddView
+LM.App.Wpf.Views.Behaviors.FileDropRequest
+LM.App.Wpf.Views.Behaviors.FileDropRequest.Args.get -> System.Windows.DragEventArgs!
+LM.App.Wpf.Views.Behaviors.FileDropRequest.Args.init -> void
+LM.App.Wpf.Views.Behaviors.FileDropRequest.DropTarget.get -> object?
+LM.App.Wpf.Views.Behaviors.FileDropRequest.DropTarget.init -> void
+LM.App.Wpf.Views.Behaviors.FileDropRequest.FileDropRequest(System.Collections.Generic.IReadOnlyList<string!>! Paths, object? DropTarget, System.Windows.DragEventArgs! Args) -> void
+LM.App.Wpf.Views.Behaviors.FileDropRequest.Paths.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.Views.Behaviors.FileDropRequest.Paths.init -> void
+LM.App.Wpf.Views.AddView.AddView() -> void
+LM.App.Wpf.Views.AddView.InitializeComponent() -> void
+LM.App.Wpf.Views.LibraryPresetPickerDialog
+LM.App.Wpf.Views.LibraryPresetPickerDialog.InitializeComponent() -> void
+LM.App.Wpf.Views.LibraryPresetPickerDialog.LibraryPresetPickerDialog(LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel! viewModel) -> void
+LM.App.Wpf.Views.LibraryPresetPickerDialog.ViewModel.get -> LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel!
+LM.App.Wpf.Views.LibraryPresetPrompt.LibraryPresetPrompt(System.IServiceProvider! services) -> void
+LM.App.Wpf.Views.Library.AttachmentMetadataDialog
+LM.App.Wpf.Views.Library.AttachmentMetadataDialog.InitializeComponent() -> void
+LM.App.Wpf.Views.Library.AttachmentMetadataDialog.AttachmentMetadataDialog(LM.App.Wpf.ViewModels.Library.AttachmentMetadataDialogViewModel! viewModel) -> void
+LM.App.Wpf.Views.LibraryPresetSaveDialog
+LM.App.Wpf.Views.LibraryPresetSaveDialog.InitializeComponent() -> void
+LM.App.Wpf.Views.LibraryPresetSaveDialog.LibraryPresetSaveDialog(LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel! viewModel) -> void
+LM.App.Wpf.Views.LibraryPresetSaveDialog.ViewModel.get -> LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel!
+LM.App.Wpf.Views.LibraryView
+LM.App.Wpf.Views.LibraryView.InitializeComponent() -> void
+LM.App.Wpf.Views.LibraryView.LibraryView() -> void
+LM.App.Wpf.Views.Library.TagTokenSelector
+LM.App.Wpf.Views.Library.TagTokenSelector.InitializeComponent() -> void
+LM.App.Wpf.Views.Library.TagTokenSelector.FilteredSuggestions.get -> System.Collections.ObjectModel.ObservableCollection<string!>!
+LM.App.Wpf.Views.Library.TagTokenSelector.SelectedTags.get -> System.Collections.ObjectModel.ObservableCollection<string!>?
+LM.App.Wpf.Views.Library.TagTokenSelector.SelectedTags.set -> void
+LM.App.Wpf.Views.Library.TagTokenSelector.TagTokenSelector() -> void
+LM.App.Wpf.Views.Library.TagTokenSelector.TagVocabulary.get -> System.Collections.Generic.IEnumerable<string!>!
+LM.App.Wpf.Views.Library.TagTokenSelector.TagVocabulary.set -> void
+field System.Windows.DependencyProperty! LM.App.Wpf.Views.Library.TagTokenSelector.SelectedTagsProperty
+field System.Windows.DependencyProperty! LM.App.Wpf.Views.Library.TagTokenSelector.TagVocabularyProperty
+LM.App.Wpf.Views.LibraryPresetPrompt
+LM.App.Wpf.Views.LibraryPresetPrompt.RequestSaveAsync(LM.App.Wpf.Common.LibraryPresetSaveContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.LibraryPresetSaveResult?>!
+LM.App.Wpf.Views.LibraryPresetPrompt.RequestSelectionAsync(LM.App.Wpf.Common.LibraryPresetSelectionContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.LibraryPresetSelectionResult?>!
+LM.App.Wpf.Views.SearchSavePrompt
+LM.App.Wpf.Views.SearchSavePrompt.RequestAsync(LM.App.Wpf.Common.SearchSavePromptContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Common.SearchSavePromptResult?>!
+LM.App.Wpf.Views.SearchSavePrompt.SearchSavePrompt(System.IServiceProvider! services) -> void
+LM.App.Wpf.Views.Behaviors.DataGridColumnVisibilityBehavior
+LM.App.Wpf.Views.Behaviors.DataGridColumnVisibilityBehavior.DataGridColumnVisibilityBehavior() -> void
+LM.App.Wpf.Views.Behaviors.DataGridColumnVisibilityBehavior.VisibilityMap.get -> LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility?
+LM.App.Wpf.Views.Behaviors.DataGridColumnVisibilityBehavior.VisibilityMap.set -> void
+LM.App.Wpf.Views.SearchView
+LM.App.Wpf.Views.SearchView.InitializeComponent() -> void
+LM.App.Wpf.Views.SearchView.SearchView() -> void
+LM.App.Wpf.Views.TabulaSharp.TabulaSharpPlaygroundWindow
+LM.App.Wpf.Views.TabulaSharp.TabulaSharpPlaygroundWindow.InitializeComponent() -> void
+LM.App.Wpf.Views.TabulaSharp.TabulaSharpPlaygroundWindow.TabulaSharpPlaygroundWindow() -> void
+LM.App.Wpf.Views.ShellWindow
+LM.App.Wpf.Views.ShellWindow.InitializeComponent() -> void
+LM.App.Wpf.Views.ShellWindow.ShellWindow() -> void
+override LM.App.Wpf.Views.Library.AttachmentMetadataDialog.OnClosed(System.EventArgs! e) -> void
+LM.App.Wpf.Views.WorkspaceChooser
+LM.App.Wpf.Views.WorkspaceChooser.InitializeComponent() -> void
+LM.App.Wpf.Views.WorkspaceChooser.SelectedWorkspacePath.get -> string?
+LM.App.Wpf.Views.WorkspaceChooser.WorkspaceChooser(LM.App.Wpf.ViewModels.Dialogs.WorkspaceChooserViewModel! viewModel) -> void
+override LM.App.Wpf.App.OnExit(System.Windows.ExitEventArgs! e) -> void
+override LM.App.Wpf.App.OnStartup(System.Windows.StartupEventArgs! e) -> void
+override LM.App.Wpf.Views.LibraryPresetPickerDialog.OnClosed(System.EventArgs! e) -> void
+override LM.App.Wpf.Views.LibraryPresetSaveDialog.OnClosed(System.EventArgs! e) -> void
+override LM.App.Wpf.Views.WorkspaceChooser.OnClosed(System.EventArgs! e) -> void
+static LM.App.Wpf.App.Main() -> void

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -243,6 +243,7 @@ LM.App.Wpf.ViewModels.AddViewModel.InitializeAsync(System.Threading.Cancellation
 LM.App.Wpf.ViewModels.AddViewModel.IsBusy.get -> bool
 LM.App.Wpf.ViewModels.AddViewModel.PropertyChanged -> System.ComponentModel.PropertyChangedEventHandler?
 LM.App.Wpf.ViewModels.AddViewModel.ReviewStagedCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.AddViewModel.OpenTabulaSharpPlaygroundCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.AddViewModel.RemoveWatchedFolderCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.AddViewModel.ScanWatchedFolderCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.AddViewModel.ScanAllWatchedFoldersCommand.get -> System.Windows.Input.ICommand!
@@ -681,6 +682,9 @@ LM.App.Wpf.Views.Behaviors.DataGridColumnVisibilityBehavior.VisibilityMap.set ->
 LM.App.Wpf.Views.SearchView
 LM.App.Wpf.Views.SearchView.InitializeComponent() -> void
 LM.App.Wpf.Views.SearchView.SearchView() -> void
+LM.App.Wpf.Views.TabulaSharp.TabulaSharpPlaygroundWindow
+LM.App.Wpf.Views.TabulaSharp.TabulaSharpPlaygroundWindow.InitializeComponent() -> void
+LM.App.Wpf.Views.TabulaSharp.TabulaSharpPlaygroundWindow.TabulaSharpPlaygroundWindow() -> void
 LM.App.Wpf.Views.ShellWindow
 LM.App.Wpf.Views.ShellWindow.InitializeComponent() -> void
 LM.App.Wpf.Views.ShellWindow.ShellWindow() -> void

--- a/src/LM.App.Wpf/Views/TabulaSharp/TabulaSharpPlaygroundWindow.xaml.cs
+++ b/src/LM.App.Wpf/Views/TabulaSharp/TabulaSharpPlaygroundWindow.xaml.cs
@@ -2,7 +2,7 @@
 
 namespace LM.App.Wpf.Views.TabulaSharp
 {
-    internal partial class TabulaSharpPlaygroundWindow : System.Windows.Window
+    public partial class TabulaSharpPlaygroundWindow : System.Windows.Window
     {
         public TabulaSharpPlaygroundWindow()
         {


### PR DESCRIPTION
## Summary
- make the TabulaSharp playground window public so the generated XAML partial compiles without accessibility conflicts
- record the new window and command surface area in the WPF public API listings

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: WindowsDesktop runtime unavailable; TableVocabularyTests assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68d9041beed8832ba5e4a62af87c027e