### PR TITLE
Expand data extraction playground with OCR idea board

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.IdeaBoard.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.IdeaBoard.cs
@@ -1,0 +1,425 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using CommunityToolkit.Mvvm.Input;
+
+namespace LM.App.Wpf.ViewModels.Library;
+
+internal sealed partial class DataExtractionPlaygroundViewModel
+{
+    [RelayCommand]
+    private void CopyIdeaSnippet(OcrIdeaViewModel? idea)
+    {
+        if (idea is null || !idea.HasSnippet)
+        {
+            return;
+        }
+
+        try
+        {
+            _clipboard.SetText(idea.Snippet);
+            StatusMessage = $"Copied {idea.SnippetLabel} for {idea.Title}.";
+        }
+        catch (Exception ex)
+        {
+            System.Windows.MessageBox.Show(
+                $"Failed to copy snippet:\n{ex.Message}",
+                "Copy idea",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+    }
+
+    [RelayCommand]
+    private void CopyIdeaPlan(OcrIdeaViewModel? idea)
+    {
+        if (idea is null)
+        {
+            return;
+        }
+
+        var plan = idea.BuildPlan();
+        if (string.IsNullOrWhiteSpace(plan))
+        {
+            return;
+        }
+
+        try
+        {
+            _clipboard.SetText(plan);
+            StatusMessage = $"Copied plan for {idea.Title}.";
+        }
+        catch (Exception ex)
+        {
+            System.Windows.MessageBox.Show(
+                $"Failed to copy plan:\n{ex.Message}",
+                "Copy idea",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+    }
+
+    [RelayCommand]
+    private void OpenIdeaResource(IdeaResourceViewModel? resource)
+    {
+        if (resource is null || !resource.HasUri)
+        {
+            return;
+        }
+
+        try
+        {
+            var startInfo = new ProcessStartInfo(resource.Uri!.AbsoluteUri)
+            {
+                UseShellExecute = true
+            };
+
+            Process.Start(startInfo);
+            StatusMessage = $"Opened {resource.Label}.";
+        }
+        catch (Exception ex)
+        {
+            System.Windows.MessageBox.Show(
+                $"Failed to open {resource.Label}:\n{ex.Message}",
+                "Open link",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+    }
+
+    private void PopulateIdeaBoard()
+    {
+        IdeaGroups.Clear();
+
+        var tesseractIdeas = new OcrIdeaGroupViewModel(
+            "Tesseract-first experiments",
+            "Use offline OCR to complement Tabula when tables are scanned or poorly tagged.",
+            new[]
+            {
+                new OcrIdeaViewModel(
+                    "Interactive region OCR",
+                    "Allow analysts to drag a rectangle over the preview and run that fragment through Tesseract.",
+                    new[]
+                    {
+                        "Rasterize the selected PDF page into a bitmap (PdfPig's rendering API or SkiaSharp).",
+                        "Capture the rectangle in page coordinates and crop the bitmap before OCR.",
+                        "Call Tesseract with `PageSegMode.SingleTable` to preserve tab stops.",
+                        "Split the TSV output into rows and feed a new `DataExtractionTableViewModel`."
+                    },
+                    """
+using Tesseract;
+
+using var engine = new TesseractEngine(@"./tessdata", "eng", EngineMode.Default);
+using var pix = Pix.LoadFromFile(pageImagePath);
+using var region = pix.ClipRectangle(new System.Drawing.Rectangle(left, top, width, height));
+using var page = engine.Process(region, PageSegMode.SingleTable);
+
+var tsv = page.GetTsvText();
+var rows = tsv.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+// Map TSV columns 11+ into cells and hydrate a DataTable.
+                    """,
+                    "Copy Tesseract region sample",
+                    new[] { "Offline", "Tables", "Interactive" },
+                    new[]
+                    {
+                        new IdeaResourceViewModel("Tesseract docs", "https://tesseract-ocr.github.io/tessdoc/"),
+                        new IdeaResourceViewModel("Tesseract .NET", "https://github.com/charlesw/tesseract")
+                    }),
+                new OcrIdeaViewModel(
+                    "Hybrid lattice + OCR",
+                    "Keep Tabula for grid detection but validate each cell with OCR to clean noisy scans.",
+                    new[]
+                    {
+                        "Run the existing lattice detector to get bounding boxes per cell.",
+                        "Rasterize only the detected cells and send them through a shared Tesseract engine instance.",
+                        "Replace low-confidence cells with OCR text and emit confidence scores to the grid.",
+                        "Highlight suspicious cells in the preview with a semi-transparent overlay."
+                    },
+                    """
+var engine = OcrEnginePool.Rent();
+foreach (var cell in detectedCells)
+{
+    using var pix = Pix.LoadFromMemory(cell.ImageBytes);
+    using var page = engine.Process(pix, PageSegMode.SingleBlock);
+    if (page.TryGetMeanConfidence(out var confidence) && confidence < 85)
+    {
+        cell.MarkAsLowConfidence();
+    }
+
+    cell.Text = page.GetText();
+}
+                    """,
+                    "Copy confidence blending sample",
+                    new[] { "Quality", "Confidence", "Automation" },
+                    Array.Empty<IdeaResourceViewModel>()),
+                new OcrIdeaViewModel(
+                    "Train a table-specific language pack",
+                    "Fine-tune Tesseract to the typography of recurring reports and share the traineddata in the workspace.",
+                    new[]
+                    {
+                        "Collect cropped cell images plus the ground truth text while analysts correct results.",
+                        "Generate box files with jTessBoxEditor and train a custom `.traineddata` file.",
+                        "Ship the model under `.knowledgeworks/tessdata` and auto-sync via the library."
+                    },
+                    null,
+                    null,
+                    new[] { "Customization", "Model", "Shared" },
+                    new[]
+                    {
+                        new IdeaResourceViewModel("Training walkthrough", "https://github.com/tesseract-ocr/tesseract/wiki/TrainingTesseract-5")
+                    })
+            });
+
+        var cloudIdeas = new OcrIdeaGroupViewModel(
+            "Cloud document intelligence",
+            "Tap managed OCR/AI services when latency and network policies allow it.",
+            new[]
+            {
+                new OcrIdeaViewModel(
+                    "Azure Document Intelligence tables",
+                    "Send pages to the prebuilt layout model and stream back structured tables with coordinates.",
+                    new[]
+                    {
+                        "Use `DocumentAnalysisClient` with a SAS token sourced from the hub.",
+                        "Cache the analysis JSON inside the entry so replays are instant.",
+                        "Convert table spans to `DataExtractionTableViewModel` while preserving row/column spans.",
+                        "Fallback to Tabula when the service is offline or rate-limited."
+                    },
+                    """
+using Azure;
+using Azure.AI.FormRecognizer.DocumentAnalysis;
+
+var client = new DocumentAnalysisClient(new Uri(endpoint), new AzureKeyCredential(key));
+AnalyzeDocumentOperation op = await client.AnalyzeDocumentFromUriAsync(WaitUntil.Completed, "prebuilt-layout", pdfUri);
+foreach (var table in op.Value.Tables)
+{
+    // Map table.Cells into your view model, using table.Cells[i].RowSpan etc.
+}
+                    """,
+                    "Copy Azure layout sample",
+                    new[] { "Azure", "Managed", "JSON" },
+                    new[]
+                    {
+                        new IdeaResourceViewModel("Azure setup", "https://learn.microsoft.com/azure/ai-services/document-intelligence/overview"),
+                        new IdeaResourceViewModel("SDK docs", "https://learn.microsoft.com/dotnet/api/azure.ai.formrecognizer")
+                    }),
+                new OcrIdeaViewModel(
+                    "AWS Textract for forms",
+                    "Leverage Textract AnalyzeDocument to pull tables and key-value pairs simultaneously.",
+                    new[]
+                    {
+                        "Stream PDF bytes via S3 or byte[] to Textract's async API.",
+                        "Persist job IDs on the entry hook and poll status with exponential backoff.",
+                        "Use the geometry metadata to anchor extracted values back onto the preview overlay."
+                    },
+                    null,
+                    null,
+                    new[] { "AWS", "Async", "Overlays" },
+                    new[]
+                    {
+                        new IdeaResourceViewModel("Textract tables", "https://docs.aws.amazon.com/textract/latest/dg/how-it-works-tables.html")
+                    }),
+                new OcrIdeaViewModel(
+                    "Bring-your-own LLM post-check",
+                    "Send the raw OCR grid to a hosted LLM to normalize headers, units, and totals.",
+                    new[]
+                    {
+                        "Compose a prompt with the TSV payload and ask for JSON-formatted corrections.",
+                        "Validate numeric totals locally before applying changes.",
+                        "Log adjustments through the changelog hook for traceability."
+                    },
+                    """
+var prompt = $$"""
+You are cleaning an OCR table. Return strict JSON with fields rows, warnings.
+
+{tsv}
+"""$$;
+
+var response = await openAiClient.GetChatCompletionsAsync(deploymentId, new ChatCompletionsOptions
+{
+    Messages =
+    {
+        new ChatRequestSystemMessage("Normalize table headers and units"),
+        new ChatRequestUserMessage(prompt)
+    }
+});
+                    """,
+                    "Copy LLM normalization sample",
+                    new[] { "LLM", "Validation", "Normalization" },
+                    Array.Empty<IdeaResourceViewModel>())
+            });
+
+        var automationIdeas = new OcrIdeaGroupViewModel(
+            "Automation & QA",
+            "Wrap OCR with tooling so analysts can trust the results.",
+            new[]
+            {
+                new OcrIdeaViewModel(
+                    "Versioned extraction recipes",
+                    "Store playground presets (mode, detector, OCR toggles) in the workspace so teams can replay them.",
+                    new[]
+                    {
+                        "Serialize the current playground settings into YAML alongside the entry.",
+                        "Add a toolbar to load/save recipes and compare outputs with diff tooling.",
+                        "Write every replay to the changelog hook with the recipe identifier."
+                    },
+                    null,
+                    null,
+                    new[] { "Repeatable", "Presets", "Collaboration" },
+                    Array.Empty<IdeaResourceViewModel>()),
+                new OcrIdeaViewModel(
+                    "Confidence heatmaps",
+                    "Overlay a color-coded heatmap on the PDF preview based on OCR confidence and Tabula heuristics.",
+                    new[]
+                    {
+                        "Project OCR bounding boxes back to PDF coordinates.",
+                        "Blend them over the WebBrowser host using a transparent Canvas.",
+                        "Expose filters to hide low-risk areas so reviewers focus on the outliers."
+                    },
+                    null,
+                    null,
+                    new[] { "UX", "Visualization", "QA" },
+                    Array.Empty<IdeaResourceViewModel>()),
+                new OcrIdeaViewModel(
+                    "Automated reconciliation",
+                    "Compare extracted totals against ledger data or previously ingested entries to flag drifts.",
+                    new[]
+                    {
+                        "Cross-match numeric columns with known control totals from the knowledge graph.",
+                        "Trigger a review task when deltas exceed configured tolerances.",
+                        "Persist the reconciliation result back into the hook metadata for auditing."
+                    },
+                    null,
+                    null,
+                    new[] { "Controls", "Monitoring", "Hooks" },
+                    Array.Empty<IdeaResourceViewModel>())
+            });
+
+        IdeaGroups.Add(tesseractIdeas);
+        IdeaGroups.Add(cloudIdeas);
+        IdeaGroups.Add(automationIdeas);
+
+        OnPropertyChanged(nameof(HasIdeaGroups));
+    }
+}
+
+internal sealed class OcrIdeaGroupViewModel
+{
+    public OcrIdeaGroupViewModel(string title, string description, IEnumerable<OcrIdeaViewModel> ideas)
+    {
+        Title = title;
+        Description = description;
+        Ideas = new ObservableCollection<OcrIdeaViewModel>((ideas ?? Array.Empty<OcrIdeaViewModel>()).ToList());
+    }
+
+    public string Title { get; }
+
+    public string Description { get; }
+
+    public ObservableCollection<OcrIdeaViewModel> Ideas { get; }
+}
+
+internal sealed class OcrIdeaViewModel
+{
+    private readonly string? _snippetLabel;
+
+    public OcrIdeaViewModel(string title,
+                            string summary,
+                            IEnumerable<string> steps,
+                            string? snippet,
+                            string? snippetLabel,
+                            IEnumerable<string>? tags,
+                            IEnumerable<IdeaResourceViewModel>? resources)
+    {
+        Title = title;
+        Summary = summary;
+
+        var stepList = steps?.Where(step => !string.IsNullOrWhiteSpace(step)).Select(step => step.Trim()).ToList()
+                       ?? new List<string>();
+        Steps = new ReadOnlyCollection<string>(stepList);
+
+        Snippet = snippet?.TrimEnd() ?? string.Empty;
+        _snippetLabel = snippetLabel;
+
+        var tagList = tags?.Where(tag => !string.IsNullOrWhiteSpace(tag)).Select(tag => tag.Trim()).ToList()
+                     ?? new List<string>();
+        Tags = new ReadOnlyCollection<string>(tagList);
+
+        var resourceList = resources?.Where(resource => resource is not null).ToList()
+                          ?? new List<IdeaResourceViewModel>();
+        Resources = new ObservableCollection<IdeaResourceViewModel>(resourceList);
+    }
+
+    public string Title { get; }
+
+    public string Summary { get; }
+
+    public ReadOnlyCollection<string> Steps { get; }
+
+    public string Snippet { get; }
+
+    public bool HasSnippet => !string.IsNullOrWhiteSpace(Snippet);
+
+    public bool HasSteps => Steps.Count > 0;
+
+    public string SnippetLabel => string.IsNullOrWhiteSpace(_snippetLabel) ? "Copy sample code" : _snippetLabel!;
+
+    public ReadOnlyCollection<string> Tags { get; }
+
+    public ObservableCollection<IdeaResourceViewModel> Resources { get; }
+
+    public bool HasResources => Resources.Count > 0;
+
+    public bool HasTags => Tags.Count > 0;
+
+    public string BuildPlan()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(Title);
+
+        if (!string.IsNullOrWhiteSpace(Summary))
+        {
+            builder.AppendLine(Summary);
+        }
+
+        if (Steps.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("Execution checklist:");
+            foreach (var step in Steps)
+            {
+                builder.AppendLine($"- {step}");
+            }
+        }
+
+        if (Tags.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine($"Tags: {string.Join(", ", Tags)}");
+        }
+
+        return builder.ToString().Trim();
+    }
+}
+
+internal sealed class IdeaResourceViewModel
+{
+    public IdeaResourceViewModel(string label, string url)
+    {
+        Label = label;
+        if (Uri.TryCreate(url, UriKind.Absolute, out var parsed))
+        {
+            Uri = parsed;
+        }
+    }
+
+    public string Label { get; }
+
+    public Uri? Uri { get; }
+
+    public bool HasUri => Uri is not null;
+}
+

--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.cs
@@ -61,6 +61,10 @@ internal sealed partial class DataExtractionPlaygroundViewModel : ViewModelBase
         HeaderRowOptions = new ObservableCollection<TableRowOption>();
         RemoveEmptyColumns = true;
         MergeSignColumns = true;
+
+        IdeaGroups = new ObservableCollection<OcrIdeaGroupViewModel>();
+        PopulateIdeaBoard();
+        OnPropertyChanged(nameof(HasIdeaGroups));
     }
 
     public IReadOnlyList<ExtractionModeOption> ModeOptions { get; }
@@ -112,6 +116,10 @@ internal sealed partial class DataExtractionPlaygroundViewModel : ViewModelBase
     public ObservableCollection<DataExtractionTableViewModel> Tables { get; }
 
     public ObservableCollection<TableRowOption> HeaderRowOptions { get; }
+
+    public ObservableCollection<OcrIdeaGroupViewModel> IdeaGroups { get; }
+
+    public bool HasIdeaGroups => IdeaGroups.Count > 0;
 
     public bool HasResults => Tables.Count > 0;
 

--- a/src/LM.App.Wpf/Views/Library/DataExtractionPlaygroundWindow.xaml
+++ b/src/LM.App.Wpf/Views/Library/DataExtractionPlaygroundWindow.xaml
@@ -13,6 +13,9 @@
         WindowStartupLocation="CenterOwner"
         MinHeight="600"
         MinWidth="960">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </Window.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="3*" MinWidth="360" />
@@ -49,6 +52,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="2*" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
@@ -245,6 +249,142 @@
             </Grid>
 
             <Border Grid.Row="3"
+                    Margin="0,12,0,0"
+                    Padding="12"
+                    Background="{DynamicResource LibraryPanelBackgroundBrush}"
+                    BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                    BorderThickness="1"
+                    Visibility="{Binding HasIdeaGroups, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0"
+                               Text="OCR &amp; AI idea board"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource LibraryPrimaryForegroundBrush}" />
+
+                    <TextBlock Grid.Row="1"
+                               Text="Curated experiments that pair Tesseract OCR, cloud services, and automation concepts with the playground."
+                               Margin="0,4,0,0"
+                               TextWrapping="Wrap"
+                               Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+
+                    <ScrollViewer Grid.Row="2"
+                                  Margin="0,12,0,0"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled">
+                        <ItemsControl ItemsSource="{Binding IdeaGroups}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type viewModels:OcrIdeaGroupViewModel}">
+                                    <Expander IsExpanded="True" Margin="0,0,0,12">
+                                        <Expander.Header>
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                                                <TextBlock Text="{Binding Description}"
+                                                           TextWrapping="Wrap"
+                                                           Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                                            </StackPanel>
+                                        </Expander.Header>
+                                        <ItemsControl ItemsSource="{Binding Ideas}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate DataType="{x:Type viewModels:OcrIdeaViewModel}">
+                                                    <Border Margin="0,0,0,12"
+                                                            Padding="12"
+                                                            Background="{DynamicResource LibraryPanelSubtleBrush}"
+                                                            BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                                                            BorderThickness="1">
+                                                        <StackPanel>
+                                                            <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                                                            <TextBlock Text="{Binding Summary}"
+                                                                       Margin="0,4,0,0"
+                                                                       TextWrapping="Wrap"
+                                                                       Foreground="{DynamicResource LibraryPrimaryForegroundBrush}" />
+                                                            <ItemsControl ItemsSource="{Binding Steps}"
+                                                                          Margin="0,6,0,0"
+                                                                          Visibility="{Binding HasSteps, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                                <ItemsControl.ItemTemplate>
+                                                                    <DataTemplate>
+                                                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                                                                            <TextBlock Text="•"
+                                                                                       Margin="0,0,6,0"
+                                                                                       Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                                                                            <TextBlock Text="{Binding}"
+                                                                                       TextWrapping="Wrap"
+                                                                                       Foreground="{DynamicResource LibraryPrimaryForegroundBrush}" />
+                                                                        </StackPanel>
+                                                                    </DataTemplate>
+                                                                </ItemsControl.ItemTemplate>
+                                                            </ItemsControl>
+                                                            <ItemsControl ItemsSource="{Binding Tags}"
+                                                                          Margin="0,6,0,0"
+                                                                          Visibility="{Binding HasTags, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                                <ItemsControl.ItemsPanel>
+                                                                    <ItemsPanelTemplate>
+                                                                        <WrapPanel />
+                                                                    </ItemsPanelTemplate>
+                                                                </ItemsControl.ItemsPanel>
+                                                                <ItemsControl.ItemTemplate>
+                                                                    <DataTemplate>
+                                                                        <Border Background="{DynamicResource LibraryPanelBackgroundBrush}"
+                                                                                BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                                                                                BorderThickness="1"
+                                                                                CornerRadius="4"
+                                                                                Padding="4"
+                                                                                Margin="0,0,6,6">
+                                                                            <TextBlock Text="{Binding}"
+                                                                                       FontSize="12"
+                                                                                       Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                                                                        </Border>
+                                                                    </DataTemplate>
+                                                                </ItemsControl.ItemTemplate>
+                                                            </ItemsControl>
+                                                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                                                <Button Content="{Binding SnippetLabel}"
+                                                                        Visibility="{Binding HasSnippet, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                                        Command="{Binding DataContext.CopyIdeaSnippetCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                        CommandParameter="{Binding}"
+                                                                        Margin="0,0,8,0" />
+                                                                <Button Content="Copy plan"
+                                                                        Command="{Binding DataContext.CopyIdeaPlanCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                        CommandParameter="{Binding}"
+                                                                        Margin="0,0,8,0" />
+                                                                <ItemsControl ItemsSource="{Binding Resources}"
+                                                                              Visibility="{Binding HasResources, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                                    <ItemsControl.ItemsPanel>
+                                                                        <ItemsPanelTemplate>
+                                                                            <StackPanel Orientation="Horizontal" />
+                                                                        </ItemsPanelTemplate>
+                                                                    </ItemsControl.ItemsPanel>
+                                                                    <ItemsControl.ItemTemplate>
+                                                                        <DataTemplate DataType="{x:Type viewModels:IdeaResourceViewModel}">
+                                                                            <Button Content="{Binding Label}"
+                                                                                    Margin="0,0,8,0"
+                                                                                    Command="{Binding DataContext.OpenIdeaResourceCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                                    CommandParameter="{Binding}"
+                                                                                    IsEnabled="{Binding HasUri}" />
+                                                                        </DataTemplate>
+                                                                    </ItemsControl.ItemTemplate>
+                                                                </ItemsControl>
+                                                            </StackPanel>
+                                                        </StackPanel>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </Expander>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+
+            <Border Grid.Row="4"
                     Margin="0,12,0,0"
                     Padding="12"
                     Background="{DynamicResource LibraryPanelSubtleBrush}"


### PR DESCRIPTION
## Summary
- add an OCR/AI idea board partial view model with curated experiments, helper commands, and resource metadata
- initialize the playground view model with the idea board content so analysts can copy snippets and project plans
- extend the WPF playground window with an idea board panel that exposes the new commands and resources

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: installed SDK 8.0.414 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d9570e980c832b8a9e49ab70df4d4a