### PR TITLE
Handle inequality symbols in sign column detection

### DIFF
--- a/src/LM.App.Wpf.Tests/Library/DataExtractionTableViewModelTests.cs
+++ b/src/LM.App.Wpf.Tests/Library/DataExtractionTableViewModelTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using LM.App.Wpf.ViewModels.Library;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.Library
+{
+    public sealed class DataExtractionTableViewModelTests
+    {
+        [Fact]
+        public void ToTsv_MergesSignColumnsWithInequalityTokens()
+        {
+            var rows = new List<IReadOnlyList<string>>
+            {
+                new List<string> { "<=", "5" },
+                new List<string> { "≥", "10" },
+                new List<string> { "±", "0.3" }
+            };
+
+            var viewModel = CreateViewModel(rows, columnCount: 2);
+
+            var tsv = viewModel.ToTsv();
+            var lines = tsv.Split(Environment.NewLine, StringSplitOptions.None);
+
+            Assert.Collection(
+                lines,
+                header => Assert.Equal("Column 1", header),
+                first => Assert.Equal("<= 5", first),
+                second => Assert.Equal("≥ 10", second),
+                third => Assert.Equal("± 0.3", third));
+
+            Assert.All(lines.Skip(1), line => Assert.DoesNotContain('\t', line));
+        }
+
+        private static DataExtractionTableViewModel CreateViewModel(
+            IReadOnlyList<IReadOnlyList<string>> rows,
+            int columnCount)
+        {
+            var constructor = typeof(DataExtractionTableViewModel)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .Single();
+
+            return (DataExtractionTableViewModel)constructor.Invoke(new object?[]
+            {
+                1,
+                1,
+                DataExtractionMode.Stream,
+                TableDetectionStrategy.Auto,
+                null,
+                rows,
+                columnCount,
+                string.Empty
+            });
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionTableViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionTableViewModel.cs
@@ -367,9 +367,14 @@ internal sealed class DataExtractionTableViewModel
 
         return trimmed switch
         {
-            "+" or "-" or "±" or "+/-" or "-/+" => true,
-            _ => trimmed.All(static ch => ch is '+' or '-' or '±' or '/' or ' ')
+            "+" or "-" or "±" or "∓" or "+/-" or "-/+" => true,
+            _ => trimmed.All(static ch => IsSignCharacter(ch))
         };
+    }
+
+    private static bool IsSignCharacter(char ch)
+    {
+        return ch is '+' or '-' or '−' or '±' or '∓' or '/' or '／' or ' ' or '<' or '>' or '=' or '≤' or '≥';
     }
 
     private static int FindMergeTarget(List<List<string>> rows, int signColumn, int totalColumns, HashSet<int> columnsToRemove)


### PR DESCRIPTION
## Summary
- broaden the table sign token detection to include inequality glyphs and related characters
- add a WPF unit test that verifies sign/value merging for <=, ≥, and ± tokens

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: LM.Infrastructure.Tests.JsonReviewProjectStoreTests.SaveAssignmentAsync_RemovesLegacyLockFile already failing on main)*
- dotnet test src/LM.App.Wpf.Tests/LM.App.Wpf.Tests.csproj -c Debug *(fails: Microsoft.WindowsDesktop.App 9.0.0 runtime unavailable on Linux runners)*

------
https://chatgpt.com/codex/tasks/task_e_68d95060b130832ba6376710cf5a3292