### PR TITLE
Add stage workspace preview window for project creation

### DIFF
--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -341,6 +341,9 @@ LM.App.Wpf.ViewModels.Review.ProjectEditorViewModel.LitSearchEntryId.get -> stri
 LM.App.Wpf.ViewModels.Review.ProjectEditorViewModel.LitSearchRunId.get -> string!
 LM.App.Wpf.ViewModels.Review.ProjectEditorViewModel.MoveStageDownCommand.get -> CommunityToolkit.Mvvm.Input.RelayCommand<LM.App.Wpf.ViewModels.Review.StageBlueprintViewModel!>!
 LM.App.Wpf.ViewModels.Review.ProjectEditorViewModel.MoveStageUpCommand.get -> CommunityToolkit.Mvvm.Input.RelayCommand<LM.App.Wpf.ViewModels.Review.StageBlueprintViewModel!>!
+LM.App.Wpf.ViewModels.Review.ProjectEditorViewModel.PreviewStageCommand.get -> CommunityToolkit.Mvvm.Input.RelayCommand<LM.App.Wpf.ViewModels.Review.StageBlueprintViewModel!>!
+LM.App.Wpf.ViewModels.Review.ProjectEditorViewModel.StagePreviewRequested.add -> void
+LM.App.Wpf.ViewModels.Review.ProjectEditorViewModel.StagePreviewRequested.remove -> void
 LM.App.Wpf.ViewModels.Review.ProjectEditorViewModel.ProjectName.get -> string!
 LM.App.Wpf.ViewModels.Review.ProjectEditorViewModel.ProjectName.set -> void
 LM.App.Wpf.ViewModels.Review.ProjectEditorViewModel.RemoveStageCommand.get -> CommunityToolkit.Mvvm.Input.RelayCommand<LM.App.Wpf.ViewModels.Review.StageBlueprintViewModel!>!
@@ -374,6 +377,9 @@ LM.App.Wpf.ViewModels.Review.StageDisplayOptionViewModel.Label.get -> string!
 LM.App.Wpf.ViewModels.Review.StageDisplayOptionViewModel.Description.get -> string!
 LM.App.Wpf.ViewModels.Review.StageDisplayOptionViewModel.IsSelected.get -> bool
 LM.App.Wpf.ViewModels.Review.StageDisplayOptionViewModel.IsSelected.set -> void
+LM.App.Wpf.ViewModels.Review.StagePreviewRequestedEventArgs
+LM.App.Wpf.ViewModels.Review.StagePreviewRequestedEventArgs.StagePreviewRequestedEventArgs(LM.App.Wpf.ViewModels.Review.StageBlueprintViewModel! stage) -> void
+LM.App.Wpf.ViewModels.Review.StagePreviewRequestedEventArgs.Stage.get -> LM.App.Wpf.ViewModels.Review.StageBlueprintViewModel!
 LM.App.Wpf.ViewModels.Review.StageBlueprintViewModel.StageBlueprintViewModel(LM.App.Wpf.Services.Review.Design.StageBlueprint! blueprint) -> void
 LM.App.Wpf.ViewModels.Review.StageBlueprintViewModel.EscalateOnDisagreement.get -> bool
 LM.App.Wpf.ViewModels.Review.StageBlueprintViewModel.EscalateOnDisagreement.set -> void

--- a/src/LM.App.Wpf/ViewModels/Review/ProjectEditorViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Review/ProjectEditorViewModel.cs
@@ -36,6 +36,8 @@ public sealed class ProjectEditorViewModel : DialogViewModelBase
     private bool _isBusy;
     private Func<CancellationToken, Task<ProjectBlueprint?>>? _runReloadHandler;
 
