### PR TITLE
Add TabulaSharp data extraction playground

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
     <PackageVersion Include="UglyToad.PdfPig.Core" Version="1.7.0" />
     <PackageVersion Include="UglyToad.PdfPig.Fonts" Version="1.7.0" />
+    <PackageVersion Include="Tabula" Version="0.1.5" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="2.20.0" />
 
     <!-- === Microsoft.Extensions family (pin if used anywhere) === -->

--- a/src/LM.App.Wpf.Tests/LibraryViewModelFullTextTests.cs
+++ b/src/LM.App.Wpf.Tests/LibraryViewModelFullTextTests.cs
@@ -494,7 +494,8 @@ namespace LM.App.Wpf.Tests
                                                        ILibraryDocumentService? documentService = null,
                                                        IClipboardService? clipboard = null,
                                                        IFileExplorerService? fileExplorer = null,
-                                                       IUserPreferencesStore? preferencesStore = null)
+                                                       IUserPreferencesStore? preferencesStore = null,
+                                                       Func<Entry, CancellationToken, Task<bool>>? dataExtractionLauncher = null)
         {
             var ws = new TestWorkspaceService(workspace.RootPath);
             var presetStore = new LibraryFilterPresetStore(ws);
@@ -509,7 +510,8 @@ namespace LM.App.Wpf.Tests
             clipboard ??= new RecordingClipboardService();
             fileExplorer ??= new RecordingFileExplorerService();
             preferencesStore ??= new InMemoryPreferencesStore();
-            return new LibraryViewModel(store, search, filters, results, ws, preferencesStore, clipboard, fileExplorer, documentService);
+            dataExtractionLauncher ??= (_, _) => Task.FromResult(true);
+            return new LibraryViewModel(store, search, filters, results, ws, preferencesStore, clipboard, fileExplorer, documentService, dataExtractionLauncher);
         }
 
         private sealed class NoopEntryEditor : ILibraryEntryEditor

--- a/src/LM.App.Wpf/LM.App.Wpf.csproj
+++ b/src/LM.App.Wpf/LM.App.Wpf.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" />
+    <PackageReference Include="Tabula" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LM.App.Wpf/Library/LibraryDataExtractionLauncher.cs
+++ b/src/LM.App.Wpf/Library/LibraryDataExtractionLauncher.cs
@@ -1,0 +1,59 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using LM.App.Wpf.ViewModels.Library;
+using LM.App.Wpf.Views.Library;
+using LM.Core.Models;
+
+namespace LM.App.Wpf.Library
+{
+    internal sealed class LibraryDataExtractionLauncher
+    {
+        private readonly IServiceProvider _services;
+
+        public LibraryDataExtractionLauncher(IServiceProvider services)
+        {
+            _services = services ?? throw new ArgumentNullException(nameof(services));
+        }
+
+        public Task<bool> LaunchAsync(Entry entry, CancellationToken cancellationToken)
+        {
+            if (entry is null)
+                throw new ArgumentNullException(nameof(entry));
+
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher is null)
+                throw new InvalidOperationException("Application dispatcher is not available.");
+
+            if (!dispatcher.CheckAccess())
+            {
+                var operation = dispatcher.InvokeAsync(() => LaunchInternalAsync(entry, cancellationToken));
+                return operation.Task.Unwrap();
+            }
+
+            return LaunchInternalAsync(entry, cancellationToken);
+        }
+
+        private async Task<bool> LaunchInternalAsync(Entry entry, CancellationToken cancellationToken)
+        {
+            using var scope = _services.CreateScope();
+            var viewModel = scope.ServiceProvider.GetRequiredService<DataExtractionPlaygroundViewModel>();
+
+            var initialized = await viewModel.InitializeAsync(entry, cancellationToken).ConfigureAwait(true);
+            if (!initialized)
+            {
+                return false;
+            }
+
+            var window = new DataExtractionPlaygroundWindow(viewModel)
+            {
+                Owner = System.Windows.Application.Current?.MainWindow
+            };
+
+            window.Show();
+            return true;
+        }
+    }
+}

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -584,7 +584,7 @@ LM.App.Wpf.Views.Library.Controls.LibrarySearchQueryBox.Text.get -> string!
 LM.App.Wpf.Views.Library.Controls.LibrarySearchQueryBox.Text.set -> void
 LM.App.Wpf.ViewModels.LibraryViewModel
 LM.App.Wpf.ViewModels.LibraryViewModel.Filters.get -> LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel!
-LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel! filters, LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel! results, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.Configuration.IUserPreferencesStore! preferencesStore, LM.App.Wpf.Common.IClipboardService! clipboard, LM.App.Wpf.Common.IFileExplorerService! fileExplorer, LM.App.Wpf.Library.ILibraryDocumentService! documentService) -> void
+LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel! filters, LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel! results, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.Configuration.IUserPreferencesStore! preferencesStore, LM.App.Wpf.Common.IClipboardService! clipboard, LM.App.Wpf.Common.IFileExplorerService! fileExplorer, LM.App.Wpf.Library.ILibraryDocumentService! documentService, System.Func<LM.Core.Models.Entry!, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.Boolean>!>! dataExtractionLauncher) -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.Results.get -> LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel!
 LM.App.Wpf.ViewModels.LibraryViewModel.ColumnOptions.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.Library.LibraryColumnOption!>!
 LM.App.Wpf.ViewModels.LibraryViewModel.ColumnVisibility.get -> LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility!
