### PR TITLE
Fix dispatcher violation in data extraction playground

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.cs
@@ -205,7 +205,7 @@ internal sealed partial class DataExtractionPlaygroundViewModel : ViewModelBase
                 OnPropertyChanged(nameof(CanCopyTable));
             }
 
-            await WriteChangeLogEventAsync(mode, detector, pageNumbers, totalTables).ConfigureAwait(false);
+            await WriteChangeLogEventAsync(mode, detector, pageNumbers, totalTables);
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
## Summary
- ensure the data extraction playground logs change events without leaving the UI dispatcher thread

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: NETSDK1045 – installed SDK 8.0.414 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d937a1fb8c832b9835f132c4bbc9dc