### PR TITLE
Add manual adjustment controls for extracted tables

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionTableViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionTableViewModel.cs
@@ -21,7 +21,6 @@ internal sealed class DataExtractionTableViewModel
                                          TableRectangle? region,
                                          IReadOnlyList<IReadOnlyList<string>> cells,
                                          int columnCount,
-                                         DataView dataView,
                                          string preview)
     {
         PageNumber = pageNumber;
@@ -31,7 +30,6 @@ internal sealed class DataExtractionTableViewModel
         Region = region;
         _cells = cells;
         _columnCount = columnCount;
-        RowsView = dataView ?? throw new ArgumentNullException(nameof(dataView));
         Preview = preview;
     }
 
@@ -44,8 +42,6 @@ internal sealed class DataExtractionTableViewModel
     public TableDetectionStrategy Detector { get; }
 
     public TableRectangle? Region { get; }
-
-    public DataView RowsView { get; }
 
     public int RowCount => _cells.Count;
 
@@ -70,7 +66,6 @@ internal sealed class DataExtractionTableViewModel
         var normalized = NormalizeCells(table.Rows, table.ColumnCount);
         var cells = normalized.Rows;
         var columnCount = normalized.ColumnCount;
-        var dataTable = BuildDataTable(cells, columnCount);
         var preview = BuildPreview(cells);
 
         return new DataExtractionTableViewModel(
@@ -81,20 +76,12 @@ internal sealed class DataExtractionTableViewModel
             region,
             cells,
             columnCount,
-            dataTable.DefaultView,
             preview);
     }
 
     public string ToTsv()
     {
-        var rows = new List<string>(_cells.Count);
-        foreach (var row in _cells)
-        {
-            var normalized = row.Select(cell => cell?.Replace("\t", "    ").Replace("\r", " ").Replace("\n", " ") ?? string.Empty);
-            rows.Add(string.Join('\t', normalized));
-        }
-
-        return string.Join(Environment.NewLine, rows);
+        return ToTsv(TableAdjustmentOptions.Default);
     }
 
     private static (IReadOnlyList<IReadOnlyList<string>> Rows, int ColumnCount) NormalizeCells(IReadOnlyList<IReadOnlyList<Cell>> source,
@@ -201,33 +188,464 @@ internal sealed class DataExtractionTableViewModel
         return (projectedRows, keepIndexes.Count);
     }
 
-    private static DataTable BuildDataTable(IReadOnlyList<IReadOnlyList<string>> rows, int columnCount)
+    public string ToTsv(TableAdjustmentOptions options)
     {
-        var table = new DataTable();
+        var adjusted = ApplyAdjustments(options ?? TableAdjustmentOptions.Default);
+        var rows = new List<string>();
 
-        if (columnCount <= 0)
+        if (adjusted.Headers.Count > 0)
         {
-            return table;
+            rows.Add(string.Join('\t', adjusted.Headers));
         }
 
-        for (var column = 0; column < columnCount; column++)
+        foreach (var row in adjusted.Rows)
         {
-            table.Columns.Add($"Column {column + 1}");
+            var normalized = row.Select(static cell => cell?.Replace("\t", "    ").Replace("\r", " ").Replace("\n", " ") ?? string.Empty);
+            rows.Add(string.Join('\t', normalized));
         }
 
-        foreach (var row in rows)
+        return string.Join(Environment.NewLine, rows);
+    }
+
+    public DataView BuildView(TableAdjustmentOptions options)
+    {
+        var adjusted = ApplyAdjustments(options ?? TableAdjustmentOptions.Default);
+        var dataTable = new DataTable();
+
+        foreach (var header in adjusted.Headers)
         {
-            var dataRow = table.NewRow();
-            for (var column = 0; column < columnCount; column++)
+            dataTable.Columns.Add(header);
+        }
+
+        foreach (var row in adjusted.Rows)
+        {
+            var dataRow = dataTable.NewRow();
+            for (var column = 0; column < adjusted.Headers.Count; column++)
             {
                 dataRow[column] = column < row.Count ? row[column] ?? string.Empty : string.Empty;
             }
 
-            table.Rows.Add(dataRow);
+            dataTable.Rows.Add(dataRow);
         }
 
-        return table;
+        return dataTable.DefaultView;
     }
