### PR TITLE
Add project creation review window with staged screening UI

### DIFF
--- a/src/LM.App.Wpf.Tests/Dialogs/Projects/ProjectCreationViewModelTests.cs
+++ b/src/LM.App.Wpf.Tests/Dialogs/Projects/ProjectCreationViewModelTests.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using LM.App.Wpf.ViewModels.Dialogs.Projects;
+using LM.Review.Core.Models;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.Dialogs.Projects
+{
+    public sealed class ProjectCreationViewModelTests
+    {
+        private static ProjectCreationRequest CreateRequest()
+        {
+            var document = new ScreeningDocumentDefinition(
+                "Example study",
+                "Abstract",
+                new[] { "Doe J.", "Smith A." },
+                new[] { new DocumentAttributeDefinition("Journal", "Example"), new DocumentAttributeDefinition("Year", "2024") },
+                new[] { "cardiology" });
+
+            var stage = new ScreeningStageDefinition(
+                "Stage",
+                "Description",
+                "Include",
+                "Exclude",
+                true,
+                true,
+                new[]
+                {
+                    new ScreeningCriterionDefinition("p", "Population", null, false)
+                });
+
+            var pdf = new List<PdfPagePreviewDefinition>
+            {
+                new PdfPagePreviewDefinition(1, "Cover", "Summary")
+            };
+
+            var groups = new List<DataExtractionGroupDefinition>
+            {
+                new DataExtractionGroupDefinition(
+                    "Group",
+                    new[]
+                    {
+                        new DataExtractionFieldDefinition("field", "Field", ProjectCreationFieldTemplates.Text, null, null, null, false)
+                    })
+            };
+
+            return new ProjectCreationRequest("Project", document, stage, stage, pdf, groups);
+        }
+
+        [Fact]
+        public void DataExtractionVisibility_FollowsStageDecisions()
+        {
+            var viewModel = new ProjectCreationViewModel(CreateRequest());
+
+            Assert.False(viewModel.IsDataExtractionVisible);
+
+            viewModel.TitleAbstractStage.IncludeCommand.Execute(null);
+            Assert.False(viewModel.IsDataExtractionVisible);
+
+            viewModel.FullTextStage.IncludeCommand.Execute(null);
+            Assert.True(viewModel.IsDataExtractionVisible);
+
+            viewModel.FullTextStage.ExcludeCommand.Execute(null);
+            Assert.False(viewModel.IsDataExtractionVisible);
+        }
+
+        [Fact]
+        public void SaveCommandRequiresDecisions()
+        {
+            var viewModel = new ProjectCreationViewModel(CreateRequest());
+
+            Assert.False(viewModel.SaveCommand.CanExecute(null));
+
+            viewModel.TitleAbstractStage.IncludeCommand.Execute(null);
+            viewModel.FullTextStage.IncludeCommand.Execute(null);
+
+            Assert.True(viewModel.SaveCommand.CanExecute(null));
+        }
+    }
+}

--- a/src/LM.App.Wpf/App.xaml.cs
+++ b/src/LM.App.Wpf/App.xaml.cs
@@ -79,6 +79,8 @@ namespace LM.App.Wpf
             await addVm.InitializeAsync();
             _addViewModel = addVm;
             var searchVm = host.GetRequiredService<SearchViewModel>();
+            var shellVm = host.GetRequiredService<ShellViewModel>();
+            shell.DataContext = shellVm;
 
             // Bind – resolve the views by name because the generated fields are not
             // available when building from the command line (designer-only feature).

--- a/src/LM.App.Wpf/Common/Dialogs/IDialogService.cs
+++ b/src/LM.App.Wpf/Common/Dialogs/IDialogService.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using LM.App.Wpf.ViewModels;
+using LM.App.Wpf.ViewModels.Dialogs.Projects;
 
 namespace LM.App.Wpf.Common.Dialogs
 {
@@ -27,5 +28,6 @@ namespace LM.App.Wpf.Common.Dialogs
         string? ShowSaveFileDialog(FileSavePickerOptions options);
         bool? ShowStagingEditor(StagingListViewModel stagingList);
         bool? ShowDataExtractionWorkspace(StagingItem stagingItem);
+        bool? ShowProjectCreation(ProjectCreationRequest request);
     }
 }

--- a/src/LM.App.Wpf/Common/Dialogs/WpfDialogService.cs
+++ b/src/LM.App.Wpf/Common/Dialogs/WpfDialogService.cs
@@ -2,9 +2,11 @@
 using System;
 using System.Linq;
 using LM.App.Wpf.ViewModels;
+using LM.App.Wpf.ViewModels.Dialogs.Projects;
 using LM.App.Wpf.ViewModels.Dialogs.Staging;
 using LM.App.Wpf.Views;
 using LM.App.Wpf.Views.Dialogs.Staging;
+using LM.App.Wpf.Views.Dialogs.Projects;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LM.App.Wpf.Common.Dialogs
@@ -90,6 +92,24 @@ namespace LM.App.Wpf.Common.Dialogs
             using var scope = _services.CreateScope();
             var viewModel = ActivatorUtilities.CreateInstance<DataExtractionWorkspaceViewModel>(scope.ServiceProvider, stagingItem);
             var window = ActivatorUtilities.CreateInstance<DataExtractionWorkspaceWindow>(scope.ServiceProvider, viewModel);
+
+            var owner = System.Windows.Application.Current?.Windows
+                .OfType<System.Windows.Window>()
+                .FirstOrDefault(static w => w.IsActive);
+            if (owner is not null)
+                window.Owner = owner;
+
+            return window.ShowDialog();
+        }
+
+        public bool? ShowProjectCreation(ProjectCreationRequest request)
+        {
+            if (request is null)
+                throw new ArgumentNullException(nameof(request));
+
+            using var scope = _services.CreateScope();
+            var viewModel = ActivatorUtilities.CreateInstance<ProjectCreationViewModel>(scope.ServiceProvider, request);
+            var window = ActivatorUtilities.CreateInstance<ProjectCreationWindow>(scope.ServiceProvider, viewModel);
 
             var owner = System.Windows.Application.Current?.Windows
                 .OfType<System.Windows.Window>()

--- a/src/LM.App.Wpf/Composition/Modules/AddModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/AddModule.cs
@@ -1,8 +1,10 @@
 using LM.App.Wpf.Common.Dialogs;
 using LM.App.Wpf.ViewModels;
 using LM.App.Wpf.ViewModels.Dialogs;
+using LM.App.Wpf.ViewModels.Dialogs.Projects;
 using LM.App.Wpf.Views;
 using LM.App.Wpf.Views.Dialogs.Staging;
+using LM.App.Wpf.Views.Dialogs.Projects;
 using LM.App.Wpf.ViewModels.Dialogs.Staging;
 using LM.Core.Abstractions;
 using LM.Core.Abstractions.Configuration;
@@ -49,6 +51,8 @@ namespace LM.App.Wpf.Composition.Modules
                 sp.GetRequiredService<IDataExtractionCommitBuilder>()));
             services.AddTransient<DataExtractionWorkspaceViewModel>();
             services.AddTransient<DataExtractionWorkspaceWindow>();
+            services.AddTransient<ProjectCreationViewModel>();
+            services.AddTransient<ProjectCreationWindow>();
             services.AddTransient<StagingEditorViewModel>();
             services.AddTransient<StagingEditorWindow>();
 
@@ -67,6 +71,8 @@ namespace LM.App.Wpf.Composition.Modules
                 sp.GetRequiredService<StagingListViewModel>(),
                 sp.GetRequiredService<WatchedFoldersViewModel>(),
                 sp.GetRequiredService<IDialogService>()));
+
+            services.AddSingleton<ShellViewModel>();
         }
     }
 }

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -182,16 +182,74 @@ LM.App.Wpf.Common.Dialogs.IDialogService
 LM.App.Wpf.Common.Dialogs.IDialogService.ShowFolderBrowserDialog(LM.App.Wpf.Common.Dialogs.FolderPickerOptions! options) -> string?
 LM.App.Wpf.Common.Dialogs.IDialogService.ShowStagingEditor(LM.App.Wpf.ViewModels.StagingListViewModel! stagingList) -> bool?
 LM.App.Wpf.Common.Dialogs.IDialogService.ShowDataExtractionWorkspace(LM.App.Wpf.ViewModels.StagingItem! stagingItem) -> bool?