@@ -593,6 +593,7 @@ LM.App.Wpf.ViewModels.LibraryViewModel.CopyWorkspacePathCommand.get -> System.Wi
 LM.App.Wpf.ViewModels.LibraryViewModel.EditEntryCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.LibraryViewModel.OpenContainingFolderCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.LibraryViewModel.OpenEntryCommand.get -> System.Windows.Input.ICommand!
+LM.App.Wpf.ViewModels.LibraryViewModel.OpenDataExtractionCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.ViewModels.SearchItemViewModel
 LM.App.Wpf.ViewModels.SearchItemViewModel.Header.get -> string!
 LM.App.Wpf.ViewModels.SearchItemViewModel.SearchItemViewModel(string! header, LM.App.Wpf.ViewModels.LibraryViewModel! vm) -> void

--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.cs
@@ -1,0 +1,568 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LM.App.Wpf.Common;
+using LM.Core.Abstractions;
+using LM.Core.Models;
+using LM.Infrastructure.Hooks;
+using HookM = LM.HubSpoke.Models;
+using Tabula;
+using Tabula.Detectors;
+using Tabula.Extractors;
+using UglyToad.PdfPig;
+
+namespace LM.App.Wpf.ViewModels.Library;
+
+internal sealed partial class DataExtractionPlaygroundViewModel : ViewModelBase
+{
+    private readonly HookOrchestrator _hookOrchestrator;
+    private readonly IWorkSpaceService _workspace;
+    private readonly IClipboardService _clipboard;
+
+    private string? _entryId;
+    private string? _pdfPath;
+    private string? _pdfRelativePath;
+    private string? _pdfAttachmentId;
+
+    public DataExtractionPlaygroundViewModel(HookOrchestrator hookOrchestrator,
+                                             IWorkSpaceService workspace,
+                                             IClipboardService clipboard)
+    {
+        _hookOrchestrator = hookOrchestrator ?? throw new ArgumentNullException(nameof(hookOrchestrator));
+        _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+        _clipboard = clipboard ?? throw new ArgumentNullException(nameof(clipboard));
+
+        ModeOptions = new[]
+        {
+            new ExtractionModeOption(DataExtractionMode.Stream, "Stream (BasicExtractionAlgorithm)", "Optimised for tables without ruled lines."),
+            new ExtractionModeOption(DataExtractionMode.Lattice, "Lattice (SpreadsheetExtractionAlgorithm)", "Optimised for ruled tables with clear cell borders.")
+        };
+
+        DetectorOptions = new[]
+        {
+            new DetectorOption(TableDetectionStrategy.Auto, "Auto-detect per mode", "Use Nurminen or Spreadsheet detection depending on the extraction mode."),
+            new DetectorOption(TableDetectionStrategy.Nurminen, "Nurminen detector", "Use SimpleNurminenDetectionAlgorithm for table candidates."),
+            new DetectorOption(TableDetectionStrategy.Spreadsheet, "Spreadsheet detector", "Use SpreadsheetDetectionAlgorithm (line-based)."),
+            new DetectorOption(TableDetectionStrategy.None, "Full page", "Run extraction against the full page bounds.")
+        };
+
+        SelectedMode = ModeOptions[0];
+        SelectedDetector = DetectorOptions[0];
+        PageSelection = "1";
+
+        Tables = new ObservableCollection<DataExtractionTableViewModel>();
+    }
+
+    public IReadOnlyList<ExtractionModeOption> ModeOptions { get; }
+
+    public IReadOnlyList<DetectorOption> DetectorOptions { get; }
+
+    [ObservableProperty]
+    private ExtractionModeOption selectedMode;
+
+    [ObservableProperty]
+    private DetectorOption selectedDetector;
+
+    [ObservableProperty]
+    private string documentTitle = string.Empty;
+
+    [ObservableProperty]
+    private string pdfFileName = string.Empty;
+
+    [ObservableProperty]
+    private Uri? pdfSource;
+
+    [ObservableProperty]
+    private string pageSelection;
+
+    [ObservableProperty]
+    private bool isBusy;
+
+    [ObservableProperty]
+    private string statusMessage = string.Empty;
+
+    [ObservableProperty]
+    private DataExtractionTableViewModel? selectedTable;
+
+    public ObservableCollection<DataExtractionTableViewModel> Tables { get; }
+
+    public bool HasResults => Tables.Count > 0;
+
+    public bool HasPdf => PdfSource is not null;
+
+    public bool CanCopyTable => SelectedTable is not null;
+
+    public async Task<bool> InitializeAsync(Entry entry, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        ResetState();
+
+        if (string.IsNullOrWhiteSpace(entry.Id))
+        {
+            System.Windows.MessageBox.Show(
+                "Entry is missing an identifier.",
+                "Data extraction",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Warning);
+            return false;
+        }
+
+        var pdfSource = ResolvePdfSource(entry);
+        if (pdfSource is null)
+        {
+            System.Windows.MessageBox.Show(
+                "Data extraction playground is only available for entries with a PDF file.",
+                "Data extraction",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Information);
+            return false;
+        }
+
+        await Task.Yield();
+
+        _entryId = entry.Id;
+        _pdfPath = pdfSource.AbsolutePath;
+        _pdfRelativePath = pdfSource.RelativePath;
+        _pdfAttachmentId = pdfSource.AttachmentId;
+
+        DocumentTitle = ResolveEntryTitle(entry);
+        PdfFileName = pdfSource.DisplayName;
+        PdfSource = new Uri(pdfSource.AbsolutePath);
+
+        var pageIndexes = ReadPageIndexes(pdfSource.AbsolutePath);
+        if (pageIndexes.Count > 0)
+        {
+            PageSelection = pageIndexes[0].ToString();
+        }
+
+        StatusMessage = "Configure options and select Extract tables to begin.";
+        Tables.Clear();
+        SelectedTable = null;
+
+        OnPropertyChanged(nameof(HasResults));
+        OnPropertyChanged(nameof(HasPdf));
+        OnPropertyChanged(nameof(CanCopyTable));
+
+        ExtractTablesCommand.NotifyCanExecuteChanged();
+        CopyTableCommand.NotifyCanExecuteChanged();
+
+        return true;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanExtractTables))]
+    private async Task ExtractTablesAsync()
+    {
+        if (_pdfPath is null)
+            return;
+
+        IsBusy = true;
+        StatusMessage = "Extracting tables...";
+        Tables.Clear();
+        SelectedTable = null;
+        OnPropertyChanged(nameof(HasResults));
+        OnPropertyChanged(nameof(CanCopyTable));
+
+        try
+        {
+            using var document = PdfDocument.Open(_pdfPath, new ParsingOptions { ClipPaths = true });
+            var pageNumbers = ParsePages(PageSelection, document.NumberOfPages);
+            if (pageNumbers.Count == 0)
+            {
+                StatusMessage = "No valid pages were selected.";
+                return;
+            }
+
+            var mode = SelectedMode.Mode;
+            var detector = SelectedDetector.Strategy;
+            var totalTables = 0;
+
+            foreach (var pageNumber in pageNumbers)
+            {
+                var page = ObjectExtractor.Extract(document, pageNumber);
+                var tables = ExtractFromPage(page, mode, detector);
+                foreach (var table in tables)
+                {
+                    Tables.Add(table);
+                    totalTables++;
+                }
+            }
+
+            if (Tables.Count == 0)
+            {
+                StatusMessage = "No tables were detected with the current settings.";
+            }
+            else
+            {
+                StatusMessage = $"Extracted {Tables.Count} tables.";
+                SelectedTable = Tables[0];
+                OnPropertyChanged(nameof(CanCopyTable));
+            }
+
+            await WriteChangeLogEventAsync(mode, detector, pageNumbers, totalTables).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            StatusMessage = "Extraction cancelled.";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = "Extraction failed.";
+            System.Windows.MessageBox.Show(
+                $"Failed to extract tables:\n{ex.Message}",
+                "Data extraction",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+        finally
+        {
+            IsBusy = false;
+            ExtractTablesCommand.NotifyCanExecuteChanged();
+            CopyTableCommand.NotifyCanExecuteChanged();
+            OnPropertyChanged(nameof(HasResults));
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCopyTable))]
+    private void CopyTable()
+    {
+        var table = SelectedTable;
+        if (table is null)
+            return;
+
+        try
+        {
+            _clipboard.SetText(table.ToTsv());
+            StatusMessage = $"Copied table from page {table.PageNumber} to the clipboard.";
+        }
+        catch (Exception ex)
+        {
+            System.Windows.MessageBox.Show(
+                $"Failed to copy table:\n{ex.Message}",
+                "Copy table",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+    }
+
+    partial void OnSelectedTableChanged(DataExtractionTableViewModel? value)
+    {
+        CopyTableCommand.NotifyCanExecuteChanged();
+        OnPropertyChanged(nameof(CanCopyTable));
+    }
+
+    private bool CanExtractTables()
+    {
+        return !IsBusy && _pdfPath is not null;
+    }
+
+    private static string ResolveEntryTitle(Entry entry)
+    {
+        if (!string.IsNullOrWhiteSpace(entry.DisplayName))
+            return entry.DisplayName!.Trim();
+        if (!string.IsNullOrWhiteSpace(entry.Title))
+            return entry.Title!.Trim();
+        return entry.Id ?? "Entry";
+    }
+
+    private static IReadOnlyList<int> ReadPageIndexes(string pdfPath)
+    {
+        try
+        {
+            using var document = PdfDocument.Open(pdfPath);
+            return Enumerable.Range(1, document.NumberOfPages).ToArray();
+        }
+        catch
+        {
+            return Array.Empty<int>();
+        }
+    }
+
+    private IReadOnlyList<int> ParsePages(string? input, int totalPages)
+    {
+        var pages = new SortedSet<int>();
+        var maxPage = Math.Max(totalPages, 1);
+
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            pages.Add(1);
+            return pages.ToList();
+        }
+
+        var segments = input.Split(',', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var segment in segments)
+        {
+            var trimmed = segment.Trim();
+            if (trimmed.Equals("all", StringComparison.OrdinalIgnoreCase))
+            {
+                for (var i = 1; i <= maxPage; i++)
+                    pages.Add(i);
+                continue;
+            }
+
+            var dashIndex = trimmed.IndexOf('-');
+            if (dashIndex > 0)
+            {
+                if (int.TryParse(trimmed[..dashIndex], out var start) &&
+                    int.TryParse(trimmed[(dashIndex + 1)..], out var end))
+                {
+                    if (start > end)
+                        (start, end) = (end, start);
+
+                    start = Math.Max(1, Math.Min(maxPage, start));
+                    end = Math.Max(1, Math.Min(maxPage, end));
+
+                    for (var i = start; i <= end; i++)
+                        pages.Add(i);
+                }
+                continue;
+            }
+
+            if (int.TryParse(trimmed, out var pageNumber))
+            {
+                pageNumber = Math.Max(1, Math.Min(maxPage, pageNumber));
+                pages.Add(pageNumber);
+            }
+        }
+
+        return pages.ToList();
+    }
+
+    private IReadOnlyList<DataExtractionTableViewModel> ExtractFromPage(PageArea page,
+                                                                        DataExtractionMode mode,
+                                                                        TableDetectionStrategy detector)
+    {
+        var extraction = CreateAlgorithm(mode);
+        var regions = DetectRegions(page, detector, mode);
+        var results = new List<DataExtractionTableViewModel>();
+        var index = 1;
+
+        if (regions.Count == 0)
+        {
+            var extracted = extraction.Extract(page);
+            foreach (var table in extracted)
+            {
+                results.Add(DataExtractionTableViewModel.FromTable(page.PageNumber, index++, mode, detector, table, null));
+            }
+
+            return results;
+        }
+
+        foreach (var region in regions)
+        {
+            var area = page.GetArea(region.BoundingBox);
+            var extracted = extraction.Extract(area);
+            foreach (var table in extracted)
+            {
+                results.Add(DataExtractionTableViewModel.FromTable(page.PageNumber, index++, mode, detector, table, region));
+            }
+        }
+
+        return results;
+    }
+
+    private static IExtractionAlgorithm CreateAlgorithm(DataExtractionMode mode)
+    {
+        return mode switch
+        {
+            DataExtractionMode.Lattice => new SpreadsheetExtractionAlgorithm(),
+            _ => new BasicExtractionAlgorithm()
+        };
+    }
+
+    private static IReadOnlyList<TableRectangle> DetectRegions(PageArea page,
+                                                               TableDetectionStrategy strategy,
+                                                               DataExtractionMode mode)
+    {
+        return strategy switch
+        {
+            TableDetectionStrategy.Nurminen => new SimpleNurminenDetectionAlgorithm().Detect(page),
+            TableDetectionStrategy.Spreadsheet => new SpreadsheetDetectionAlgorithm().Detect(page),
+            TableDetectionStrategy.Auto => mode == DataExtractionMode.Lattice
+                ? new SpreadsheetDetectionAlgorithm().Detect(page)
+                : new SimpleNurminenDetectionAlgorithm().Detect(page),
+            _ => Array.Empty<TableRectangle>()
+        };
+    }
+
+    private async Task WriteChangeLogEventAsync(DataExtractionMode mode,
+                                                TableDetectionStrategy detector,
+                                                IReadOnlyCollection<int> pages,
+                                                int tableCount)
+    {
+        if (_entryId is null)
+            return;
+
+        var tags = new List<string>
+        {
+            $"mode:{mode}",
+            $"detector:{detector}",
+            $"pages:{string.Join('-', CompressSequence(pages))}",
+            $"tables:{tableCount}"
+        };
+
+        var hook = new HookM.EntryChangeLogHook
+        {
+            Events = new List<HookM.EntryChangeLogEvent>
+            {
+                new()
+                {
+                    EventId = Guid.NewGuid().ToString("N"),
+                    TimestampUtc = DateTime.UtcNow,
+                    PerformedBy = GetCurrentUser(),
+                    Action = "DataExtractionRun",
+                    Details = new HookM.ChangeLogAttachmentDetails
+                    {
+                        Title = DocumentTitle,
+                        LibraryPath = NormalizeLibraryPath(_pdfRelativePath ?? _pdfPath),
+                        Purpose = AttachmentKind.Metadata,
+                        AttachmentId = _pdfAttachmentId ?? string.Empty,
+                        Tags = tags
+                    }
+                }
+            }
+        };
+
+        try
+        {
+            await _hookOrchestrator.ProcessAsync(
+                _entryId,
+                new HookContext { ChangeLog = hook },
+                CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Logging best-effort; ignore failures.
+        }
+    }
+
+    private static IEnumerable<string> CompressSequence(IReadOnlyCollection<int> pages)
+    {
+        if (pages.Count == 0)
+            yield break;
+
+        var ordered = pages.OrderBy(p => p).ToArray();
+        var start = ordered[0];
+        var end = start;
+
+        for (var i = 1; i < ordered.Length; i++)
+        {
+            var current = ordered[i];
+            if (current == end + 1)
+            {
+                end = current;
+                continue;
+            }
+
+            yield return start == end ? start.ToString() : $"{start}-{end}";
+            start = end = current;
+        }
+
+        yield return start == end ? start.ToString() : $"{start}-{end}";
+    }
+
+    private static string GetCurrentUser()
+    {
+        var user = Environment.UserName;
+        return string.IsNullOrWhiteSpace(user) ? "unknown" : user.Trim();
+    }
+
+    private static string NormalizeLibraryPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+        return path.Replace("\\", "/");
+    }
+
+    private void ResetState()
+    {
+        Tables.Clear();
+        SelectedTable = null;
+        _entryId = null;
+        _pdfPath = null;
+        _pdfRelativePath = null;
+        _pdfAttachmentId = null;
+        PdfSource = null;
+        DocumentTitle = string.Empty;
+        PdfFileName = string.Empty;
+        PageSelection = string.Empty;
+        StatusMessage = string.Empty;
+
+        OnPropertyChanged(nameof(HasResults));
+        OnPropertyChanged(nameof(HasPdf));
+        OnPropertyChanged(nameof(CanCopyTable));
+
+        ExtractTablesCommand.NotifyCanExecuteChanged();
+        CopyTableCommand.NotifyCanExecuteChanged();
+    }
+
+    private PdfSourceInfo? ResolvePdfSource(Entry entry)
+    {
+        if (!string.IsNullOrWhiteSpace(entry.MainFilePath))
+        {
+            var mainAbsolute = _workspace.GetAbsolutePath(entry.MainFilePath);
+            if (!string.IsNullOrWhiteSpace(mainAbsolute) &&
+                File.Exists(mainAbsolute) &&
+                string.Equals(Path.GetExtension(mainAbsolute), ".pdf", StringComparison.OrdinalIgnoreCase))
+            {
+                var relativePath = entry.MainFilePath ?? string.Empty;
+                var displayName = Path.GetFileName(mainAbsolute) ?? relativePath;
+                return new PdfSourceInfo(mainAbsolute, relativePath, displayName, null);
+            }
+        }
+
+        if (entry.Attachments is not null)
+        {
+            foreach (var attachment in entry.Attachments)
+            {
+                if (attachment is null || string.IsNullOrWhiteSpace(attachment.RelativePath))
+                {
+                    continue;
+                }
+
+                var absolute = _workspace.GetAbsolutePath(attachment.RelativePath);
+                if (string.IsNullOrWhiteSpace(absolute) ||
+                    !File.Exists(absolute) ||
+                    !string.Equals(Path.GetExtension(absolute), ".pdf", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var fileName = Path.GetFileName(absolute) ?? attachment.RelativePath;
+                var displayName = string.IsNullOrWhiteSpace(attachment.Title)
+                    ? fileName
+                    : $"{attachment.Title.Trim()} ({fileName})";
+
+                return new PdfSourceInfo(absolute, attachment.RelativePath, displayName, attachment.Id);
+            }
+        }
+
+        return null;
+    }
+
+    private sealed record PdfSourceInfo(string AbsolutePath, string RelativePath, string DisplayName, string? AttachmentId);
+}
+
+  internal enum DataExtractionMode
+  {
+      Stream,
+      Lattice
+  }
+
+  internal enum TableDetectionStrategy
+  {
+      Auto,
+      Nurminen,
+      Spreadsheet,
+      None
+  }
+
+  internal sealed record ExtractionModeOption(DataExtractionMode Mode, string DisplayName, string Description);
+
+  internal sealed record DetectorOption(TableDetectionStrategy Strategy, string DisplayName, string Description);

--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionTableViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionTableViewModel.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+using Tabula;
+using Tabula.Detectors;
+using UglyToad.PdfPig.Core;
+
+namespace LM.App.Wpf.ViewModels.Library;
+
+internal sealed class DataExtractionTableViewModel
+{
+    private readonly IReadOnlyList<IReadOnlyList<string>> _cells;
+
+    private DataExtractionTableViewModel(int pageNumber,
+                                         int tableIndex,
+                                         DataExtractionMode mode,
+                                         TableDetectionStrategy detector,
+                                         TableRectangle? region,
+                                         IReadOnlyList<IReadOnlyList<string>> cells,
+                                         DataView dataView,
+                                         string preview)
+    {
+        PageNumber = pageNumber;
+        TableIndex = tableIndex;
+        Mode = mode;
+        Detector = detector;
+        Region = region;
+        _cells = cells;
+        RowsView = dataView ?? throw new ArgumentNullException(nameof(dataView));
+        Preview = preview;
+    }
+
+    public int PageNumber { get; }
+
+    public int TableIndex { get; }
+
+    public DataExtractionMode Mode { get; }
+
+    public TableDetectionStrategy Detector { get; }
+
+    public TableRectangle? Region { get; }
+
+    public DataView RowsView { get; }
+
+    public int RowCount => _cells.Count;
+
+    public int ColumnCount => _cells.Count == 0 ? 0 : _cells.Max(row => row.Count);
+
+    public string Preview { get; }
+
+    public string RegionSummary => Region is null ? "Full page" : FormatRegion(Region.BoundingBox);
+
+    public string Title => $"Page {PageNumber} · Table {TableIndex}";
+
+    public static DataExtractionTableViewModel FromTable(int pageNumber,
+                                                         int tableIndex,
+                                                         DataExtractionMode mode,
+                                                         TableDetectionStrategy detector,
+                                                         Table table,
+                                                         TableRectangle? region)
+    {
+        if (table is null)
+            throw new ArgumentNullException(nameof(table));
+
+        var cells = NormalizeCells(table.Rows);
+        var dataTable = BuildDataTable(cells);
+        var preview = BuildPreview(cells);
+
+        return new DataExtractionTableViewModel(
+            pageNumber,
+            tableIndex,
+            mode,
+            detector,
+            region,
+            cells,
+            dataTable.DefaultView,
+            preview);
+    }
+
+    public string ToTsv()
+    {
+        var rows = new List<string>(_cells.Count);
+        foreach (var row in _cells)
+        {
+            var normalized = row.Select(cell => cell?.Replace("\t", "    ").Replace("\r", " ").Replace("\n", " ") ?? string.Empty);
+            rows.Add(string.Join('\t', normalized));
+        }
+
+        return string.Join(Environment.NewLine, rows);
+    }
+
+    private static IReadOnlyList<IReadOnlyList<string>> NormalizeCells(IReadOnlyList<IReadOnlyList<Cell>> source)
+    {
+        var rows = new List<IReadOnlyList<string>>();
+        if (source is null)
+            return rows;
+
+        foreach (var row in source)
+        {
+            if (row is null)
+            {
+                rows.Add(Array.Empty<string>());
+                continue;
+            }
+
+            var values = new List<string>(row.Count);
+            foreach (var cell in row)
+            {
+                if (cell is null)
+                {
+                    values.Add(string.Empty);
+                    continue;
+                }
+
+                var text = cell.GetText(true) ?? string.Empty;
+                values.Add(text.Trim());
+            }
+
+            rows.Add(values);
+        }
+
+        return rows;
+    }
+
+    private static DataTable BuildDataTable(IReadOnlyList<IReadOnlyList<string>> rows)
+    {
+        var table = new DataTable();
+        var columnCount = rows.Count == 0 ? 0 : rows.Max(row => row.Count);
+
+        for (var column = 0; column < columnCount; column++)
+        {
+            table.Columns.Add($"Column {column + 1}");
+        }
+
+        foreach (var row in rows)
+        {
+            var dataRow = table.NewRow();
+            for (var column = 0; column < columnCount; column++)
+            {
+                dataRow[column] = column < row.Count ? row[column] ?? string.Empty : string.Empty;
+            }
+
+            table.Rows.Add(dataRow);
+        }
+
+        return table;
+    }
+
+    private static string BuildPreview(IReadOnlyList<IReadOnlyList<string>> rows)
+    {
+        if (rows.Count == 0)
+            return "(empty table)";
+
+        var firstRow = rows[0];
+        var columns = firstRow.Select(cell => string.IsNullOrWhiteSpace(cell) ? "(blank)" : cell.Trim());
+        return string.Join(" | ", columns);
+    }
+
+    private static string FormatRegion(PdfRectangle rectangle)
+    {
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "x:{0:0.##}-{1:0.##}, y:{2:0.##}-{3:0.##}",
+            rectangle.Left,
+            rectangle.Right,
+            rectangle.Bottom,
+            rectangle.Top);
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/LibraryViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/LibraryViewModel.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using LM.App.Wpf.Common;
@@ -22,6 +23,7 @@ namespace LM.App.Wpf.ViewModels
     /// <summary>
     /// Coordinates Library filters, search execution, and result presentation.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftPublicApi", "RS0016:PublicSymbolsMustBeDocumented", Justification = "Public API recorded in PublicAPI.Unshipped.txt.")]
     public sealed partial class LibraryViewModel : ViewModelBase
     {
         private readonly IEntryStore _store;
@@ -37,7 +39,8 @@ namespace LM.App.Wpf.ViewModels
                                 IUserPreferencesStore preferencesStore,
                                 IClipboardService clipboard,
                                 IFileExplorerService fileExplorer,
-                                ILibraryDocumentService documentService)
+                                ILibraryDocumentService documentService,
+                                Func<Entry, CancellationToken, Task<bool>> dataExtractionLauncher)
         {
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _fullTextSearch = fullTextSearch ?? throw new ArgumentNullException(nameof(fullTextSearch));
@@ -49,6 +52,7 @@ namespace LM.App.Wpf.ViewModels
             _clipboard = clipboard ?? throw new ArgumentNullException(nameof(clipboard));
             _fileExplorer = fileExplorer ?? throw new ArgumentNullException(nameof(fileExplorer));
             _documentService = documentService ?? throw new ArgumentNullException(nameof(documentService));
+            _dataExtractionLauncher = dataExtractionLauncher ?? throw new ArgumentNullException(nameof(dataExtractionLauncher));
 
             Results.SelectionChanged += OnResultsSelectionChanged;
 

--- a/src/LM.App.Wpf/Views/Library/DataExtractionPlaygroundWindow.xaml
+++ b/src/LM.App.Wpf/Views/Library/DataExtractionPlaygroundWindow.xaml
@@ -1,0 +1,230 @@
+<Window x:Class="LM.App.Wpf.Views.Library.DataExtractionPlaygroundWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:viewModels="clr-namespace:LM.App.Wpf.ViewModels.Library"
+        mc:Ignorable="d"
+        x:ClassModifier="internal"
+        d:DataContext="{d:DesignInstance Type=viewModels:DataExtractionPlaygroundViewModel}"
+        Title="Data extraction playground"
+        Height="720"
+        Width="1200"
+        WindowStartupLocation="CenterOwner"
+        MinHeight="600"
+        MinWidth="960">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="3*" MinWidth="360" />
+            <ColumnDefinition Width="4*" MinWidth="480" />
+        </Grid.ColumnDefinitions>
+
+        <!-- PDF preview -->
+        <Border Grid.Column="0"
+                Margin="16"
+                Padding="0"
+                Background="{DynamicResource LibraryPanelBackgroundBrush}"
+                BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                BorderThickness="1">
+            <Grid>
+                <TextBlock Text="PDF preview"
+                           FontSize="16"
+                           FontWeight="SemiBold"
+                           Margin="12"
+                           HorizontalAlignment="Left"
+                           VerticalAlignment="Top" />
+                <Border Margin="12,40,12,12"
+                        Background="White"
+                        BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                        BorderThickness="1">
+                    <Grid>
+                        <WebBrowser x:Name="PdfBrowser" />
+                    </Grid>
+                </Border>
+            </Grid>
+        </Border>
+
+        <!-- Extraction workspace -->
+        <Grid Grid.Column="1" Margin="16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <StackPanel Orientation="Vertical" Grid.Row="0" Margin="0,0,0,12">
+                <TextBlock Text="Data extraction playground"
+                           FontSize="20"
+                           FontWeight="SemiBold"
+                           Foreground="{DynamicResource LibraryPrimaryForegroundBrush}" />
+                <TextBlock Text="Interactively run TabulaSharp algorithms against the entry's PDF and review structured tables."
+                           Margin="0,4,0,0"
+                           TextWrapping="Wrap"
+                           Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+            </StackPanel>
+
+            <Border Grid.Row="1"
+                    Padding="12"
+                    Margin="0,0,0,12"
+                    Background="{DynamicResource LibraryPanelBackgroundBrush}"
+                    BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                    BorderThickness="1">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Vertical">
+                        <TextBlock Text="Entry"
+                                   FontWeight="SemiBold"
+                                   Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                        <TextBlock Text="{Binding DocumentTitle}"
+                                   TextWrapping="Wrap"
+                                   FontSize="14"
+                                   Foreground="{DynamicResource LibraryPrimaryForegroundBrush}" />
+                        <TextBlock Text="{Binding PdfFileName}"
+                                   TextWrapping="Wrap"
+                                   Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Vertical" Margin="24,0,0,0">
+                        <TextBlock Text="Pages" FontWeight="SemiBold" />
+                        <TextBox Text="{Binding PageSelection, UpdateSourceTrigger=PropertyChanged}"
+                                 Width="180"
+                                 ToolTip="Enter page numbers or ranges (e.g., 1,3-4,all)."
+                                 Margin="0,4,0,0" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Row="0" Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button Content="Extract tables"
+                                Width="140"
+                                Height="32"
+                                Margin="0,4,0,0"
+                                Command="{Binding ExtractTablesCommand}" />
+                        <Button Content="Copy selected"
+                                Width="140"
+                                Height="32"
+                                Margin="8,4,0,0"
+                                Command="{Binding CopyTableCommand}" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="0,12,0,0">
+                        <StackPanel Width="220" Margin="0,0,24,0">
+                            <TextBlock Text="Extraction mode" FontWeight="SemiBold" />
+                            <ComboBox ItemsSource="{Binding ModeOptions}"
+                                      SelectedItem="{Binding SelectedMode}"
+                                      DisplayMemberPath="DisplayName"
+                                      Margin="0,4,0,0" />
+                            <TextBlock Text="{Binding SelectedMode.Description}"
+                                       TextWrapping="Wrap"
+                                       Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                        </StackPanel>
+                        <StackPanel Width="220">
+                            <TextBlock Text="Table detection" FontWeight="SemiBold" />
+                            <ComboBox ItemsSource="{Binding DetectorOptions}"
+                                      SelectedItem="{Binding SelectedDetector}"
+                                      DisplayMemberPath="DisplayName"
+                                      Margin="0,4,0,0" />
+                            <TextBlock Text="{Binding SelectedDetector.Description}"
+                                       TextWrapping="Wrap"
+                                       Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                        </StackPanel>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <Grid Grid.Row="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*" MinWidth="240" />
+                    <ColumnDefinition Width="3*" MinWidth="320" />
+                </Grid.ColumnDefinitions>
+
+                <Border Grid.Column="0"
+                        Margin="0,0,12,0"
+                        Padding="0"
+                        Background="{DynamicResource LibraryPanelBackgroundBrush}"
+                        BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                        BorderThickness="1">
+                    <Grid>
+                        <TextBlock Text="Detected tables"
+                                   FontWeight="SemiBold"
+                                   Margin="12"
+                                   Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                        <ListBox ItemsSource="{Binding Tables}"
+                                 SelectedItem="{Binding SelectedTable}"
+                                 Margin="12,40,12,12"
+                                 HorizontalContentAlignment="Stretch">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate DataType="{x:Type viewModels:DataExtractionTableViewModel}">
+                                    <Border Padding="8"
+                                            Margin="0,0,0,8"
+                                            Background="{DynamicResource LibraryPanelSubtleBrush}"
+                                            BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                                            BorderThickness="1">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                                            <TextBlock Text="{Binding RegionSummary}" Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                                            <TextBlock Text="{Binding Preview}"
+                                                       Margin="0,4,0,0"
+                                                       TextWrapping="Wrap"
+                                                       Foreground="{DynamicResource LibraryPrimaryForegroundBrush}" />
+                                            <TextBlock Text="{Binding RowCount, StringFormat=Rows: {0}}"
+                                                       Margin="0,4,0,0"
+                                                       Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                                            <TextBlock Text="{Binding ColumnCount, StringFormat=Columns: {0}}"
+                                                       Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Grid>
+                </Border>
+
+                <Border Grid.Column="1"
+                        Padding="0"
+                        Background="{DynamicResource LibraryPanelBackgroundBrush}"
+                        BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                        BorderThickness="1">
+                    <Grid>
+                        <TextBlock Text="Table preview"
+                                   FontWeight="SemiBold"
+                                   Margin="12"
+                                   Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                        <DataGrid ItemsSource="{Binding SelectedTable.RowsView}"
+                                  AutoGenerateColumns="True"
+                                  IsReadOnly="True"
+                                  Margin="12,40,12,12"
+                                  HeadersVisibility="Column"
+                                  AlternatingRowBackground="{DynamicResource LibraryPanelSubtleBrush}"
+                                  GridLinesVisibility="All" />
+                    </Grid>
+                </Border>
+            </Grid>
+
+            <Border Grid.Row="3"
+                    Margin="0,12,0,0"
+                    Padding="12"
+                    Background="{DynamicResource LibraryPanelSubtleBrush}"
+                    BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                    BorderThickness="1">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
+                    <TextBlock Text="Status:"
+                               FontWeight="SemiBold"
+                               Margin="0,0,8,0" />
+                    <TextBlock Text="{Binding StatusMessage}"
+                               TextWrapping="Wrap"
+                               Foreground="{DynamicResource LibrarySecondaryForegroundBrush}"
+                               Width="Auto" />
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Grid>
+</Window>

--- a/src/LM.App.Wpf/Views/Library/DataExtractionPlaygroundWindow.xaml.cs
+++ b/src/LM.App.Wpf/Views/Library/DataExtractionPlaygroundWindow.xaml.cs
@@ -1,0 +1,61 @@
+#nullable enable
+using System;
+using System.ComponentModel;
+using LM.App.Wpf.ViewModels.Library;
+
+namespace LM.App.Wpf.Views.Library
+{
+    internal partial class DataExtractionPlaygroundWindow : System.Windows.Window
+    {
+        private readonly DataExtractionPlaygroundViewModel _viewModel;
+
+        internal DataExtractionPlaygroundWindow(DataExtractionPlaygroundViewModel viewModel)
+        {
+            InitializeComponent();
+            _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+            DataContext = _viewModel;
+            Loaded += OnLoaded;
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            base.OnClosed(e);
+        }
+
+        private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            Loaded -= OnLoaded;
+            _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+            NavigateToPdf();
+        }
+
+        private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (string.Equals(e.PropertyName, nameof(DataExtractionPlaygroundViewModel.PdfSource), StringComparison.Ordinal))
+            {
+                NavigateToPdf();
+            }
+        }
+
+        private void NavigateToPdf()
+        {
+            var source = _viewModel.PdfSource;
+            if (source is null)
+                return;
+
+            try
+            {
+                PdfBrowser.Navigate(source);
+            }
+            catch (Exception ex)
+            {
+                System.Windows.MessageBox.Show(
+                    $"Failed to load PDF preview:\n{ex.Message}",
+                    "PDF preview",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Warning);
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -410,6 +410,9 @@
                   <MenuItem Header="Edit entry"
                             Command="{Binding PlacementTarget.Tag.EditEntryCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                             CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                  <MenuItem Header="Data extraction playground"
+                            Command="{Binding PlacementTarget.Tag.OpenDataExtractionCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                            CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
                 </ContextMenu>
               </Setter.Value>
             </Setter>


### PR DESCRIPTION
## Summary
- add TabulaSharp dependencies and register a data extraction launcher and command for library entries with PDFs
- implement a TabulaSharp-powered data extraction playground window with PDF preview, table extraction controls, and changelog logging
- add supporting table view model and adjust library view model tests for the new launcher delegate

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug`
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: missing Microsoft.WindowsDesktop runtime in CI environment and pre-existing JsonReviewProjectStoreTests.SaveAssignmentAsync_RemovesLegacyLockFile assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68d92d5b3c68832bb40fa3df92095eaf