+
+    public string GetRowPreview(int index)
+    {
+        if (index < 0 || index >= _cells.Count)
+        {
+            return string.Empty;
+        }
+
+        var row = _cells[index];
+        if (row.Count == 0)
+        {
+            return "(empty)";
+        }
+
+        var preview = row.Select(static cell => string.IsNullOrWhiteSpace(cell) ? "(blank)" : cell.Trim());
+        return string.Join(" | ", preview);
+    }
+
+    public IReadOnlyList<IReadOnlyList<string>> GetRawRows()
+    {
+        return _cells;
+    }
+
+    private AdjustedTable ApplyAdjustments(TableAdjustmentOptions options)
+    {
+        var effective = options ?? TableAdjustmentOptions.Default;
+        var working = CloneRows(_cells);
+        var initialColumnCount = working.Count == 0 ? 0 : working.Max(static row => row.Count);
+        var columnsToRemove = new HashSet<int>();
+
+        if (effective.MergeSignColumns)
+        {
+            MergeSignColumns(working, columnsToRemove, initialColumnCount);
+        }
+
+        var trimmed = ProjectRemainingColumns(working, columnsToRemove);
+
+        if (effective.RemoveEmptyColumns)
+        {
+            trimmed = RemoveEmptyColumns(trimmed);
+        }
+
+        if (effective.RemoveEmptyRows)
+        {
+            trimmed = RemoveEmptyRows(trimmed);
+        }
+
+        var columnCount = trimmed.Count == 0 ? 0 : trimmed.Max(static row => row.Count);
+        var headers = BuildHeaders(trimmed, columnCount, effective.HeaderRowIndex);
+        var dataRows = ExtractDataRows(trimmed, effective.HeaderRowIndex);
+
+        return new AdjustedTable(headers, dataRows);
+    }
+
+    private static List<List<string>> CloneRows(IReadOnlyList<IReadOnlyList<string>> source)
+    {
+        var result = new List<List<string>>(source.Count);
+        foreach (var row in source)
+        {
+            result.Add(row.Select(static cell => cell ?? string.Empty).ToList());
+        }
+
+        return result;
+    }
+
+    private static void MergeSignColumns(List<List<string>> rows, HashSet<int> columnsToRemove, int columnCount)
+    {
+        for (var column = 0; column < columnCount; column++)
+        {
+            if (columnsToRemove.Contains(column))
+            {
+                continue;
+            }
+
+            if (!IsSignColumn(rows, column))
+            {
+                continue;
+            }
+
+            var targetColumn = FindMergeTarget(rows, column, columnCount, columnsToRemove);
+            if (targetColumn < 0)
+            {
+                continue;
+            }
+
+            foreach (var row in rows)
+            {
+                var sign = column < row.Count ? row[column] : string.Empty;
+                if (targetColumn >= row.Count)
+                {
+                    PadRow(row, targetColumn + 1);
+                }
+
+                var value = targetColumn < row.Count ? row[targetColumn] : string.Empty;
+                row[targetColumn] = CombineSignAndValue(sign, value);
+            }
+
+            columnsToRemove.Add(column);
+        }
+    }
+
+    private static bool IsSignColumn(List<List<string>> rows, int column)
+    {
+        var hasCandidate = false;
+        foreach (var row in rows)
+        {
+            if (column >= row.Count)
+            {
+                continue;
+            }
+
+            var text = row[column];
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                continue;
+            }
+
+            hasCandidate = true;
+            if (!IsSignToken(text))
+            {
+                return false;
+            }
+        }
+
+        return hasCandidate;
+    }
+
+    private static bool IsSignToken(string text)
+    {
+        var trimmed = text.Trim();
+        if (trimmed.Length == 0)
+        {
+            return false;
+        }
+
+        return trimmed switch
+        {
+            "+" or "-" or "±" or "+/-" or "-/+" => true,
+            _ => trimmed.All(static ch => ch is '+' or '-' or '±' or '/' or ' ')
+        };
+    }
+
+    private static int FindMergeTarget(List<List<string>> rows, int signColumn, int totalColumns, HashSet<int> columnsToRemove)
+    {
+        var next = FindNumericColumn(rows, signColumn + 1, totalColumns, +1, columnsToRemove);
+        if (next >= 0)
+        {
+            return next;
+        }
+
+        return FindNumericColumn(rows, signColumn - 1, -1, -1, columnsToRemove);
+    }
+
+    private static int FindNumericColumn(List<List<string>> rows, int start, int boundary, int step, HashSet<int> columnsToRemove)
+    {
+        for (var column = start; column != boundary; column += step)
+        {
+            if (column < 0)
+            {
+                break;
+            }
+
+            if (columnsToRemove.Contains(column))
+            {
+                continue;
+            }
+
+            var hasNumeric = false;
+            foreach (var row in rows)
+            {
+                if (column >= row.Count)
+                {
+                    continue;
+                }
+
+                var text = row[column];
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    continue;
+                }
+
+                if (ContainsDigit(text))
+                {
+                    hasNumeric = true;
+                    break;
+                }
+            }
+
+            if (hasNumeric)
+            {
+                return column;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool ContainsDigit(string text)
+    {
+        foreach (var ch in text)
+        {
+            if (char.IsDigit(ch))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void PadRow(List<string> row, int targetLength)
+    {
+        while (row.Count < targetLength)
+        {
+            row.Add(string.Empty);
+        }
+    }
+
+    private static string CombineSignAndValue(string sign, string value)
+    {
+        var trimmedSign = sign?.Trim() ?? string.Empty;
+        var trimmedValue = value?.Trim() ?? string.Empty;
+
+        if (trimmedSign.Length == 0)
+        {
+            return trimmedValue;
+        }
+
+        if (trimmedValue.Length == 0)
+        {
+            return trimmedSign;
+        }
+
+        var separatorNeeded = NeedsSeparator(trimmedSign, trimmedValue);
+        return separatorNeeded ? $"{trimmedSign} {trimmedValue}" : trimmedSign + trimmedValue;
+    }
+
+    private static bool NeedsSeparator(string sign, string value)
+    {
+        if (sign.Length == 0)
+        {
+            return false;
+        }
+
+        var last = sign[^1];
+        if (last is '+' or '-' or '/' or '±')
+        {
+            return false;
+        }
+
+        return value.Length > 0 && !char.IsWhiteSpace(value[0]);
+    }
+
+    private static List<List<string>> ProjectRemainingColumns(List<List<string>> rows, HashSet<int> columnsToRemove)
+    {
+        if (columnsToRemove.Count == 0)
+        {
+            return rows.Select(static row => row.ToList()).ToList();
+        }
+
+        var projected = new List<List<string>>(rows.Count);
+        foreach (var row in rows)
+        {
+            var values = new List<string>();
+            for (var column = 0; column < row.Count; column++)
+            {
+                if (columnsToRemove.Contains(column))
+                {
+                    continue;
+                }
+
+                values.Add(row[column]);
+            }
+
+            projected.Add(values);
+        }
+
+        return projected;
+    }
+
+    private static List<List<string>> RemoveEmptyColumns(List<List<string>> rows)
+    {
+        if (rows.Count == 0)
+        {
+            return rows;
+        }
+
+        var columnCount = rows.Max(static row => row.Count);
+        var keep = new List<int>();
+
+        for (var column = 0; column < columnCount; column++)
+        {
+            var hasContent = false;
+            foreach (var row in rows)
+            {
+                if (column >= row.Count)
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrWhiteSpace(row[column]))
+                {
+                    hasContent = true;
+                    break;
+                }
+            }
+
+            if (hasContent)
+            {
+                keep.Add(column);
+            }
+        }
+
+        if (keep.Count == 0)
+        {
+            keep.Add(0);
+        }
+
+        var projected = new List<List<string>>(rows.Count);
+        foreach (var row in rows)
+        {
+            var values = new List<string>(keep.Count);
+            foreach (var column in keep)
+            {
+                values.Add(column < row.Count ? row[column] : string.Empty);
+            }
+
+            projected.Add(values);
+        }
+
+        return projected;
+    }
+
+    private static List<List<string>> RemoveEmptyRows(List<List<string>> rows)
+    {
+        var filtered = new List<List<string>>();
+        foreach (var row in rows)
+        {
+            if (row.All(static cell => string.IsNullOrWhiteSpace(cell)))
+            {
+                continue;
+            }
+
+            filtered.Add(row);
+        }
+
+        return filtered;
+    }
+
+    private static IReadOnlyList<string> BuildHeaders(List<List<string>> rows, int columnCount, int headerRowIndex)
+    {
+        var headers = new List<string>(columnCount);
+        IReadOnlyList<string>? headerRow = null;
+
+        if (headerRowIndex >= 0 && headerRowIndex < rows.Count)
+        {
+            headerRow = rows[headerRowIndex];
+        }
+
+        for (var column = 0; column < columnCount; column++)
+        {
+            string name;
+            if (headerRow is not null && column < headerRow.Count)
+            {
+                name = headerRow[column];
+            }
+            else
+            {
+                name = $"Column {column + 1}";
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                name = $"Column {column + 1}";
+            }
+
+            headers.Add(EnsureUnique(headers, name.Trim()));
+        }
+
+        return headers;
+    }
+
+    private static string EnsureUnique(List<string> existing, string candidate)
+    {
+        if (!existing.Any(name => string.Equals(name, candidate, StringComparison.Ordinal)))
+        {
+            return candidate;
+        }
+
+        var suffix = 2;
+        var baseName = candidate;
+        while (existing.Any(name => string.Equals(name, $"{baseName} ({suffix})", StringComparison.Ordinal)))
+        {
+            suffix++;
+        }
+
+        return $"{baseName} ({suffix})";
+    }
+
+    private static IReadOnlyList<IReadOnlyList<string>> ExtractDataRows(List<List<string>> rows, int headerRowIndex)
+    {
+        var data = new List<IReadOnlyList<string>>();
+        for (var i = 0; i < rows.Count; i++)
+        {
+            if (i == headerRowIndex)
+            {
+                continue;
+            }
+
+            data.Add(rows[i]);
+        }
+
+        return data;
+    }
+
+    private sealed record AdjustedTable(IReadOnlyList<string> Headers, IReadOnlyList<IReadOnlyList<string>> Rows);
 
     private static string BuildPreview(IReadOnlyList<IReadOnlyList<string>> rows)
     {

--- a/src/LM.App.Wpf/ViewModels/Library/TableAdjustmentOptions.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/TableAdjustmentOptions.cs
@@ -1,0 +1,44 @@
+namespace LM.App.Wpf.ViewModels.Library;
+
+internal sealed record TableAdjustmentOptions(bool RemoveEmptyRows,
+                                              bool RemoveEmptyColumns,
+                                              bool MergeSignColumns,
+                                              int HeaderRowIndex)
+{
+    public static TableAdjustmentOptions Default { get; } = new(false, true, true, -1);
+
+    public TableAdjustmentOptions WithHeaderRow(int headerRowIndex)
+    {
+        return this with { HeaderRowIndex = headerRowIndex };
+    }
+
+    public TableAdjustmentOptions WithRemoveEmptyRows(bool remove)
+    {
+        return this with { RemoveEmptyRows = remove };
+    }
+
+    public TableAdjustmentOptions WithRemoveEmptyColumns(bool remove)
+    {
+        return this with { RemoveEmptyColumns = remove };
+    }
+
+    public TableAdjustmentOptions WithMergeSignColumns(bool merge)
+    {
+        return this with { MergeSignColumns = merge };
+    }
+
+    public static TableAdjustmentOptions ClampHeader(TableAdjustmentOptions options, int maxRowIndex)
+    {
+        if (options.HeaderRowIndex < 0)
+        {
+            return options;
+        }
+
+        if (options.HeaderRowIndex > maxRowIndex)
+        {
+            return options with { HeaderRowIndex = maxRowIndex };
+        }
+
+        return options;
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Library/TableRowOption.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/TableRowOption.cs
@@ -1,0 +1,11 @@
+namespace LM.App.Wpf.ViewModels.Library;
+
+internal sealed record TableRowOption(int? RowIndex, string DisplayText)
+{
+    public bool IsHeader => RowIndex.HasValue;
+
+    public override string ToString()
+    {
+        return DisplayText;
+    }
+}

--- a/src/LM.App.Wpf/Views/Library/DataExtractionPlaygroundWindow.xaml
+++ b/src/LM.App.Wpf/Views/Library/DataExtractionPlaygroundWindow.xaml
@@ -194,14 +194,49 @@
                         BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
                         BorderThickness="1">
                     <Grid>
-                        <TextBlock Text="Table preview"
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0"
+                                   Text="Table preview"
                                    FontWeight="SemiBold"
                                    Margin="12"
                                    Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
-                        <DataGrid ItemsSource="{Binding SelectedTable.RowsView}"
+
+                        <StackPanel Grid.Row="1" Margin="12,0,12,0">
+                            <TextBlock Text="Adjustments"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                            <WrapPanel Margin="0,4,0,0">
+                                <CheckBox Content="Remove empty columns"
+                                          IsChecked="{Binding RemoveEmptyColumns}"
+                                          Margin="0,0,12,0" />
+                                <CheckBox Content="Remove empty rows"
+                                          IsChecked="{Binding RemoveEmptyRows}"
+                                          Margin="0,0,12,0" />
+                                <CheckBox Content="Merge +/- columns"
+                                          IsChecked="{Binding MergeSignColumns}" />
+                            </WrapPanel>
+                            <StackPanel Orientation="Vertical" Margin="0,8,0,0">
+                                <TextBlock Text="Header row"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                                <ComboBox ItemsSource="{Binding HeaderRowOptions}"
+                                          SelectedItem="{Binding SelectedHeaderRow}"
+                                          DisplayMemberPath="DisplayText"
+                                          Margin="0,4,0,0"
+                                          Width="280" />
+                            </StackPanel>
+                        </StackPanel>
+
+                        <DataGrid Grid.Row="2"
+                                  ItemsSource="{Binding SelectedTableView}"
                                   AutoGenerateColumns="True"
                                   IsReadOnly="True"
-                                  Margin="12,40,12,12"
+                                  Margin="12,12,12,12"
                                   HeadersVisibility="Column"
                                   AlternatingRowBackground="{DynamicResource LibraryPanelSubtleBrush}"
                                   GridLinesVisibility="All" />


### PR DESCRIPTION
## Summary
- allow users to tweak table output by toggling removal of blank rows/columns, merging sign columns, and selecting header rows in the data extraction playground
- extend the table view model with adjustable projections/TSV output and helper records for managing adjustment options
- refresh the WPF table preview so the DataGrid reflects the adjusted view and exposes the new controls

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: .NET 9.0 SDK is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d949594c64832b83f6004866a6a739