+    public event EventHandler<StagePreviewRequestedEventArgs>? StagePreviewRequested;
+
     public ProjectEditorViewModel()
     {
         _stages = new ObservableCollection<StageBlueprintViewModel>();
@@ -63,6 +65,7 @@ public sealed class ProjectEditorViewModel : DialogViewModelBase
         RemoveStageCommand = new RelayCommand<StageBlueprintViewModel>(RemoveStage, CanModifyStage);
         MoveStageUpCommand = new RelayCommand<StageBlueprintViewModel>(MoveStageUp, CanMoveStageUp);
         MoveStageDownCommand = new RelayCommand<StageBlueprintViewModel>(MoveStageDown, CanMoveStageDown);
+        PreviewStageCommand = new RelayCommand<StageBlueprintViewModel>(PreviewStage, CanPreviewStage);
         NextCommand = new RelayCommand(MoveNext, CanMoveNext);
         BackCommand = new RelayCommand(MoveBack, CanMoveBack);
         SaveCommand = new RelayCommand(Save, CanSave);
@@ -227,6 +230,8 @@ public sealed class ProjectEditorViewModel : DialogViewModelBase
 
     public RelayCommand<StageBlueprintViewModel> MoveStageDownCommand { get; }
 
+    public RelayCommand<StageBlueprintViewModel> PreviewStageCommand { get; }
+
     public RelayCommand NextCommand { get; }
 
     public RelayCommand BackCommand { get; }
@@ -285,6 +290,21 @@ public sealed class ProjectEditorViewModel : DialogViewModelBase
 
         var index = _stages.IndexOf(stage!);
         return index >= 0 && index < _stages.Count - 1;
+    }
+
+    private bool CanPreviewStage(StageBlueprintViewModel? stage)
+    {
+        return stage is not null;
+    }
+
+    private void PreviewStage(StageBlueprintViewModel? stage)
+    {
+        if (stage is null)
+        {
+            return;
+        }
+
+        StagePreviewRequested?.Invoke(this, new StagePreviewRequestedEventArgs(stage));
     }
 
     private void AddStage()

--- a/src/LM.App.Wpf/ViewModels/Review/StagePreviewRequestedEventArgs.cs
+++ b/src/LM.App.Wpf/ViewModels/Review/StagePreviewRequestedEventArgs.cs
@@ -1,0 +1,15 @@
+#nullable enable
+using System;
+
+namespace LM.App.Wpf.ViewModels.Review;
+
+public sealed class StagePreviewRequestedEventArgs : EventArgs
+{
+    public StagePreviewRequestedEventArgs(StageBlueprintViewModel stage)
+    {
+        ArgumentNullException.ThrowIfNull(stage);
+        Stage = stage;
+    }
+
+    public StageBlueprintViewModel Stage { get; }
+}