+LM.App.Wpf.Common.Dialogs.IDialogService.ShowProjectCreation(LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationRequest! request) -> bool?
 LM.App.Wpf.Common.Dialogs.WpfDialogService
 LM.App.Wpf.Common.Dialogs.WpfDialogService.ShowFolderBrowserDialog(LM.App.Wpf.Common.Dialogs.FolderPickerOptions! options) -> string?
 LM.App.Wpf.Common.Dialogs.WpfDialogService.ShowStagingEditor(LM.App.Wpf.ViewModels.StagingListViewModel! stagingList) -> bool?
 LM.App.Wpf.Common.Dialogs.WpfDialogService.ShowDataExtractionWorkspace(LM.App.Wpf.ViewModels.StagingItem! stagingItem) -> bool?
+LM.App.Wpf.Common.Dialogs.WpfDialogService.ShowProjectCreation(LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationRequest! request) -> bool?
 LM.App.Wpf.Common.StringJoinConverter
 LM.App.Wpf.Common.StringJoinConverter.Convert(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 LM.App.Wpf.Common.StringJoinConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 LM.App.Wpf.Common.StringJoinConverter.StringJoinConverter() -> void
 LM.App.Wpf.Common.ViewModelBase
 LM.App.Wpf.Common.ViewModelBase.ViewModelBase() -> void
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionFieldDefinition
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionFieldDefinition.DataExtractionFieldDefinition(string! key, string! label, string! templateKey, string? placeholder, System.Collections.Generic.IEnumerable<string?>? options, string? defaultValue, bool isRequired) -> void
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionFieldDefinition.DefaultValue.get -> string?
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionFieldDefinition.IsRequired.get -> bool
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionFieldDefinition.Key.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionFieldDefinition.Label.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionFieldDefinition.Options.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionFieldDefinition.Placeholder.get -> string?
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionFieldDefinition.TemplateKey.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionGroupDefinition
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionGroupDefinition.DataExtractionGroupDefinition(string! name, System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionFieldDefinition!>! fields) -> void
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionGroupDefinition.Fields.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionFieldDefinition!>!
+LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionGroupDefinition.Name.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.DocumentAttributeDefinition
+LM.App.Wpf.ViewModels.Dialogs.Projects.DocumentAttributeDefinition.DocumentAttributeDefinition(string! label, string! value) -> void
+LM.App.Wpf.ViewModels.Dialogs.Projects.DocumentAttributeDefinition.Label.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.DocumentAttributeDefinition.Value.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.PdfPagePreviewDefinition
+LM.App.Wpf.ViewModels.Dialogs.Projects.PdfPagePreviewDefinition.Caption.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.PdfPagePreviewDefinition.PageNumber.get -> int
+LM.App.Wpf.ViewModels.Dialogs.Projects.PdfPagePreviewDefinition.PdfPagePreviewDefinition(int pageNumber, string caption, string summary) -> void
+LM.App.Wpf.ViewModels.Dialogs.Projects.PdfPagePreviewDefinition.Summary.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationFieldTemplates
+LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationFieldTemplates.Choice -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationFieldTemplates.MultiLine -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationFieldTemplates.Text -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationRequest
+LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationRequest.DataExtractionGroups.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionGroupDefinition!>!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationRequest.Document.get -> LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningDocumentDefinition!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationRequest.FullTextPdfPages.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.Dialogs.Projects.PdfPagePreviewDefinition!>!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationRequest.FullTextStage.get -> LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationRequest.ProjectCreationRequest(string! projectName, LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningDocumentDefinition! document, LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition! titleAbstractStage, LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition! fullTextStage, System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.Dialogs.Projects.PdfPagePreviewDefinition!>! fullTextPdfPages, System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.Dialogs.Projects.DataExtractionGroupDefinition!>! dataExtractionGroups) -> void
+LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationRequest.ProjectName.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ProjectCreationRequest.TitleAbstractStage.get -> LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningCriterionDefinition
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningCriterionDefinition.Description.get -> string?
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningCriterionDefinition.IsDefaultSelected.get -> bool
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningCriterionDefinition.Key.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningCriterionDefinition.Label.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningCriterionDefinition.ScreeningCriterionDefinition(string! key, string! label, string? description, bool isDefaultSelected) -> void
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningDocumentDefinition
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningDocumentDefinition.AbstractText.get -> string?
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningDocumentDefinition.Attributes.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.Dialogs.Projects.DocumentAttributeDefinition!>!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningDocumentDefinition.Authors.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningDocumentDefinition.Keywords.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningDocumentDefinition.ScreeningDocumentDefinition(string! title, string? abstractText, System.Collections.Generic.IEnumerable<string!>! authors, System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.Dialogs.Projects.DocumentAttributeDefinition!>! attributes, System.Collections.Generic.IEnumerable<string!>! keywords) -> void
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningDocumentDefinition.Title.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition.AllowMultipleCriteria.get -> bool
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition.AllowNotes.get -> bool
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition.Criteria.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningCriterionDefinition!>!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition.Description.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition.ExcludeLabel.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition.IncludeLabel.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition.Name.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningStageDefinition.ScreeningStageDefinition(string! name, string description, string! includeLabel, string! excludeLabel, bool allowMultipleCriteria, bool allowNotes, System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.Dialogs.Projects.ScreeningCriterionDefinition!>! criteria) -> void
 LM.App.Wpf.Library.LibraryFilterPreset
 LM.App.Wpf.Library.LibraryFilterPreset.LibraryFilterPreset() -> void
 LM.App.Wpf.Library.LibraryFilterPreset.Name.get -> string!

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/DataExtractionFieldDefinition.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/DataExtractionFieldDefinition.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    public sealed record DataExtractionFieldDefinition
+    {
+        public DataExtractionFieldDefinition(
+            string key,
+            string label,
+            string templateKey,
+            string? placeholder,
+            IEnumerable<string>? options,
+            string? defaultValue,
+            bool isRequired)
+        {
+            Key = NormalizeKey(key);
+            Label = NormalizeRequired(label, nameof(label));
+            TemplateKey = NormalizeRequired(templateKey, nameof(templateKey));
+            Placeholder = placeholder?.Trim();
+            DefaultValue = defaultValue?.Trim();
+            Options = CreateOptions(options);
+            IsRequired = isRequired;
+        }
+
+        public string Key { get; }
+
+        public string Label { get; }
+
+        public string TemplateKey { get; }
+
+        public string? Placeholder { get; }
+
+        public IReadOnlyList<string> Options { get; }
+
+        public string? DefaultValue { get; }
+
+        public bool IsRequired { get; }
+
+        private static string NormalizeKey(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException("A non-empty key is required.", nameof(value));
+
+            return value.Trim();
+        }
+
+        private static string NormalizeRequired(string value, string argumentName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException($"A non-empty value for '{argumentName}' is required.", argumentName);
+
+            return value.Trim();
+        }
+
+        private static IReadOnlyList<string> CreateOptions(IEnumerable<string>? options)
+        {
+            if (options is null)
+            {
+                return Array.Empty<string>();
+            }
+
+            var list = new List<string>();
+            foreach (var option in options)
+            {
+                if (string.IsNullOrWhiteSpace(option))
+                {
+                    continue;
+                }
+
+                list.Add(option.Trim());
+            }
+
+            return list.AsReadOnly();
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/DataExtractionFieldViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/DataExtractionFieldViewModel.cs
@@ -1,0 +1,40 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    internal sealed partial class DataExtractionFieldViewModel : ObservableObject
+    {
+        public DataExtractionFieldViewModel(DataExtractionFieldDefinition definition)
+        {
+            Definition = definition;
+            Key = definition.Key;
+            Label = definition.Label;
+            TemplateKey = definition.TemplateKey;
+            Placeholder = definition.Placeholder;
+            Options = new ObservableCollection<string>(definition.Options);
+            isRequired = definition.IsRequired;
+            value = definition.DefaultValue;
+        }
+
+        public DataExtractionFieldDefinition Definition { get; }
+
+        public string Key { get; }
+
+        public string Label { get; }
+
+        public string TemplateKey { get; }
+
+        public string? Placeholder { get; }
+
+        public ObservableCollection<string> Options { get; }
+
+        public bool HasOptions => Options.Count > 0;
+
+        [ObservableProperty]
+        private string? value;
+
+        [ObservableProperty]
+        private bool isRequired;
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/DataExtractionGroupDefinition.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/DataExtractionGroupDefinition.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    public sealed record DataExtractionGroupDefinition
+    {
+        public DataExtractionGroupDefinition(string name, IEnumerable<DataExtractionFieldDefinition> fields)
+        {
+            Name = NormalizeName(name);
+            Fields = CreateFields(fields);
+        }
+
+        public string Name { get; }
+
+        public IReadOnlyList<DataExtractionFieldDefinition> Fields { get; }
+
+        private static string NormalizeName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("A non-empty group name is required.", nameof(name));
+
+            return name.Trim();
+        }
+
+        private static IReadOnlyList<DataExtractionFieldDefinition> CreateFields(IEnumerable<DataExtractionFieldDefinition> fields)
+        {
+            if (fields is null)
+                throw new ArgumentNullException(nameof(fields));
+
+            var list = new List<DataExtractionFieldDefinition>();
+            foreach (var field in fields)
+            {
+                if (field is null)
+                    throw new ArgumentException("Field definitions cannot contain null entries.", nameof(fields));
+
+                list.Add(field);
+            }
+
+            return list.AsReadOnly();
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/DataExtractionGroupViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/DataExtractionGroupViewModel.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.ObjectModel;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    internal sealed class DataExtractionGroupViewModel
+    {
+        public DataExtractionGroupViewModel(DataExtractionGroupDefinition definition)
+        {
+            Definition = definition ?? throw new ArgumentNullException(nameof(definition));
+            Name = definition.Name;
+            Fields = new ObservableCollection<DataExtractionFieldViewModel>(CreateFields(definition));
+        }
+
+        public DataExtractionGroupDefinition Definition { get; }
+
+        public string Name { get; }
+
+        public ObservableCollection<DataExtractionFieldViewModel> Fields { get; }
+
+        private static ObservableCollection<DataExtractionFieldViewModel> CreateFields(DataExtractionGroupDefinition definition)
+        {
+            var collection = new ObservableCollection<DataExtractionFieldViewModel>();
+            foreach (var field in definition.Fields)
+            {
+                collection.Add(new DataExtractionFieldViewModel(field));
+            }
+
+            return collection;
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/DocumentAttributeDefinition.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/DocumentAttributeDefinition.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    public sealed record DocumentAttributeDefinition
+    {
+        public DocumentAttributeDefinition(string label, string value)
+        {
+            Label = Normalize(label, nameof(label));
+            Value = Normalize(value, nameof(value));
+        }
+
+        public string Label { get; }
+
+        public string Value { get; }
+
+        private static string Normalize(string input, string argumentName)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                throw new ArgumentException($"A non-empty value for '{argumentName}' is required.", argumentName);
+
+            return input.Trim();
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/PdfPagePreviewDefinition.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/PdfPagePreviewDefinition.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    public sealed record PdfPagePreviewDefinition
+    {
+        public PdfPagePreviewDefinition(int pageNumber, string caption, string summary)
+        {
+            if (pageNumber <= 0)
+                throw new ArgumentOutOfRangeException(nameof(pageNumber), "Page numbers must be greater than zero.");
+
+            PageNumber = pageNumber;
+            Caption = caption?.Trim() ?? string.Empty;
+            Summary = summary?.Trim() ?? string.Empty;
+        }
+
+        public int PageNumber { get; }
+
+        public string Caption { get; }
+
+        public string Summary { get; }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/PdfPagePreviewViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/PdfPagePreviewViewModel.cs
@@ -1,0 +1,26 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    internal sealed partial class PdfPagePreviewViewModel : ObservableObject
+    {
+        public PdfPagePreviewViewModel(PdfPagePreviewDefinition definition)
+        {
+            Definition = definition;
+            PageNumber = definition.PageNumber;
+            Caption = definition.Caption;
+            Summary = definition.Summary;
+        }
+
+        public PdfPagePreviewDefinition Definition { get; }
+
+        [ObservableProperty]
+        private int pageNumber;
+
+        [ObservableProperty]
+        private string caption;
+
+        [ObservableProperty]
+        private string summary;
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ProjectCreationFieldTemplates.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ProjectCreationFieldTemplates.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    /// <summary>
+    /// Well-known template identifiers that drive the data extraction field presentation.
+    /// </summary>
+    public static class ProjectCreationFieldTemplates
+    {
+        public const string Text = "Text";
+        public const string MultiLine = "MultiLine";
+        public const string Choice = "Choice";
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ProjectCreationRequest.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ProjectCreationRequest.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    public sealed record ProjectCreationRequest
+    {
+        public ProjectCreationRequest(
+            string projectName,
+            ScreeningDocumentDefinition document,
+            ScreeningStageDefinition titleAbstractStage,
+            ScreeningStageDefinition fullTextStage,
+            IEnumerable<PdfPagePreviewDefinition> fullTextPdfPages,
+            IEnumerable<DataExtractionGroupDefinition> dataExtractionGroups)
+        {
+            ProjectName = Normalize(projectName, nameof(projectName));
+            Document = document ?? throw new ArgumentNullException(nameof(document));
+            TitleAbstractStage = titleAbstractStage ?? throw new ArgumentNullException(nameof(titleAbstractStage));
+            FullTextStage = fullTextStage ?? throw new ArgumentNullException(nameof(fullTextStage));
+            FullTextPdfPages = CreatePages(fullTextPdfPages);
+            DataExtractionGroups = CreateGroups(dataExtractionGroups);
+        }
+
+        public string ProjectName { get; }
+
+        public ScreeningDocumentDefinition Document { get; }
+
+        public ScreeningStageDefinition TitleAbstractStage { get; }
+
+        public ScreeningStageDefinition FullTextStage { get; }
+
+        public IReadOnlyList<PdfPagePreviewDefinition> FullTextPdfPages { get; }
+
+        public IReadOnlyList<DataExtractionGroupDefinition> DataExtractionGroups { get; }
+
+        private static string Normalize(string value, string argumentName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException($"A non-empty value for '{argumentName}' is required.", argumentName);
+
+            return value.Trim();
+        }
+
+        private static IReadOnlyList<PdfPagePreviewDefinition> CreatePages(IEnumerable<PdfPagePreviewDefinition> pages)
+        {
+            if (pages is null)
+                throw new ArgumentNullException(nameof(pages));
+
+            var list = new List<PdfPagePreviewDefinition>();
+            foreach (var page in pages)
+            {
+                if (page is null)
+                    throw new ArgumentException("PDF preview collections cannot contain null entries.", nameof(pages));
+
+                list.Add(page);
+            }
+
+            return list.AsReadOnly();
+        }
+
+        private static IReadOnlyList<DataExtractionGroupDefinition> CreateGroups(IEnumerable<DataExtractionGroupDefinition> groups)
+        {
+            if (groups is null)
+                throw new ArgumentNullException(nameof(groups));
+
+            var list = new List<DataExtractionGroupDefinition>();
+            foreach (var group in groups)
+            {
+                if (group is null)
+                    throw new ArgumentException("Data extraction group collections cannot contain null entries.", nameof(groups));
+
+                list.Add(group);
+            }
+
+            return list.AsReadOnly();
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ProjectCreationViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ProjectCreationViewModel.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LM.App.Wpf.Common.Dialogs;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    internal sealed partial class ProjectCreationViewModel : DialogViewModelBase, IDisposable
+    {
+        private readonly RelayCommand _saveCommand;
+        private readonly RelayCommand _cancelCommand;
+        private bool _disposed;
+
+        public ProjectCreationViewModel(ProjectCreationRequest request)
+        {
+            Request = request ?? throw new ArgumentNullException(nameof(request));
+            Document = new ProjectDocumentViewModel(request.Document);
+            TitleAbstractStage = new StageScreeningViewModel(request.TitleAbstractStage);
+            FullTextStage = new StageScreeningViewModel(request.FullTextStage);
+            PdfPages = new ObservableCollection<PdfPagePreviewViewModel>(CreatePdfPages(request));
+            DataExtractionGroups = new ObservableCollection<DataExtractionGroupViewModel>(CreateGroups(request));
+
+            TitleAbstractStage.DecisionChanged += OnStageDecisionChanged;
+            FullTextStage.DecisionChanged += OnStageDecisionChanged;
+
+            _saveCommand = new RelayCommand(Save, CanSave);
+            _cancelCommand = new RelayCommand(Cancel);
+            UpdateDataExtractionVisibility();
+        }
+
+        public ProjectCreationRequest Request { get; }
+
+        public string ProjectName => Request.ProjectName;
+
+        public ProjectDocumentViewModel Document { get; }
+
+        public StageScreeningViewModel TitleAbstractStage { get; }
+
+        public StageScreeningViewModel FullTextStage { get; }
+
+        public ObservableCollection<PdfPagePreviewViewModel> PdfPages { get; }
+
+        public ObservableCollection<DataExtractionGroupViewModel> DataExtractionGroups { get; }
+
+        [ObservableProperty]
+        private bool isDataExtractionVisible;
+
+        public RelayCommand SaveCommand => _saveCommand;
+
+        public RelayCommand CancelCommand => _cancelCommand;
+
+        public string WindowTitle => $"Create project – {ProjectName}";
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            TitleAbstractStage.DecisionChanged -= OnStageDecisionChanged;
+            FullTextStage.DecisionChanged -= OnStageDecisionChanged;
+            _disposed = true;
+        }
+
+        private bool CanSave()
+        {
+            return TitleAbstractStage.HasDecision && FullTextStage.HasDecision;
+        }
+
+        private void Save()
+        {
+            RequestClose(true);
+        }
+
+        private void Cancel()
+        {
+            RequestClose(false);
+        }
+
+        private void OnStageDecisionChanged(object? sender, EventArgs e)
+        {
+            UpdateDataExtractionVisibility();
+            _saveCommand.NotifyCanExecuteChanged();
+        }
+
+        private void UpdateDataExtractionVisibility()
+        {
+            IsDataExtractionVisible = TitleAbstractStage.IsIncluded && FullTextStage.IsIncluded;
+        }
+
+        private static ObservableCollection<PdfPagePreviewViewModel> CreatePdfPages(ProjectCreationRequest request)
+        {
+            var pages = new ObservableCollection<PdfPagePreviewViewModel>();
+            foreach (var definition in request.FullTextPdfPages)
+            {
+                pages.Add(new PdfPagePreviewViewModel(definition));
+            }
+
+            return pages;
+        }
+
+        private static ObservableCollection<DataExtractionGroupViewModel> CreateGroups(ProjectCreationRequest request)
+        {
+            var groups = new ObservableCollection<DataExtractionGroupViewModel>();
+            foreach (var definition in request.DataExtractionGroups)
+            {
+                groups.Add(new DataExtractionGroupViewModel(definition));
+            }
+
+            return groups;
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ProjectDocumentViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ProjectDocumentViewModel.cs
@@ -1,0 +1,29 @@
+using System.Collections.ObjectModel;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    internal sealed class ProjectDocumentViewModel
+    {
+        public ProjectDocumentViewModel(ScreeningDocumentDefinition definition)
+        {
+            Definition = definition;
+            Title = definition.Title;
+            AbstractText = definition.AbstractText;
+            Authors = new ObservableCollection<string>(definition.Authors);
+            Keywords = new ObservableCollection<string>(definition.Keywords);
+            Attributes = new ObservableCollection<DocumentAttributeDefinition>(definition.Attributes);
+        }
+
+        public ScreeningDocumentDefinition Definition { get; }
+
+        public string Title { get; }
+
+        public string? AbstractText { get; }
+
+        public ObservableCollection<string> Authors { get; }
+
+        public ObservableCollection<string> Keywords { get; }
+
+        public ObservableCollection<DocumentAttributeDefinition> Attributes { get; }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ScreeningCriterionDefinition.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ScreeningCriterionDefinition.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    public sealed record ScreeningCriterionDefinition
+    {
+        public ScreeningCriterionDefinition(string key, string label, string? description, bool isDefaultSelected)
+        {
+            Key = NormalizeKey(key);
+            Label = Normalize(label, nameof(label));
+            Description = description?.Trim();
+            IsDefaultSelected = isDefaultSelected;
+        }
+
+        public string Key { get; }
+
+        public string Label { get; }
+
+        public string? Description { get; }
+
+        public bool IsDefaultSelected { get; }
+
+        private static string NormalizeKey(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException("A non-empty key is required.", nameof(value));
+
+            return value.Trim();
+        }
+
+        private static string Normalize(string value, string argumentName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException($"A non-empty value for '{argumentName}' is required.", argumentName);
+
+            return value.Trim();
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ScreeningCriterionViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ScreeningCriterionViewModel.cs
@@ -1,0 +1,27 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    internal sealed partial class ScreeningCriterionViewModel : ObservableObject
+    {
+        public ScreeningCriterionViewModel(ScreeningCriterionDefinition definition)
+        {
+            Definition = definition;
+            Key = definition.Key;
+            Label = definition.Label;
+            Description = definition.Description;
+            isSelected = definition.IsDefaultSelected;
+        }
+
+        public ScreeningCriterionDefinition Definition { get; }
+
+        public string Key { get; }
+
+        public string Label { get; }
+
+        public string? Description { get; }
+
+        [ObservableProperty]
+        private bool isSelected;
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ScreeningDocumentDefinition.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ScreeningDocumentDefinition.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    public sealed record ScreeningDocumentDefinition
+    {
+        public ScreeningDocumentDefinition(
+            string title,
+            string? abstractText,
+            IEnumerable<string> authors,
+            IEnumerable<DocumentAttributeDefinition> attributes,
+            IEnumerable<string> keywords)
+        {
+            Title = Normalize(title, nameof(title));
+            AbstractText = abstractText?.Trim();
+            Authors = CreateList(authors, nameof(authors));
+            Attributes = CreateAttributes(attributes);
+            Keywords = CreateKeywords(keywords);
+        }
+
+        public string Title { get; }
+
+        public string? AbstractText { get; }
+
+        public IReadOnlyList<string> Authors { get; }
+
+        public IReadOnlyList<DocumentAttributeDefinition> Attributes { get; }
+
+        public IReadOnlyList<string> Keywords { get; }
+
+        private static string Normalize(string value, string argumentName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException($"A non-empty value for '{argumentName}' is required.", argumentName);
+
+            return value.Trim();
+        }
+
+        private static IReadOnlyList<string> CreateList(IEnumerable<string> values, string argumentName)
+        {
+            if (values is null)
+                throw new ArgumentNullException(argumentName);
+
+            var list = new List<string>();
+            foreach (var value in values)
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    continue;
+
+                list.Add(value.Trim());
+            }
+
+            return list.AsReadOnly();
+        }
+
+        private static IReadOnlyList<DocumentAttributeDefinition> CreateAttributes(IEnumerable<DocumentAttributeDefinition> values)
+        {
+            if (values is null)
+                throw new ArgumentNullException(nameof(values));
+
+            var list = new List<DocumentAttributeDefinition>();
+            foreach (var value in values)
+            {
+                if (value is null)
+                    throw new ArgumentException("Attribute collections cannot contain null entries.", nameof(values));
+
+                list.Add(value);
+            }
+
+            return list.AsReadOnly();
+        }
+
+        private static IReadOnlyList<string> CreateKeywords(IEnumerable<string> values)
+        {
+            return CreateList(values, nameof(values));
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ScreeningStageDefinition.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/ScreeningStageDefinition.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    public sealed record ScreeningStageDefinition
+    {
+        public ScreeningStageDefinition(
+            string name,
+            string description,
+            string includeLabel,
+            string excludeLabel,
+            bool allowMultipleCriteria,
+            bool allowNotes,
+            IEnumerable<ScreeningCriterionDefinition> criteria)
+        {
+            Name = Normalize(name, nameof(name));
+            Description = description?.Trim() ?? string.Empty;
+            IncludeLabel = Normalize(includeLabel, nameof(includeLabel));
+            ExcludeLabel = Normalize(excludeLabel, nameof(excludeLabel));
+            AllowMultipleCriteria = allowMultipleCriteria;
+            AllowNotes = allowNotes;
+            Criteria = CreateCriteria(criteria);
+        }
+
+        public string Name { get; }
+
+        public string Description { get; }
+
+        public string IncludeLabel { get; }
+
+        public string ExcludeLabel { get; }
+
+        public bool AllowMultipleCriteria { get; }
+
+        public bool AllowNotes { get; }
+
+        public IReadOnlyList<ScreeningCriterionDefinition> Criteria { get; }
+
+        private static string Normalize(string value, string argumentName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException($"A non-empty value for '{argumentName}' is required.", argumentName);
+
+            return value.Trim();
+        }
+
+        private static IReadOnlyList<ScreeningCriterionDefinition> CreateCriteria(IEnumerable<ScreeningCriterionDefinition> criteria)
+        {
+            if (criteria is null)
+                throw new ArgumentNullException(nameof(criteria));
+
+            var list = new List<ScreeningCriterionDefinition>();
+            foreach (var criterion in criteria)
+            {
+                if (criterion is null)
+                    throw new ArgumentException("Criteria collections cannot contain null entries.", nameof(criteria));
+
+                list.Add(criterion);
+            }
+
+            return list.AsReadOnly();
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Dialogs/Projects/StageScreeningViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/Projects/StageScreeningViewModel.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LM.Review.Core.Models;
+
+namespace LM.App.Wpf.ViewModels.Dialogs.Projects
+{
+    internal sealed partial class StageScreeningViewModel : ObservableObject
+    {
+        private readonly RelayCommand _includeCommand;
+        private readonly RelayCommand _excludeCommand;
+        private readonly RelayCommand _resetCommand;
+
+        public StageScreeningViewModel(ScreeningStageDefinition definition)
+        {
+            Definition = definition ?? throw new ArgumentNullException(nameof(definition));
+            Name = definition.Name;
+            Description = definition.Description;
+            IncludeLabel = definition.IncludeLabel;
+            ExcludeLabel = definition.ExcludeLabel;
+            AllowMultipleCriteria = definition.AllowMultipleCriteria;
+            AllowNotes = definition.AllowNotes;
+            Criteria = new ObservableCollection<ScreeningCriterionViewModel>(CreateCriteria(definition.Criteria));
+
+            foreach (var criterion in Criteria)
+            {
+                criterion.PropertyChanged += OnCriterionPropertyChanged;
+            }
+
+            _includeCommand = new RelayCommand(SetIncluded, static () => true);
+            _excludeCommand = new RelayCommand(SetExcluded, static () => true);
+            _resetCommand = new RelayCommand(ResetDecision, () => Decision != ScreeningStatus.Pending);
+        }
+
+        public event EventHandler? DecisionChanged;
+
+        public ScreeningStageDefinition Definition { get; }
+
+        public string Name { get; }
+
+        public string Description { get; }
+
+        public string IncludeLabel { get; }
+
+        public string ExcludeLabel { get; }
+
+        public bool AllowMultipleCriteria { get; }
+
+        public bool AllowNotes { get; }
+
+        public ObservableCollection<ScreeningCriterionViewModel> Criteria { get; }
+
+        [ObservableProperty]
+        private ScreeningStatus decision = ScreeningStatus.Pending;
+
+        [ObservableProperty]
+        private string? notes;
+
+        public RelayCommand IncludeCommand => _includeCommand;
+
+        public RelayCommand ExcludeCommand => _excludeCommand;
+
+        public RelayCommand ResetCommand => _resetCommand;
+
+        public bool IsIncluded => Decision == ScreeningStatus.Included;
+
+        public bool IsExcluded => Decision == ScreeningStatus.Excluded;
+
+        public bool HasDecision => Decision is ScreeningStatus.Included or ScreeningStatus.Excluded;
+
+        partial void OnDecisionChanged(ScreeningStatus value)
+        {
+            _resetCommand.NotifyCanExecuteChanged();
+            DecisionChanged?.Invoke(this, EventArgs.Empty);
+            OnPropertyChanged(nameof(IsIncluded));
+            OnPropertyChanged(nameof(IsExcluded));
+            OnPropertyChanged(nameof(HasDecision));
+        }
+
+        private void SetIncluded()
+        {
+            Decision = ScreeningStatus.Included;
+        }
+
+        private void SetExcluded()
+        {
+            Decision = ScreeningStatus.Excluded;
+        }
+
+        private void ResetDecision()
+        {
+            Decision = ScreeningStatus.Pending;
+            Notes = null;
+            foreach (var criterion in Criteria)
+            {
+                criterion.IsSelected = false;
+            }
+        }
+
+        private IEnumerable<ScreeningCriterionViewModel> CreateCriteria(IReadOnlyList<ScreeningCriterionDefinition> definitions)
+        {
+            foreach (var definition in definitions)
+            {
+                yield return new ScreeningCriterionViewModel(definition);
+            }
+        }
+
+        private void OnCriterionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (!AllowMultipleCriteria && sender is ScreeningCriterionViewModel changed && e.PropertyName == nameof(ScreeningCriterionViewModel.IsSelected))
+            {
+                if (!changed.IsSelected)
+                {
+                    return;
+                }
+
+                foreach (var criterion in Criteria)
+                {
+                    if (!ReferenceEquals(criterion, changed))
+                    {
+                        criterion.IsSelected = false;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/ShellViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/ShellViewModel.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LM.App.Wpf.Common.Dialogs;
+using LM.App.Wpf.ViewModels.Dialogs.Projects;
+
+namespace LM.App.Wpf.ViewModels
+{
+    internal sealed partial class ShellViewModel : ObservableObject
+    {
+        private readonly IDialogService _dialogService;
+        private readonly RelayCommand _createProjectCommand;
+
+        public ShellViewModel(IDialogService dialogService)
+        {
+            _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
+            _createProjectCommand = new RelayCommand(OpenProjectCreation);
+        }
+
+        public RelayCommand CreateProjectCommand => _createProjectCommand;
+
+        private void OpenProjectCreation()
+        {
+            var request = BuildSampleRequest();
+            _dialogService.ShowProjectCreation(request);
+        }
+
+        private static ProjectCreationRequest BuildSampleRequest()
+        {
+            var document = new ScreeningDocumentDefinition(
+                "When surgery is not an option: case report of transcatheter valve-in-valve replacement for mitral valve dysfunction",
+                "Bioprosthetic heart valve dysfunction remains a challenge for frail patients with high surgical risk. This rapid assessment reviews transcatheter valve-in-valve replacement as an alternative, summarizing outcomes and peri-procedural considerations.",
+                new[]
+                {
+                    "Alsancak Y.",
+                    "Kani H.",
+                    "Gürbüz A.S.",
+                    "Aydın M.F."
+                },
+                new[]
+                {
+                    new DocumentAttributeDefinition("Journal", "Literature Medicine"),
+                    new DocumentAttributeDefinition("Published", "Dec 2023"),
+                    new DocumentAttributeDefinition("DOI", "10.1000/example-doi-2023")
+                },
+                new[]
+                {
+                    "transcatheter", "valve-in-valve", "mitral", "structural heart"
+                });
+
+            var titleStage = new ScreeningStageDefinition(
+                "Title & abstract screening",
+                "Decide whether the study meets the PICOS criteria based on bibliographic information.",
+                "Include",
+                "Exclude",
+                true,
+                true,
+                new[]
+                {
+                    new ScreeningCriterionDefinition("population", "Population mismatch", "The study population diverges from the specified patient cohort.", false),
+                    new ScreeningCriterionDefinition("intervention", "Intervention mismatch", "Procedure or therapy does not evaluate transcatheter valve-in-valve approaches.", false),
+                    new ScreeningCriterionDefinition("outcomes", "Outcomes insufficient", "No relevant clinical endpoints are reported.", false),
+                    new ScreeningCriterionDefinition("language", "Language restriction", "Full text unavailable in the review language.", false)
+                });
+
+            var fullTextStage = new ScreeningStageDefinition(
+                "Full text review",
+                "Confirm eligibility against full inclusion criteria and document any exclusion rationale.",
+                "Include",
+                "Exclude",
+                false,
+                true,
+                new[]
+                {
+                    new ScreeningCriterionDefinition("study-design", "Study design mismatch", "Does not meet accepted design types (RCT, observational, case series).", false),
+                    new ScreeningCriterionDefinition("picos", "PICOS deviation", "Fails to satisfy PICOS specifications in detail.", false),
+                    new ScreeningCriterionDefinition("insufficient-data", "Insufficient data", "Missing quantitative outcomes or follow-up details.", false)
+                });
+
+            var pdfPages = new List<PdfPagePreviewDefinition>
+            {
+                new PdfPagePreviewDefinition(1, "Abstract & summary", "The introductory section outlines mitral valve dysfunction cases treated with a transcatheter valve-in-valve approach, including key hemodynamic outcomes."),
+                new PdfPagePreviewDefinition(2, "Procedural details", "Illustrations highlight catheter positioning, valve deployment, and peri-procedural imaging guidance."),
+                new PdfPagePreviewDefinition(3, "Clinical outcomes", "Table summarises survival, rehospitalisation, and post-operative complications across the presented cohort.")
+            };
+
+            var dataExtractionGroups = new List<DataExtractionGroupDefinition>
+            {
+                new DataExtractionGroupDefinition(
+                    "Study profile",
+                    new[]
+                    {
+                        new DataExtractionFieldDefinition("design", "Study design", ProjectCreationFieldTemplates.Choice, "Select the study design", new[] { "Case report", "Case series", "Prospective cohort", "Randomised trial" }, "Case report", true),
+                        new DataExtractionFieldDefinition("sample-size", "Sample size", ProjectCreationFieldTemplates.Text, "Enter the number of participants", null, null, true),
+                        new DataExtractionFieldDefinition("setting", "Clinical setting", ProjectCreationFieldTemplates.Text, "Hospital type or region", null, null, false)
+                    }),
+                new DataExtractionGroupDefinition(
+                    "Primary outcomes",
+                    new[]
+                    {
+                        new DataExtractionFieldDefinition("primary-outcome", "Primary outcome", ProjectCreationFieldTemplates.MultiLine, "Summarise mortality, valve gradients, and rehospitalisation", null, null, true),
+                        new DataExtractionFieldDefinition("follow-up", "Follow-up duration", ProjectCreationFieldTemplates.Text, "Specify median or mean follow-up period", null, null, false)
+                    }),
+                new DataExtractionGroupDefinition(
+                    "Secondary notes",
+                    new[]
+                    {
+                        new DataExtractionFieldDefinition("complications", "Notable complications", ProjectCreationFieldTemplates.MultiLine, "Record periprocedural complications or device malfunctions", null, null, false),
+                        new DataExtractionFieldDefinition("remarks", "Reviewer remarks", ProjectCreationFieldTemplates.MultiLine, "Add contextual insights or escalation notes", null, null, false)
+                    })
+            };
+
+            return new ProjectCreationRequest(
+                "Structural valve intervention project",
+                document,
+                titleStage,
+                fullTextStage,
+                pdfPages,
+                dataExtractionGroups);
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/Dialogs/Projects/ProjectCreationWindow.xaml
+++ b/src/LM.App.Wpf/Views/Dialogs/Projects/ProjectCreationWindow.xaml
@@ -1,0 +1,550 @@
+<Window x:Class="LM.App.Wpf.Views.Dialogs.Projects.ProjectCreationWindow"
+        x:ClassModifier="internal"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:proj="clr-namespace:LM.App.Wpf.ViewModels.Dialogs.Projects"
+        xmlns:common="clr-namespace:LM.App.Wpf.Common"
+        mc:Ignorable="d"
+        Title="{Binding WindowTitle}"
+        Height="820"
+        Width="1320"
+        Background="#FFF9FAFC"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize">
+  <Window.Resources>
+    <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+    <common:StringJoinConverter x:Key="StringJoinConverter" />
+
+    <Style x:Key="StageActionButtonStyle" TargetType="Button">
+      <Setter Property="Padding" Value="14,10" />
+      <Setter Property="Margin" Value="0,0,8,0" />
+      <Setter Property="FontSize" Value="14" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Background" Value="#FF1D4ED8" />
+      <Setter Property="Foreground" Value="White" />
+      <Setter Property="BorderBrush" Value="#FF153FA6" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="6" />
+      <Setter Property="HorizontalAlignment" Value="Stretch" />
+      <Setter Property="SnapsToDevicePixels" Value="True" />
+      <Setter Property="Template">
+        <Setter.Value>
+          <ControlTemplate TargetType="Button">
+            <Border Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="{TemplateBinding CornerRadius}">
+              <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Border>
+            <ControlTemplate.Triggers>
+              <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="#FF2A5EEA" />
+                <Setter Property="BorderBrush" Value="#FF1E40AF" />
+              </Trigger>
+              <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Background" Value="#FFCBD5F5" />
+                <Setter Property="BorderBrush" Value="#FF9AA7E0" />
+                <Setter Property="Foreground" Value="#FF5F6B94" />
+              </Trigger>
+            </ControlTemplate.Triggers>
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
+    </Style>
+
+    <Style x:Key="SecondaryStageActionButtonStyle" BasedOn="{StaticResource StageActionButtonStyle}" TargetType="Button">
+      <Setter Property="Background" Value="White" />
+      <Setter Property="Foreground" Value="#FF1D4ED8" />
+      <Setter Property="BorderBrush" Value="#FFCBD5F5" />
+      <Setter Property="Margin" Value="0,0,0,0" />
+      <Setter Property="Template">
+        <Setter.Value>
+          <ControlTemplate TargetType="Button">
+            <Border Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="{TemplateBinding CornerRadius}">
+              <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Border>
+            <ControlTemplate.Triggers>
+              <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="BorderBrush" Value="#FF93A4E6" />
+                <Setter Property="Background" Value="#FFF3F6FF" />
+              </Trigger>
+              <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="#FF94A3B8" />
+                <Setter Property="BorderBrush" Value="#FFE2E8F0" />
+              </Trigger>
+            </ControlTemplate.Triggers>
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
+    </Style>
+
+    <DataTemplate DataType="{x:Type proj:StageScreeningViewModel}" x:Key="StageActionTemplate">
+      <StackPanel>
+        <TextBlock Text="{Binding Name}"
+                   FontSize="20"
+                   FontWeight="SemiBold"
+                   Foreground="#FF1D2433" />
+        <TextBlock Text="{Binding Description}"
+                   Margin="0,4,0,16"
+                   TextWrapping="Wrap"
+                   Foreground="#FF4B5563" />
+
+        <UniformGrid Columns="2" Margin="0,0,0,16" HorizontalAlignment="Stretch">
+          <Button Content="{Binding IncludeLabel}"
+                  Command="{Binding IncludeCommand}"
+                  Style="{StaticResource StageActionButtonStyle}" />
+          <Button Content="{Binding ExcludeLabel}"
+                  Command="{Binding ExcludeCommand}"
+                  Style="{StaticResource SecondaryStageActionButtonStyle}" />
+        </UniformGrid>
+
+        <Border Background="#FFF1F5F9"
+                BorderBrush="#FFE2E8F0"
+                BorderThickness="1"
+                CornerRadius="6"
+                Padding="12"
+                Margin="0,0,0,12">
+          <StackPanel>
+            <TextBlock Text="Decision"
+                       FontSize="13"
+                       FontWeight="SemiBold"
+                       Foreground="#FF475569" />
+            <TextBlock Margin="0,4,0,0"
+                       FontSize="16"
+                       FontWeight="SemiBold"
+                       Foreground="#FF1D4ED8">
+              <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                  <Setter Property="Text" Value="Pending" />
+                  <Style.Triggers>
+                    <DataTrigger Binding="{Binding IsIncluded}" Value="True">
+                      <Setter Property="Text" Value="Included" />
+                      <Setter Property="Foreground" Value="#FF15803D" />
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding IsExcluded}" Value="True">
+                      <Setter Property="Text" Value="Excluded" />
+                      <Setter Property="Foreground" Value="#FFB91C1C" />
+                    </DataTrigger>
+                  </Style.Triggers>
+                </Style>
+              </TextBlock.Style>
+            </TextBlock>
+          </StackPanel>
+        </Border>
+
+        <StackPanel>
+          <TextBlock Text="Screening checklist"
+                     FontWeight="SemiBold"
+                     Foreground="#FF1F2937" />
+          <ItemsControl ItemsSource="{Binding Criteria}" Margin="0,8,0,0">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <Border Padding="10"
+                        Margin="0,0,0,6"
+                        Background="#FFFFFFFF"
+                        BorderBrush="#FFE2E8F0"
+                        BorderThickness="1"
+                        CornerRadius="6">
+                  <StackPanel>
+                    <CheckBox Content="{Binding Label}"
+                              IsChecked="{Binding IsSelected, Mode=TwoWay}" />
+                    <TextBlock Text="{Binding Description}"
+                               Margin="20,4,0,0"
+                               Foreground="#FF64748B"
+                               TextWrapping="Wrap">
+                      <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                          <Setter Property="Visibility" Value="Visible" />
+                          <Style.Triggers>
+                            <Trigger Property="Text" Value="">
+                              <Setter Property="Visibility" Value="Collapsed" />
+                            </Trigger>
+                            <Trigger Property="Text" Value="{x:Null}">
+                              <Setter Property="Visibility" Value="Collapsed" />
+                            </Trigger>
+                          </Style.Triggers>
+                        </Style>
+                      </TextBlock.Style>
+                    </TextBlock>
+                  </StackPanel>
+                </Border>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </StackPanel>
+
+        <StackPanel Margin="0,16,0,0"
+                    Visibility="{Binding AllowNotes, Converter={StaticResource BoolToVisibility}}">
+          <TextBlock Text="Reviewer notes"
+                     FontWeight="SemiBold"
+                     Foreground="#FF1F2937" />
+          <TextBox Text="{Binding Notes, UpdateSourceTrigger=PropertyChanged}"
+                   Margin="0,6,0,0"
+                   AcceptsReturn="True"
+                   MinHeight="80"
+                   TextWrapping="Wrap"
+                   BorderBrush="#FFCBD5F5"
+                   BorderThickness="1"
+                   Padding="8" />
+        </StackPanel>
+
+        <Button Content="Reset decision"
+                Command="{Binding ResetCommand}"
+                Margin="0,20,0,0"
+                HorizontalAlignment="Left"
+                Padding="10,6"
+                BorderBrush="#FFE2E8F0"
+                Background="White"
+                Foreground="#FF475569" />
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate x:Key="DataExtractionFieldTemplate" DataType="{x:Type proj:DataExtractionFieldViewModel}">
+      <StackPanel Margin="0,0,0,16">
+        <DockPanel>
+          <TextBlock Text="{Binding Label}"
+                     DockPanel.Dock="Left"
+                     FontWeight="SemiBold"
+                     Foreground="#FF1F2937" />
+          <TextBlock Text="Required"
+                     DockPanel.Dock="Right"
+                     FontSize="11"
+                     Foreground="#FFB91C1C"
+                     Visibility="{Binding IsRequired, Converter={StaticResource BoolToVisibility}}" />
+        </DockPanel>
+        <ContentControl>
+          <ContentControl.Style>
+            <Style TargetType="ContentControl">
+              <Setter Property="ContentTemplate">
+                <Setter.Value>
+                  <DataTemplate>
+                    <TextBox Text="{Binding Value, UpdateSourceTrigger=PropertyChanged}"
+                             Padding="10"
+                             BorderBrush="#FFCBD5F5"
+                             BorderThickness="1"
+                             Background="White"
+                             TextWrapping="Wrap"
+                             MinHeight="36"
+                             AcceptsReturn="False" />
+                  </DataTemplate>
+                </Setter.Value>
+              </Setter>
+              <Style.Triggers>
+                <DataTrigger Binding="{Binding TemplateKey}" Value="{x:Static proj:ProjectCreationFieldTemplates.MultiLine}">
+                  <Setter Property="ContentTemplate">
+                    <Setter.Value>
+                      <DataTemplate>
+                        <TextBox Text="{Binding Value, UpdateSourceTrigger=PropertyChanged}"
+                                 Padding="10"
+                                 BorderBrush="#FFCBD5F5"
+                                 BorderThickness="1"
+                                 Background="White"
+                                 MinHeight="96"
+                                 AcceptsReturn="True"
+                                 TextWrapping="Wrap" />
+                      </DataTemplate>
+                    </Setter.Value>
+                  </Setter>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding TemplateKey}" Value="{x:Static proj:ProjectCreationFieldTemplates.Choice}">
+                  <Setter Property="ContentTemplate">
+                    <Setter.Value>
+                      <DataTemplate>
+                        <ComboBox ItemsSource="{Binding Options}"
+                                  SelectedItem="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                  Padding="6"
+                                  Background="White"
+                                  BorderBrush="#FFCBD5F5"
+                                  BorderThickness="1" />
+                      </DataTemplate>
+                    </Setter.Value>
+                  </Setter>
+                </DataTrigger>
+              </Style.Triggers>
+            </Style>
+          </ContentControl.Style>
+        </ContentControl>
+        <TextBlock Text="{Binding Placeholder}"
+                   Foreground="#FF94A3B8"
+                   FontSize="11"
+                   Margin="4,4,0,0"
+                   TextWrapping="Wrap">
+          <TextBlock.Style>
+            <Style TargetType="TextBlock">
+              <Setter Property="Visibility" Value="Visible" />
+              <Style.Triggers>
+                <Trigger Property="Text" Value="">
+                  <Setter Property="Visibility" Value="Collapsed" />
+                </Trigger>
+                <Trigger Property="Text" Value="{x:Null}">
+                  <Setter Property="Visibility" Value="Collapsed" />
+                </Trigger>
+              </Style.Triggers>
+            </Style>
+          </TextBlock.Style>
+        </TextBlock>
+      </StackPanel>
+    </DataTemplate>
+  </Window.Resources>
+
+  <Grid Margin="24">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="3*" />
+      <ColumnDefinition Width="2*" />
+    </Grid.ColumnDefinitions>
+
+    <Border Grid.Row="0"
+            Grid.ColumnSpan="2"
+            Background="White"
+            BorderBrush="#FFE2E8F0"
+            BorderThickness="1"
+            CornerRadius="14"
+            Padding="24">
+      <Border.Effect>
+        <DropShadowEffect Color="#11000000" BlurRadius="18" ShadowDepth="2" />
+      </Border.Effect>
+      <StackPanel>
+        <TextBlock Text="{Binding ProjectName}"
+                   FontSize="26"
+                   FontWeight="SemiBold"
+                   Foreground="#FF111827" />
+        <ItemsControl ItemsSource="{Binding Document.Attributes}"
+                      Margin="0,12,0,0">
+          <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+              <UniformGrid Columns="3" />
+            </ItemsPanelTemplate>
+          </ItemsControl.ItemsPanel>
+          <ItemsControl.ItemTemplate>
+            <DataTemplate>
+              <StackPanel>
+                <TextBlock Text="{Binding Label}"
+                           FontSize="12"
+                           Foreground="#FF6B7280" />
+                <TextBlock Text="{Binding Value}"
+                           FontWeight="SemiBold"
+                           Foreground="#FF1F2937" />
+              </StackPanel>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+        <TextBlock Text="{Binding Document.Authors, Converter={StaticResource StringJoinConverter}}"
+                   Margin="0,12,0,0"
+                   Foreground="#FF4B5563" />
+      </StackPanel>
+    </Border>
+
+    <Border Grid.Row="1"
+            Grid.Column="0"
+            Margin="0,24,24,24"
+            Padding="0"
+            Background="Transparent">
+      <TabControl>
+        <TabItem Header="Title &amp; Abstract">
+          <Grid Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="1.6*" />
+              <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+            <Border Grid.Column="0"
+                    Background="White"
+                    BorderBrush="#FFE2E8F0"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Padding="20"
+                    Margin="0,0,16,0">
+              <ScrollViewer>
+                <StackPanel>
+                  <TextBlock Text="Abstract"
+                             FontSize="18"
+                             FontWeight="SemiBold"
+                             Foreground="#FF111827" />
+                  <TextBlock Text="{Binding DataContext.Document.AbstractText, RelativeSource={RelativeSource AncestorType=TabControl}}"
+                             Margin="0,8,0,0"
+                             TextWrapping="Wrap"
+                             Foreground="#FF4B5563" />
+                  <TextBlock Text="Authors"
+                             Margin="0,16,0,0"
+                             FontWeight="SemiBold"
+                             Foreground="#FF111827" />
+                  <ItemsControl ItemsSource="{Binding DataContext.Document.Authors, RelativeSource={RelativeSource AncestorType=TabControl}}"
+                                Margin="0,6,0,0">
+                    <ItemsControl.ItemTemplate>
+                      <DataTemplate>
+                        <TextBlock Text="•  {Binding}"
+                                   Foreground="#FF4B5563" />
+                      </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                  </ItemsControl>
+                  <TextBlock Text="Keywords"
+                             Margin="0,16,0,0"
+                             FontWeight="SemiBold"
+                             Foreground="#FF111827" />
+                  <ItemsControl ItemsSource="{Binding DataContext.Document.Keywords, RelativeSource={RelativeSource AncestorType=TabControl}}"
+                                Margin="0,6,0,0">
+                    <ItemsControl.ItemsPanel>
+                      <ItemsPanelTemplate>
+                        <WrapPanel IsItemsHost="True" />
+                      </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                      <DataTemplate>
+                        <Border Background="#FFE0E7FF"
+                                BorderBrush="#FFCBD5F5"
+                                BorderThickness="1"
+                                CornerRadius="12"
+                                Padding="10,4"
+                                Margin="0,0,8,8">
+                          <TextBlock Text="{Binding}"
+                                     Foreground="#FF1D4ED8" />
+                        </Border>
+                      </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                  </ItemsControl>
+                </StackPanel>
+              </ScrollViewer>
+            </Border>
+            <Border Grid.Column="1"
+                    Background="White"
+                    BorderBrush="#FFE2E8F0"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Padding="20">
+              <ContentControl Content="{Binding DataContext.TitleAbstractStage, RelativeSource={RelativeSource AncestorType=TabControl}}"
+                              ContentTemplate="{StaticResource StageActionTemplate}" />
+            </Border>
+          </Grid>
+        </TabItem>
+        <TabItem Header="Full Text">
+          <Grid Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="1.7*" />
+              <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+            <Border Grid.Column="0"
+                    Background="White"
+                    BorderBrush="#FFE2E8F0"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Padding="0"
+                    Margin="0,0,16,0">
+              <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <ItemsControl ItemsSource="{Binding DataContext.PdfPages, RelativeSource={RelativeSource AncestorType=TabControl}}">
+                  <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                      <Border Margin="24"
+                              Background="#FFF8FAFF"
+                              BorderBrush="#FFE0E7FF"
+                              BorderThickness="1"
+                              CornerRadius="12"
+                              Padding="18">
+                        <StackPanel>
+                          <TextBlock Text="Page {Binding PageNumber}"
+                                     FontWeight="SemiBold"
+                                     Foreground="#FF1D4ED8" />
+                          <TextBlock Text="{Binding Caption}"
+                                     Margin="0,4,0,0"
+                                     FontSize="16"
+                                     FontWeight="SemiBold"
+                                     Foreground="#FF111827" />
+                          <TextBlock Text="{Binding Summary}"
+                                     Margin="0,6,0,0"
+                                     TextWrapping="Wrap"
+                                     Foreground="#FF4B5563" />
+                        </StackPanel>
+                      </Border>
+                    </DataTemplate>
+                  </ItemsControl.ItemTemplate>
+                </ItemsControl>
+              </ScrollViewer>
+            </Border>
+            <Border Grid.Column="1"
+                    Background="White"
+                    BorderBrush="#FFE2E8F0"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Padding="20">
+              <ContentControl Content="{Binding DataContext.FullTextStage, RelativeSource={RelativeSource AncestorType=TabControl}}"
+                              ContentTemplate="{StaticResource StageActionTemplate}" />
+            </Border>
+          </Grid>
+        </TabItem>
+      </TabControl>
+    </Border>
+
+    <Border Grid.Row="1"
+            Grid.Column="1"
+            Margin="0,24,0,24"
+            Padding="20"
+            Background="White"
+            BorderBrush="#FFE2E8F0"
+            BorderThickness="1"
+            CornerRadius="12"
+            Visibility="{Binding IsDataExtractionVisible, Converter={StaticResource BoolToVisibility}}">
+      <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+          <TextBlock Text="Data extraction template"
+                     FontSize="20"
+                     FontWeight="SemiBold"
+                     Foreground="#FF0F172A" />
+          <TextBlock Text="Captured only after inclusion at both screening stages"
+                     Margin="0,4,0,16"
+                     Foreground="#FF4B5563" />
+          <ItemsControl ItemsSource="{Binding DataExtractionGroups}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <Border BorderBrush="#FFD9E0F5"
+                        BorderThickness="1"
+                        CornerRadius="10"
+                        Margin="0,0,0,16"
+                        Padding="16">
+                  <StackPanel>
+                    <TextBlock Text="{Binding Name}"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               Foreground="#FF1F2937" />
+                    <ItemsControl ItemsSource="{Binding Fields}"
+                                  ItemTemplate="{StaticResource DataExtractionFieldTemplate}"
+                                  Margin="0,12,0,0" />
+                  </StackPanel>
+                </Border>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </StackPanel>
+      </ScrollViewer>
+    </Border>
+
+    <StackPanel Grid.Row="2"
+                Grid.ColumnSpan="2"
+                Orientation="Horizontal"
+                HorizontalAlignment="Right"
+                Margin="0,12,0,0">
+      <Button Content="Cancel"
+              Command="{Binding CancelCommand}"
+              Padding="20,10"
+              Margin="0,0,12,0"
+              Background="White"
+              BorderBrush="#FFE2E8F0"
+              BorderThickness="1"
+              Foreground="#FF4B5563" />
+      <Button Content="Create project"
+              Command="{Binding SaveCommand}"
+              Padding="24,10"
+              Background="#FF2563EB"
+              Foreground="White"
+              BorderBrush="#FF1E40AF"
+              BorderThickness="1" />
+    </StackPanel>
+  </Grid>
+</Window>

--- a/src/LM.App.Wpf/Views/Dialogs/Projects/ProjectCreationWindow.xaml.cs
+++ b/src/LM.App.Wpf/Views/Dialogs/Projects/ProjectCreationWindow.xaml.cs
@@ -1,0 +1,31 @@
+using System;
+using LM.App.Wpf.Common.Dialogs;
+using LM.App.Wpf.ViewModels.Dialogs.Projects;
+
+namespace LM.App.Wpf.Views.Dialogs.Projects
+{
+    internal partial class ProjectCreationWindow : System.Windows.Window
+    {
+        private readonly ProjectCreationViewModel _viewModel;
+
+        public ProjectCreationWindow(ProjectCreationViewModel viewModel)
+        {
+            InitializeComponent();
+            _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+            DataContext = _viewModel;
+            _viewModel.CloseRequested += OnCloseRequested;
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _viewModel.CloseRequested -= OnCloseRequested;
+            _viewModel.Dispose();
+            base.OnClosed(e);
+        }
+
+        private void OnCloseRequested(object? sender, DialogCloseRequestedEventArgs e)
+        {
+            DialogResult = e.DialogResult;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/ShellWindow.xaml
+++ b/src/LM.App.Wpf/Views/ShellWindow.xaml
@@ -4,17 +4,23 @@
         xmlns:views="clr-namespace:LM.App.Wpf.Views"
         Title="KnowledgeWorks" Height="700" Width="1100"
         WindowStartupLocation="CenterScreen">
-  <Grid>
+  <DockPanel>
+    <Menu DockPanel.Dock="Top">
+      <MenuItem Header="_Project">
+        <MenuItem Header="_Create…"
+                  Command="{Binding CreateProjectCommand}" />
+      </MenuItem>
+    </Menu>
     <TabControl>
-            <TabItem Header="Library">
-                <views:LibraryView x:Name="LibraryViewControl"/>
-            </TabItem>
-            <TabItem Header="Add">
-        <views:AddView x:Name="AddViewControl"/>
+      <TabItem Header="Library">
+        <views:LibraryView x:Name="LibraryViewControl" />
       </TabItem>
-            <TabItem Header="Search">
-                <views:SearchView x:Name="SearchViewControl" />
-            </TabItem>
-        </TabControl>
-  </Grid>
+      <TabItem Header="Add">
+        <views:AddView x:Name="AddViewControl" />
+      </TabItem>
+      <TabItem Header="Search">
+        <views:SearchView x:Name="SearchViewControl" />
+      </TabItem>
+    </TabControl>
+  </DockPanel>
 </Window>


### PR DESCRIPTION
## Summary
- introduce project creation request descriptors and view models to configure screening stages and data extraction templates
- add a dedicated project creation window with title/abstract and full text tabs plus a conditional data extraction panel
- register the new dialog, expose a Shell menu command to launch it, and cover the view model logic with unit tests

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: installed .NET 8.0 SDK cannot target net9.0 projects)*
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: installed .NET 8.0 SDK cannot target net9.0 projects)*

------
https://chatgpt.com/codex/tasks/task_e_68d90fe7d768832b94c4fbf86edfbbed