--- a/src/LM.App.Wpf/ViewModels/Review/StageWorkspacePreviewViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Review/StageWorkspacePreviewViewModel.cs
@@ -1,0 +1,261 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using LM.Review.Core.Models;
+
+namespace LM.App.Wpf.ViewModels.Review;
+
+internal sealed class StageWorkspacePreviewViewModel : ObservableObject, IDisposable
+{
+    private readonly StageBlueprintViewModel _stage;
+    private readonly List<StageDisplayOptionViewModel> _trackedOptions = new();
+    private bool _hasBibliographySummary;
+    private bool _hasInclusionChecklist;
+    private bool _hasFullTextViewer;
+    private bool _hasDecisionPanel;
+    private bool _hasDataExtractionWorkspace;
+    private bool _hasNotesPane;
+    private System.Windows.GridLength _leftColumnWidth = new(3, System.Windows.GridUnitType.Star);
+    private System.Windows.GridLength _decisionColumnWidth = new(2, System.Windows.GridUnitType.Star);
+    private System.Windows.GridLength _extractionColumnWidth = new(0);
+
+    private static readonly IReadOnlyList<string> InclusionChecklistItems = new[]
+    {
+        "Population aligns with scope",
+        "Intervention matches criteria",
+        "Comparator is relevant",
+        "Outcomes address key measures",
+        "Study design fits protocol"
+    };
+
+    private static readonly IReadOnlyList<string> ExtractionFieldCaptions = new[]
+    {
+        "Population details",
+        "Intervention notes",
+        "Comparator summary",
+        "Primary outcomes",
+        "Key quotes & annotations"
+    };
+
+    public StageWorkspacePreviewViewModel(StageBlueprintViewModel stage)
+    {
+        _stage = stage ?? throw new ArgumentNullException(nameof(stage));
+        _stage.PropertyChanged += OnStagePropertyChanged;
+
+        if (_stage.DisplayOptions is INotifyCollectionChanged collection)
+        {
+            collection.CollectionChanged += OnDisplayOptionsChanged;
+        }
+
+        TrackDisplayOptions();
+        RefreshDerivedState();
+    }
+
+    public string StageName => _stage.Name;
+
+    public ReviewStageType StageType => _stage.StageType;
+
+    public bool IsTitleScreening => StageType == ReviewStageType.TitleScreening;
+
+    public bool IsFullTextReview => StageType == ReviewStageType.FullTextReview;
+
+    public bool IsDataExtractionStage => StageType == ReviewStageType.DataExtraction;
+
+    public bool HasBibliographySummary
+    {
+        get => _hasBibliographySummary;
+        private set => SetProperty(ref _hasBibliographySummary, value);
+    }
+
+    public bool HasInclusionChecklist
+    {
+        get => _hasInclusionChecklist;
+        private set => SetProperty(ref _hasInclusionChecklist, value);
+    }
+
+    public bool HasFullTextViewer
+    {
+        get => _hasFullTextViewer;
+        private set => SetProperty(ref _hasFullTextViewer, value);
+    }
+
+    public bool HasDecisionPanel
+    {
+        get => _hasDecisionPanel;
+        private set => SetProperty(ref _hasDecisionPanel, value);
+    }
+
+    public bool HasDataExtractionWorkspace
+    {
+        get => _hasDataExtractionWorkspace;
+        private set => SetProperty(ref _hasDataExtractionWorkspace, value);
+    }
+
+    public bool HasNotesPane
+    {
+        get => _hasNotesPane;
+        private set => SetProperty(ref _hasNotesPane, value);
+    }
+
+    public bool HasLeftPane => HasBibliographySummary || HasFullTextViewer;
+
+    public bool HasDecisionPane => HasDecisionPanel || HasInclusionChecklist || HasNotesPane;
+
+    public bool HasExtractionPane => HasDataExtractionWorkspace;
+
+    public System.Windows.GridLength LeftColumnWidth
+    {
+        get => _leftColumnWidth;
+        private set => SetProperty(ref _leftColumnWidth, value);
+    }
+
+    public System.Windows.GridLength DecisionColumnWidth
+    {
+        get => _decisionColumnWidth;
+        private set => SetProperty(ref _decisionColumnWidth, value);
+    }
+
+    public System.Windows.GridLength ExtractionColumnWidth
+    {
+        get => _extractionColumnWidth;
+        private set => SetProperty(ref _extractionColumnWidth, value);
+    }
+
+    public IReadOnlyList<string> InclusionChecklist => InclusionChecklistItems;
+
+    public IReadOnlyList<string> ExtractionFields => ExtractionFieldCaptions;
+
+    public string StageSubtitle => StageType switch
+    {
+        ReviewStageType.TitleScreening => "Quickly triage titles and abstracts with structured context.",
+        ReviewStageType.FullTextReview => "Assess full manuscripts while keeping inclusion decisions in view.",
+        ReviewStageType.DataExtraction => "Capture structured evidence from previously included studies.",
+        _ => "Configure reviewer workspace panels for this stage."
+    };
+
+    public string PrimaryDecisionLabel => StageType switch
+    {
+        ReviewStageType.TitleScreening => "Include (meets PICO(S))",
+        ReviewStageType.FullTextReview => "Include full text",
+        ReviewStageType.DataExtraction => "Ready for extraction",
+        _ => "Include"
+    };
+
+    public string SecondaryDecisionLabel => StageType switch
+    {
+        ReviewStageType.TitleScreening => "Exclude (out of scope)",
+        ReviewStageType.FullTextReview => "Exclude (insufficient detail)",
+        ReviewStageType.DataExtraction => "Flag for follow-up",
+        _ => "Exclude"
+    };
+
+    public string DecisionHint => StageType switch
+    {
+        ReviewStageType.TitleScreening => "Use shortcuts: ← to exclude, → to include.",
+        ReviewStageType.FullTextReview => "Track rationale for exclusion to feed PRISMA diagrams.",
+        ReviewStageType.DataExtraction => "Capture consensus, then hand off to QA reviewers.",
+        _ => "Capture reviewer choices and rationale."
+    };
+
+    private void OnStagePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(StageBlueprintViewModel.StageType))
+        {
+            OnPropertyChanged(nameof(StageType));
+            OnPropertyChanged(nameof(IsTitleScreening));
+            OnPropertyChanged(nameof(IsFullTextReview));
+            OnPropertyChanged(nameof(IsDataExtractionStage));
+            RefreshDerivedState();
+        }
+        else if (e.PropertyName is nameof(StageBlueprintViewModel.Name))
+        {
+            OnPropertyChanged(nameof(StageName));
+        }
+    }
+
+    private void OnDisplayOptionsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        TrackDisplayOptions();
+        RefreshDerivedState();
+    }
+
+    private void OnOptionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(StageDisplayOptionViewModel.IsSelected))
+        {
+            RefreshDerivedState();
+        }
+    }
+
+    private void TrackDisplayOptions()
+    {
+        foreach (var option in _trackedOptions)
+        {
+            option.PropertyChanged -= OnOptionPropertyChanged;
+        }
+
+        _trackedOptions.Clear();
+
+        foreach (var option in _stage.DisplayOptions)
+        {
+            option.PropertyChanged += OnOptionPropertyChanged;
+            _trackedOptions.Add(option);
+        }
+    }
+
+    private void RefreshDerivedState()
+    {
+        HasBibliographySummary = IsAreaEnabled(StageContentArea.BibliographySummary);
+        HasInclusionChecklist = IsAreaEnabled(StageContentArea.InclusionExclusionChecklist);
+        HasFullTextViewer = IsAreaEnabled(StageContentArea.FullTextViewer);
+        HasDecisionPanel = IsAreaEnabled(StageContentArea.ReviewerDecisionPanel);
+        HasDataExtractionWorkspace = IsAreaEnabled(StageContentArea.DataExtractionWorkspace);
+        HasNotesPane = IsAreaEnabled(StageContentArea.NotesPane);
+
+        LeftColumnWidth = HasLeftPane
+            ? new System.Windows.GridLength(3, System.Windows.GridUnitType.Star)
+            : new System.Windows.GridLength(0);
+
+        DecisionColumnWidth = HasDecisionPane
+            ? new System.Windows.GridLength(2, System.Windows.GridUnitType.Star)
+            : new System.Windows.GridLength(0);
+
+        ExtractionColumnWidth = HasExtractionPane
+            ? new System.Windows.GridLength(2, System.Windows.GridUnitType.Star)
+            : new System.Windows.GridLength(0);
+
+        OnPropertyChanged(nameof(HasLeftPane));
+        OnPropertyChanged(nameof(HasDecisionPane));
+        OnPropertyChanged(nameof(HasExtractionPane));
+        OnPropertyChanged(nameof(StageSubtitle));
+        OnPropertyChanged(nameof(PrimaryDecisionLabel));
+        OnPropertyChanged(nameof(SecondaryDecisionLabel));
+        OnPropertyChanged(nameof(DecisionHint));
+    }
+
+    private bool IsAreaEnabled(StageContentArea area)
+    {
+        return _stage.DisplayOptions.Any(option => option.Area == area && option.IsSelected);
+    }
+
+    public void Dispose()
+    {
+        _stage.PropertyChanged -= OnStagePropertyChanged;
+
+        if (_stage.DisplayOptions is INotifyCollectionChanged collection)
+        {
+            collection.CollectionChanged -= OnDisplayOptionsChanged;
+        }
+
+        foreach (var option in _trackedOptions)
+        {
+            option.PropertyChanged -= OnOptionPropertyChanged;
+        }
+
+        _trackedOptions.Clear();
+    }
+}

--- a/src/LM.App.Wpf/Views/Review/ProjectEditorWindow.xaml
+++ b/src/LM.App.Wpf/Views/Review/ProjectEditorWindow.xaml
@@ -253,6 +253,26 @@
                             </DataTemplate>
                           </ItemsControl.ItemTemplate>
                         </ItemsControl>
+
+                        <Border Background="#F3F4F6"
+                              CornerRadius="8"
+                              Padding="16"
+                              Margin="0,20,0,0">
+                          <StackPanel>
+                            <TextBlock Text="Workspace preview"
+                                     FontWeight="SemiBold"
+                                     Margin="0,0,0,4" />
+                            <TextBlock Text="Open a stage-specific layout mockup to fine-tune reviewer tooling."
+                                     Foreground="#4B5563"
+                                     TextWrapping="Wrap"
+                                     Margin="0,0,0,12" />
+                            <Button Content="Preview workspace"
+                                  Padding="16,6"
+                                  HorizontalAlignment="Left"
+                                  Command="{Binding DataContext.PreviewStageCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                  CommandParameter="{Binding}" />
+                          </StackPanel>
+                        </Border>
                       </StackPanel>
                     </StackPanel>
                   </Border>

--- a/src/LM.App.Wpf/Views/Review/ProjectEditorWindow.xaml.cs
+++ b/src/LM.App.Wpf/Views/Review/ProjectEditorWindow.xaml.cs
@@ -18,6 +18,7 @@ public partial class ProjectEditorWindow : System.Windows.Window
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         DataContext = _viewModel;
         _viewModel.CloseRequested += OnCloseRequested;
+        _viewModel.StagePreviewRequested += OnStagePreviewRequested;
     }
 
     protected override void OnClosed(EventArgs e)
@@ -25,6 +26,7 @@ public partial class ProjectEditorWindow : System.Windows.Window
         if (_viewModel is not null)
         {
             _viewModel.CloseRequested -= OnCloseRequested;
+            _viewModel.StagePreviewRequested -= OnStagePreviewRequested;
         }
 
         base.OnClosed(e);
@@ -33,5 +35,16 @@ public partial class ProjectEditorWindow : System.Windows.Window
     private void OnCloseRequested(object? sender, LM.App.Wpf.Common.Dialogs.DialogCloseRequestedEventArgs e)
     {
         DialogResult = e.DialogResult;
+    }
+
+    private void OnStagePreviewRequested(object? sender, StagePreviewRequestedEventArgs e)
+    {
+        var previewWindow = new StageWorkspacePreviewWindow
+        {
+            Owner = this
+        };
+
+        previewWindow.Attach(e.Stage);
+        previewWindow.Show();
     }
 }

--- a/src/LM.App.Wpf/Views/Review/StageWorkspacePreviewWindow.xaml
+++ b/src/LM.App.Wpf/Views/Review/StageWorkspacePreviewWindow.xaml
@@ -1,0 +1,243 @@
+<Window x:Class="LM.App.Wpf.Views.Review.StageWorkspacePreviewWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:LM.App.Wpf.ViewModels.Review"
+        mc:Ignorable="d"
+        Title="Workspace preview"
+        Height="720"
+        Width="1200"
+        ResizeMode="CanResize"
+        WindowStartupLocation="CenterOwner"
+        Background="#F9FAFB"
+        d:DataContext="{d:DesignInstance Type=vm:StageWorkspacePreviewViewModel}">
+  <Window.Resources>
+    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+  </Window.Resources>
+
+  <Grid Margin="24">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+
+    <StackPanel Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Center">
+      <TextBlock Text="{Binding StageName}"
+                 FontSize="26"
+                 FontWeight="Bold" />
+      <Border Background="#EEF2FF"
+              BorderBrush="#C7D2FE"
+              BorderThickness="1"
+              CornerRadius="16"
+              Padding="12,4"
+              Margin="16,0,0,0">
+        <TextBlock Text="{Binding StageType}" Foreground="#1D4ED8" FontWeight="SemiBold" />
+      </Border>
+    </StackPanel>
+
+    <TextBlock Grid.Row="1"
+               Text="{Binding StageSubtitle}"
+               Foreground="#4B5563"
+               FontSize="16"
+               Margin="0,6,0,0" />
+
+    <Grid Grid.Row="2" Margin="0,24,0,0">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="{Binding LeftColumnWidth}" />
+        <ColumnDefinition Width="20" />
+        <ColumnDefinition Width="{Binding DecisionColumnWidth}" />
+        <ColumnDefinition Width="20" />
+        <ColumnDefinition Width="{Binding ExtractionColumnWidth}" />
+      </Grid.ColumnDefinitions>
+
+      <Border Grid.Column="0"
+              Background="#FFFFFFFF"
+              BorderBrush="#E5E7EB"
+              BorderThickness="1"
+              CornerRadius="12"
+              Padding="20"
+              Visibility="{Binding HasLeftPane, Converter={StaticResource BooleanToVisibilityConverter}}">
+        <StackPanel>
+          <Border Background="#F9FAFB"
+                  BorderBrush="#E5E7EB"
+                  BorderThickness="1"
+                  CornerRadius="10"
+                  Padding="16"
+                  Margin="0,0,0,16"
+                  Visibility="{Binding HasBibliographySummary, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <StackPanel>
+              <TextBlock Text="Bibliography summary" FontWeight="SemiBold" />
+              <TextBlock Text="Understanding telehealth adoption for chronic care"
+                         FontSize="18"
+                         FontWeight="SemiBold"
+                         Margin="0,8,0,0" />
+              <TextBlock Text="H. Miller • K. Singh • A. Roberts"
+                         Foreground="#6B7280"
+                         Margin="0,4,0,0" />
+              <Border Background="#EEF2FF"
+                      CornerRadius="6"
+                      Padding="10"
+                      Margin="0,12,0,12">
+                <TextBlock Text="Hospitals implementing remote monitoring programmes observed improved adherence across adult populations. This abstract summarises study design, timeframe, and outcome measures so reviewers can make confident inclusion decisions." 
+                           TextWrapping="Wrap"
+                           Foreground="#111827" />
+              </Border>
+              <UniformGrid Columns="3" Margin="0,0,0,4">
+                <Border Background="#DBEAFE" CornerRadius="8" Padding="6,3" Margin="0,0,8,8">
+                  <TextBlock Text="Randomised" FontWeight="SemiBold" Foreground="#1D4ED8" />
+                </Border>
+                <Border Background="#DCFCE7" CornerRadius="8" Padding="6,3" Margin="0,0,8,8">
+                  <TextBlock Text="Adults" FontWeight="SemiBold" Foreground="#047857" />
+                </Border>
+                <Border Background="#FCE7F3" CornerRadius="8" Padding="6,3" Margin="0,0,8,8">
+                  <TextBlock Text="US" FontWeight="SemiBold" Foreground="#BE185D" />
+                </Border>
+              </UniformGrid>
+            </StackPanel>
+          </Border>
+
+          <Border Background="#111827"
+                  CornerRadius="12"
+                  Padding="12"
+                  Height="280"
+                  Visibility="{Binding HasFullTextViewer, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid>
+              <Border Background="#1F2937" CornerRadius="8" Opacity="0.65" />
+              <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="PDF manuscript preview"
+                           Foreground="#E5E7EB"
+                           FontSize="18"
+                           FontWeight="SemiBold"
+                           HorizontalAlignment="Center" />
+                <TextBlock Text="Scroll to review highlights and annotations."
+                           Foreground="#9CA3AF"
+                           Margin="0,6,0,0"
+                           HorizontalAlignment="Center" />
+                <Button Content="Open source PDF"
+                        Padding="18,8"
+                        Margin="0,16,0,0"
+                        HorizontalAlignment="Center" />
+              </StackPanel>
+            </Grid>
+          </Border>
+        </StackPanel>
+      </Border>
+
+      <Border Grid.Column="2"
+              Background="#FFFFFFFF"
+              BorderBrush="#E5E7EB"
+              BorderThickness="1"
+              CornerRadius="12"
+              Padding="20"
+              Visibility="{Binding HasDecisionPane, Converter={StaticResource BooleanToVisibilityConverter}}">
+        <StackPanel>
+          <TextBlock Text="Reviewer decision"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <StackPanel Orientation="Horizontal" Margin="0,16,0,0">
+            <Button Content="{Binding PrimaryDecisionLabel}"
+                    Padding="18,8"
+                    Background="#2563EB"
+                    Foreground="White"
+                    FontWeight="SemiBold" />
+            <Button Content="{Binding SecondaryDecisionLabel}"
+                    Padding="18,8"
+                    Margin="12,0,0,0"
+                    Background="#F9FAFB"
+                    BorderBrush="#D1D5DB"
+                    FontWeight="SemiBold" />
+          </StackPanel>
+          <TextBlock Text="{Binding DecisionHint}"
+                     Foreground="#4B5563"
+                     Margin="0,12,0,0" />
+
+          <Border Background="#F3F4F6"
+                  CornerRadius="10"
+                  Padding="14"
+                  Margin="0,16,0,0"
+                  Visibility="{Binding HasInclusionChecklist, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <StackPanel>
+              <TextBlock Text="PICO(S) inclusion checklist"
+                         FontWeight="SemiBold" />
+              <ItemsControl ItemsSource="{Binding InclusionChecklist}" Margin="0,10,0,0">
+                <ItemsControl.ItemTemplate>
+                  <DataTemplate>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                      <CheckBox IsChecked="True" Margin="0,0,8,0" />
+                      <TextBlock Text="{Binding}" />
+                    </StackPanel>
+                  </DataTemplate>
+                </ItemsControl.ItemTemplate>
+              </ItemsControl>
+            </StackPanel>
+          </Border>
+
+          <Border Background="#F9FAFB"
+                  CornerRadius="10"
+                  Padding="14"
+                  Margin="0,16,0,0"
+                  Visibility="{Binding HasNotesPane, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <StackPanel>
+              <TextBlock Text="Reviewer notes"
+                         FontWeight="SemiBold" />
+              <Border BorderBrush="#D1D5DB"
+                      BorderThickness="1"
+                      CornerRadius="6"
+                      Margin="0,8,0,0"
+                      Background="White"
+                      Padding="12">
+                <TextBlock Text="Summarise rationale or highlight follow-up questions. Notes sync across reviewers for consensus rounds."
+                           TextWrapping="Wrap"
+                           Foreground="#4B5563" />
+              </Border>
+            </StackPanel>
+          </Border>
+        </StackPanel>
+      </Border>
+
+      <Border Grid.Column="4"
+              Background="#FFFFFFFF"
+              BorderBrush="#E5E7EB"
+              BorderThickness="1"
+              CornerRadius="12"
+              Padding="20"
+              Visibility="{Binding HasExtractionPane, Converter={StaticResource BooleanToVisibilityConverter}}">
+        <StackPanel>
+          <TextBlock Text="Data extraction workspace"
+                     FontSize="18"
+                     FontWeight="SemiBold" />
+          <TextBlock Text="Fields configured during project setup appear here once a record is included in both screening steps."
+                     TextWrapping="Wrap"
+                     Foreground="#4B5563"
+                     Margin="0,6,0,16" />
+          <ItemsControl ItemsSource="{Binding ExtractionFields}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <Border BorderBrush="#D1D5DB"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="10"
+                        Margin="0,0,0,10">
+                  <StackPanel>
+                    <TextBlock Text="{Binding}" FontWeight="SemiBold" />
+                    <TextBlock Text="Add structured data points, quotes, or metrics captured during review."
+                               Foreground="#6B7280"
+                               Margin="0,4,0,0" />
+                  </StackPanel>
+                </Border>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+          <Button Content="Design extraction schema"
+                  Padding="18,8"
+                  Margin="0,12,0,0"
+                  Background="#10B981"
+                  Foreground="White"
+                  FontWeight="SemiBold" />
+        </StackPanel>
+      </Border>
+    </Grid>
+  </Grid>
+</Window>

--- a/src/LM.App.Wpf/Views/Review/StageWorkspacePreviewWindow.xaml.cs
+++ b/src/LM.App.Wpf/Views/Review/StageWorkspacePreviewWindow.xaml.cs
@@ -1,0 +1,30 @@
+#nullable enable
+using System;
+using LM.App.Wpf.ViewModels.Review;
+
+namespace LM.App.Wpf.Views.Review;
+
+internal partial class StageWorkspacePreviewWindow : System.Windows.Window
+{
+    private StageWorkspacePreviewViewModel? _previewViewModel;
+
+    public StageWorkspacePreviewWindow()
+    {
+        InitializeComponent();
+    }
+
+    public void Attach(StageBlueprintViewModel stage)
+    {
+        ArgumentNullException.ThrowIfNull(stage);
+        _previewViewModel?.Dispose();
+        _previewViewModel = new StageWorkspacePreviewViewModel(stage);
+        DataContext = _previewViewModel;
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _previewViewModel?.Dispose();
+        _previewViewModel = null;
+        base.OnClosed(e);
+    }
+}


### PR DESCRIPTION
## Summary
- raise a stage preview event and command from the project editor so reviewers can open a workspace mockup while configuring stages
- add a dedicated workspace preview window with layout-aware view model and XAML that showcases title/abstract, full-text, decision, and extraction panels
- surface the preview entry point in the stage editor panel and wire the window lifecycle to the project editor

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: installed SDK only supports up to .NET 8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d9176c25bc832baf8b8cf5383f8fb1