### PR TITLE
Add interactive ROI OCR tooling to data extraction playground

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="UglyToad.PdfPig.Fonts" Version="1.7.0" />
     <PackageVersion Include="Tabula" Version="0.1.5" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="2.20.0" />
+    <PackageVersion Include="Tesseract" Version="5.2.0" />
 
     <!-- === Microsoft.Extensions family (pin if used anywhere) === -->
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />

--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.IdeaBoard.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.IdeaBoard.cs
@@ -1,0 +1,425 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using CommunityToolkit.Mvvm.Input;
+
+namespace LM.App.Wpf.ViewModels.Library;
+
+internal sealed partial class DataExtractionPlaygroundViewModel
+{
+    [RelayCommand]
+    private void CopyIdeaSnippet(OcrIdeaViewModel? idea)
+    {
+        if (idea is null || !idea.HasSnippet)
+        {
+            return;
+        }
+
+        try
+        {
+            _clipboard.SetText(idea.Snippet);
+            StatusMessage = $"Copied {idea.SnippetLabel} for {idea.Title}.";
+        }
+        catch (Exception ex)
+        {
+            System.Windows.MessageBox.Show(
+                $"Failed to copy snippet:\n{ex.Message}",
+                "Copy idea",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+    }
+
+    [RelayCommand]
+    private void CopyIdeaPlan(OcrIdeaViewModel? idea)
+    {
+        if (idea is null)
+        {
+            return;
+        }
+
+        var plan = idea.BuildPlan();
+        if (string.IsNullOrWhiteSpace(plan))
+        {
+            return;
+        }
+
+        try
+        {
+            _clipboard.SetText(plan);
+            StatusMessage = $"Copied plan for {idea.Title}.";
+        }
+        catch (Exception ex)
+        {
+            System.Windows.MessageBox.Show(
+                $"Failed to copy plan:\n{ex.Message}",
+                "Copy idea",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+    }
+
+    [RelayCommand]
+    private void OpenIdeaResource(IdeaResourceViewModel? resource)
+    {
+        if (resource is null || !resource.HasUri)
+        {
+            return;
+        }
+
+        try
+        {
+            var startInfo = new ProcessStartInfo(resource.Uri!.AbsoluteUri)
+            {
+                UseShellExecute = true
+            };
+
+            Process.Start(startInfo);
+            StatusMessage = $"Opened {resource.Label}.";
+        }
+        catch (Exception ex)
+        {
+            System.Windows.MessageBox.Show(
+                $"Failed to open {resource.Label}:\n{ex.Message}",
+                "Open link",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+    }
+
+    private void PopulateIdeaBoard()
+    {
+        IdeaGroups.Clear();
+
+        var tesseractIdeas = new OcrIdeaGroupViewModel(
+            "Tesseract-first experiments",
+            "Use offline OCR to complement Tabula when tables are scanned or poorly tagged.",
+            new[]
+            {
+                new OcrIdeaViewModel(
+                    "Interactive region OCR",
+                    "Allow analysts to drag a rectangle over the preview and run that fragment through Tesseract.",
+                    new[]
+                    {
+                        "Rasterize the selected PDF page into a bitmap (PdfPig's rendering API or SkiaSharp).",
+                        "Capture the rectangle in page coordinates and crop the bitmap before OCR.",
+                        "Call Tesseract with `PageSegMode.SingleTable` to preserve tab stops.",
+                        "Split the TSV output into rows and feed a new `DataExtractionTableViewModel`."
+                    },
+                    """
+using Tesseract;
+
+using var engine = new TesseractEngine(@"./tessdata", "eng", EngineMode.Default);
+using var pix = Pix.LoadFromFile(pageImagePath);
+using var region = pix.ClipRectangle(new System.Drawing.Rectangle(left, top, width, height));
+using var page = engine.Process(region, PageSegMode.SingleTable);
+
+var tsv = page.GetTsvText();
+var rows = tsv.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+// Map TSV columns 11+ into cells and hydrate a DataTable.
+                    """,
+                    "Copy Tesseract region sample",
+                    new[] { "Offline", "Tables", "Interactive" },
+                    new[]
+                    {
+                        new IdeaResourceViewModel("Tesseract docs", "https://tesseract-ocr.github.io/tessdoc/"),
+                        new IdeaResourceViewModel("Tesseract .NET", "https://github.com/charlesw/tesseract")
+                    }),
+                new OcrIdeaViewModel(
+                    "Hybrid lattice + OCR",
+                    "Keep Tabula for grid detection but validate each cell with OCR to clean noisy scans.",
+                    new[]
+                    {
+                        "Run the existing lattice detector to get bounding boxes per cell.",
+                        "Rasterize only the detected cells and send them through a shared Tesseract engine instance.",
+                        "Replace low-confidence cells with OCR text and emit confidence scores to the grid.",
+                        "Highlight suspicious cells in the preview with a semi-transparent overlay."
+                    },
+                    """
+var engine = OcrEnginePool.Rent();
+foreach (var cell in detectedCells)
+{
+    using var pix = Pix.LoadFromMemory(cell.ImageBytes);
+    using var page = engine.Process(pix, PageSegMode.SingleBlock);
+    if (page.TryGetMeanConfidence(out var confidence) && confidence < 85)
+    {
+        cell.MarkAsLowConfidence();
+    }
+
+    cell.Text = page.GetText();
+}
+                    """,
+                    "Copy confidence blending sample",
+                    new[] { "Quality", "Confidence", "Automation" },
+                    Array.Empty<IdeaResourceViewModel>()),
+                new OcrIdeaViewModel(
+                    "Train a table-specific language pack",
+                    "Fine-tune Tesseract to the typography of recurring reports and share the traineddata in the workspace.",
+                    new[]
+                    {
+                        "Collect cropped cell images plus the ground truth text while analysts correct results.",
+                        "Generate box files with jTessBoxEditor and train a custom `.traineddata` file.",
+                        "Ship the model under `.knowledgeworks/tessdata` and auto-sync via the library."
+                    },
+                    null,
+                    null,
+                    new[] { "Customization", "Model", "Shared" },
+                    new[]
+                    {
+                        new IdeaResourceViewModel("Training walkthrough", "https://github.com/tesseract-ocr/tesseract/wiki/TrainingTesseract-5")
+                    })
+            });
+
+        var cloudIdeas = new OcrIdeaGroupViewModel(
+            "Cloud document intelligence",
+            "Tap managed OCR/AI services when latency and network policies allow it.",
+            new[]
+            {
+                new OcrIdeaViewModel(
+                    "Azure Document Intelligence tables",
+                    "Send pages to the prebuilt layout model and stream back structured tables with coordinates.",
+                    new[]
+                    {
+                        "Use `DocumentAnalysisClient` with a SAS token sourced from the hub.",
+                        "Cache the analysis JSON inside the entry so replays are instant.",
+                        "Convert table spans to `DataExtractionTableViewModel` while preserving row/column spans.",
+                        "Fallback to Tabula when the service is offline or rate-limited."
+                    },
+                    """
+using Azure;
+using Azure.AI.FormRecognizer.DocumentAnalysis;
+
+var client = new DocumentAnalysisClient(new Uri(endpoint), new AzureKeyCredential(key));
+AnalyzeDocumentOperation op = await client.AnalyzeDocumentFromUriAsync(WaitUntil.Completed, "prebuilt-layout", pdfUri);
+foreach (var table in op.Value.Tables)
+{
+    // Map table.Cells into your view model, using table.Cells[i].RowSpan etc.
+}
+                    """,
+                    "Copy Azure layout sample",
+                    new[] { "Azure", "Managed", "JSON" },
+                    new[]
+                    {
+                        new IdeaResourceViewModel("Azure setup", "https://learn.microsoft.com/azure/ai-services/document-intelligence/overview"),
+                        new IdeaResourceViewModel("SDK docs", "https://learn.microsoft.com/dotnet/api/azure.ai.formrecognizer")
+                    }),
+                new OcrIdeaViewModel(
+                    "AWS Textract for forms",
+                    "Leverage Textract AnalyzeDocument to pull tables and key-value pairs simultaneously.",
+                    new[]
+                    {
+                        "Stream PDF bytes via S3 or byte[] to Textract's async API.",
+                        "Persist job IDs on the entry hook and poll status with exponential backoff.",
+                        "Use the geometry metadata to anchor extracted values back onto the preview overlay."
+                    },
+                    null,
+                    null,
+                    new[] { "AWS", "Async", "Overlays" },
+                    new[]
+                    {
+                        new IdeaResourceViewModel("Textract tables", "https://docs.aws.amazon.com/textract/latest/dg/how-it-works-tables.html")
+                    }),
+                new OcrIdeaViewModel(
+                    "Bring-your-own LLM post-check",
+                    "Send the raw OCR grid to a hosted LLM to normalize headers, units, and totals.",
+                    new[]
+                    {
+                        "Compose a prompt with the TSV payload and ask for JSON-formatted corrections.",
+                        "Validate numeric totals locally before applying changes.",
+                        "Log adjustments through the changelog hook for traceability."
+                    },
+                    """
+var prompt = $$"""
+You are cleaning an OCR table. Return strict JSON with fields rows, warnings.
+
+{tsv}
+"""$$;
+
+var response = await openAiClient.GetChatCompletionsAsync(deploymentId, new ChatCompletionsOptions
+{
+    Messages =
+    {
+        new ChatRequestSystemMessage("Normalize table headers and units"),
+        new ChatRequestUserMessage(prompt)
+    }
+});
+                    """,
+                    "Copy LLM normalization sample",
+                    new[] { "LLM", "Validation", "Normalization" },
+                    Array.Empty<IdeaResourceViewModel>())
+            });
+
+        var automationIdeas = new OcrIdeaGroupViewModel(
+            "Automation & QA",
+            "Wrap OCR with tooling so analysts can trust the results.",
+            new[]
+            {
+                new OcrIdeaViewModel(
+                    "Versioned extraction recipes",
+                    "Store playground presets (mode, detector, OCR toggles) in the workspace so teams can replay them.",
+                    new[]
+                    {
+                        "Serialize the current playground settings into YAML alongside the entry.",
+                        "Add a toolbar to load/save recipes and compare outputs with diff tooling.",
+                        "Write every replay to the changelog hook with the recipe identifier."
+                    },
+                    null,
+                    null,
+                    new[] { "Repeatable", "Presets", "Collaboration" },
+                    Array.Empty<IdeaResourceViewModel>()),
+                new OcrIdeaViewModel(
+                    "Confidence heatmaps",
+                    "Overlay a color-coded heatmap on the PDF preview based on OCR confidence and Tabula heuristics.",
+                    new[]
+                    {
+                        "Project OCR bounding boxes back to PDF coordinates.",
+                        "Blend them over the WebBrowser host using a transparent Canvas.",
+                        "Expose filters to hide low-risk areas so reviewers focus on the outliers."
+                    },
+                    null,
+                    null,
+                    new[] { "UX", "Visualization", "QA" },
+                    Array.Empty<IdeaResourceViewModel>()),
+                new OcrIdeaViewModel(
+                    "Automated reconciliation",
+                    "Compare extracted totals against ledger data or previously ingested entries to flag drifts.",
+                    new[]
+                    {
+                        "Cross-match numeric columns with known control totals from the knowledge graph.",
+                        "Trigger a review task when deltas exceed configured tolerances.",
+                        "Persist the reconciliation result back into the hook metadata for auditing."
+                    },
+                    null,
+                    null,
+                    new[] { "Controls", "Monitoring", "Hooks" },
+                    Array.Empty<IdeaResourceViewModel>())
+            });
+
+        IdeaGroups.Add(tesseractIdeas);
+        IdeaGroups.Add(cloudIdeas);
+        IdeaGroups.Add(automationIdeas);
+
+        OnPropertyChanged(nameof(HasIdeaGroups));
+    }
+}
+
+internal sealed class OcrIdeaGroupViewModel
+{
+    public OcrIdeaGroupViewModel(string title, string description, IEnumerable<OcrIdeaViewModel> ideas)
+    {
+        Title = title;
+        Description = description;
+        Ideas = new ObservableCollection<OcrIdeaViewModel>((ideas ?? Array.Empty<OcrIdeaViewModel>()).ToList());
+    }
+
+    public string Title { get; }
+
+    public string Description { get; }
+
+    public ObservableCollection<OcrIdeaViewModel> Ideas { get; }
+}
+
+internal sealed class OcrIdeaViewModel
+{
+    private readonly string? _snippetLabel;
+
+    public OcrIdeaViewModel(string title,
+                            string summary,
+                            IEnumerable<string> steps,
+                            string? snippet,
+                            string? snippetLabel,
+                            IEnumerable<string>? tags,
+                            IEnumerable<IdeaResourceViewModel>? resources)
+    {
+        Title = title;
+        Summary = summary;
+
+        var stepList = steps?.Where(step => !string.IsNullOrWhiteSpace(step)).Select(step => step.Trim()).ToList()
+                       ?? new List<string>();
+        Steps = new ReadOnlyCollection<string>(stepList);
+
+        Snippet = snippet?.TrimEnd() ?? string.Empty;
+        _snippetLabel = snippetLabel;
+
+        var tagList = tags?.Where(tag => !string.IsNullOrWhiteSpace(tag)).Select(tag => tag.Trim()).ToList()
+                     ?? new List<string>();
+        Tags = new ReadOnlyCollection<string>(tagList);
+
+        var resourceList = resources?.Where(resource => resource is not null).ToList()
+                          ?? new List<IdeaResourceViewModel>();
+        Resources = new ObservableCollection<IdeaResourceViewModel>(resourceList);
+    }
+
+    public string Title { get; }
+
+    public string Summary { get; }
+
+    public ReadOnlyCollection<string> Steps { get; }
+
+    public string Snippet { get; }
+
+    public bool HasSnippet => !string.IsNullOrWhiteSpace(Snippet);
+
+    public bool HasSteps => Steps.Count > 0;
+
+    public string SnippetLabel => string.IsNullOrWhiteSpace(_snippetLabel) ? "Copy sample code" : _snippetLabel!;
+
+    public ReadOnlyCollection<string> Tags { get; }
+
+    public ObservableCollection<IdeaResourceViewModel> Resources { get; }
+
+    public bool HasResources => Resources.Count > 0;
+
+    public bool HasTags => Tags.Count > 0;
+
+    public string BuildPlan()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(Title);
+
+        if (!string.IsNullOrWhiteSpace(Summary))
+        {
+            builder.AppendLine(Summary);
+        }
+
+        if (Steps.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("Execution checklist:");
+            foreach (var step in Steps)
+            {
+                builder.AppendLine($"- {step}");
+            }
+        }
+
+        if (Tags.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine($"Tags: {string.Join(", ", Tags)}");
+        }
+
+        return builder.ToString().Trim();
+    }
+}
+
+internal sealed class IdeaResourceViewModel
+{
+    public IdeaResourceViewModel(string label, string url)
+    {
+        Label = label;
+        if (Uri.TryCreate(url, UriKind.Absolute, out var parsed))
+        {
+            Uri = parsed;
+        }
+    }
+
+    public string Label { get; }
+
+    public Uri? Uri { get; }
+
+    public bool HasUri => Uri is not null;
+}
+

--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.Preview.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.Preview.cs
@@ -1,0 +1,526 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using LM.Core.Models;
+using LM.Infrastructure.Hooks;
+using Tesseract;
+using UglyToad.PdfPig;
+using UglyToad.PdfPig.Content;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.ViewModels.Library;
+
+internal sealed partial class DataExtractionPlaygroundViewModel
+{
+    private readonly RoiSelectionViewModel _roiSelection = new();
+    private System.Windows.Point? _selectionStart;
+    private System.Windows.Media.Imaging.RenderTargetBitmap? _currentPageBitmap;
+    private int _ocrRegionCounter = 1;
+
+    [ObservableProperty]
+    private System.Windows.Media.Imaging.BitmapSource? previewBitmap;
+
+    [ObservableProperty]
+    private bool isPreviewBusy;
+
+    [ObservableProperty]
+    private string previewStatusMessage = "Select a page to render.";
+
+    [ObservableProperty]
+    private int? selectedPreviewPage;
+
+    public RoiSelectionViewModel RoiSelection => _roiSelection;
+
+    public bool HasPreview => PreviewBitmap is not null;
+
+    public double PreviewWidth => PreviewBitmap?.PixelWidth ?? 0;
+
+    public double PreviewHeight => PreviewBitmap?.PixelHeight ?? 0;
+
+    partial void InitializePreviewState()
+    {
+        _roiSelection.PropertyChanged += (_, _) => RunRegionOcrCommand.NotifyCanExecuteChanged();
+        PreviewStatusMessage = "Select a page to render.";
+    }
+
+    partial void ResetPreviewState()
+    {
+        _ocrRegionCounter = 1;
+        _selectionStart = null;
+        _currentPageBitmap = null;
+        PreviewBitmap = null;
+        SelectedPreviewPage = null;
+        PreviewStatusMessage = "Select a page to render.";
+        _roiSelection.Clear();
+        PreviewPages.Clear();
+        RunRegionOcrCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void ApplyPreviewPages(IReadOnlyList<int> pages)
+    {
+        PreviewPages.Clear();
+        foreach (var page in pages)
+        {
+            PreviewPages.Add(page);
+        }
+
+        if (PreviewPages.Count > 0)
+        {
+            SelectedPreviewPage = PreviewPages[0];
+        }
+        else
+        {
+            SelectedPreviewPage = null;
+            PreviewStatusMessage = "No renderable pages were detected.";
+        }
+    }
+
+    partial void OnPreviewBitmapChanged(System.Windows.Media.Imaging.BitmapSource? value)
+    {
+        OnPropertyChanged(nameof(PreviewWidth));
+        OnPropertyChanged(nameof(PreviewHeight));
+        OnPropertyChanged(nameof(HasPreview));
+        RunRegionOcrCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnSelectedPreviewPageChanged(int? value)
+    {
+        if (!value.HasValue)
+        {
+            return;
+        }
+
+        _ = LoadPreviewAsync(value.Value);
+    }
+
+    partial void OnIsBusyChanged(bool value)
+    {
+        RunRegionOcrCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnIsPreviewBusyChanged(bool value)
+    {
+        RunRegionOcrCommand.NotifyCanExecuteChanged();
+    }
+
+    public async Task LoadPreviewAsync(int pageNumber)
+    {
+        if (_pdfPath is null || IsPreviewBusy)
+        {
+            return;
+        }
+
+        IsPreviewBusy = true;
+        PreviewStatusMessage = $"Rendering page {pageNumber}...";
+        _roiSelection.Clear();
+        _selectionStart = null;
+
+        try
+        {
+            await Task.Yield();
+            using var document = PdfDocument.Open(_pdfPath, new ParsingOptions { ClipPaths = true, UseLenientParsing = true });
+            var page = document.GetPage(pageNumber);
+            _currentPageBitmap = RenderPageBitmap(page);
+            PreviewBitmap = _currentPageBitmap;
+            PreviewStatusMessage = $"Preview ready for page {pageNumber}. Drag to select a region.";
+        }
+        catch (Exception ex)
+        {
+            PreviewBitmap = null;
+            PreviewStatusMessage = $"Failed to render page {pageNumber}.";
+            System.Windows.MessageBox.Show(
+                $"Failed to render page {pageNumber}:{Environment.NewLine}{ex.Message}",
+                "Page preview",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Warning);
+        }
+        finally
+        {
+            IsPreviewBusy = false;
+            RunRegionOcrCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    public void BeginRegionSelection(System.Windows.Point point)
+    {
+        if (!HasPreview || IsPreviewBusy)
+        {
+            return;
+        }
+
+        var clamped = ClampPoint(point);
+        _selectionStart = clamped;
+        _roiSelection.Begin(clamped);
+        RunRegionOcrCommand.NotifyCanExecuteChanged();
+    }
+
+    public void UpdateRegionSelection(System.Windows.Point point)
+    {
+        if (_selectionStart is null || !_roiSelection.IsSelecting)
+        {
+            return;
+        }
+
+        var rect = NormalizeRect(_selectionStart.Value, ClampPoint(point));
+        _roiSelection.Update(rect);
+    }
+
+    public void CompleteRegionSelection(System.Windows.Point point)
+    {
+        if (_selectionStart is null || !_roiSelection.IsSelecting)
+        {
+            return;
+        }
+
+        var rect = NormalizeRect(_selectionStart.Value, ClampPoint(point));
+        if (rect.Width < 4 || rect.Height < 4)
+        {
+            CancelRegionSelection();
+            return;
+        }
+
+        _roiSelection.Complete(rect);
+        _selectionStart = null;
+        RunRegionOcrCommand.NotifyCanExecuteChanged();
+    }
+
+    public void CancelRegionSelection()
+    {
+        _selectionStart = null;
+        _roiSelection.Clear();
+        RunRegionOcrCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand]
+    private void ClearRegionSelection()
+    {
+        CancelRegionSelection();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRunRegionOcr))]
+    private async Task RunRegionOcrAsync()
+    {
+        if (!RoiSelection.HasSelection || _currentPageBitmap is null || !SelectedPreviewPage.HasValue)
+        {
+            return;
+        }
+
+        var region = RoiSelection.GetSelectionRect();
+        var cropped = CreateCrop(region);
+        if (cropped is null)
+        {
+            System.Windows.MessageBox.Show(
+                "Selected region is outside the rendered page.",
+                "Region OCR",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Information);
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            PreviewStatusMessage = "Running OCR on selection...";
+            StatusMessage = "Running OCR on selection...";
+
+            var ocrResult = await RecognizeRegionAsync(cropped.Value).ConfigureAwait(true);
+            if (ocrResult is null)
+            {
+                StatusMessage = "OCR returned no content.";
+                PreviewStatusMessage = "OCR returned no content.";
+                return;
+            }
+
+            var regionIndex = _ocrRegionCounter++;
+            var table = DataExtractionTableViewModel.FromOcrRegion(
+                SelectedPreviewPage.Value,
+                regionIndex,
+                ocrResult.Rows);
+
+            Tables.Add(table);
+            SelectedTable = table;
+            RefreshSelectedTableView();
+            OnPropertyChanged(nameof(HasResults));
+            CopyTableCommand.NotifyCanExecuteChanged();
+            StatusMessage = $"OCR region {regionIndex} captured {ocrResult.Rows.Count} rows across {ocrResult.ColumnCount} columns (confidence {ocrResult.Confidence:F0}%).";
+            PreviewStatusMessage = "Region OCR complete.";
+
+            await WriteRegionOcrChangeLogAsync(
+                SelectedPreviewPage.Value,
+                region,
+                ocrResult.Rows.Count,
+                ocrResult.ColumnCount,
+                ocrResult.Confidence).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex)
+        {
+            StatusMessage = "OCR not configured.";
+            PreviewStatusMessage = ex.Message;
+            System.Windows.MessageBox.Show(
+                ex.Message,
+                "Region OCR",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Warning);
+        }
+        catch (DllNotFoundException ex)
+        {
+            StatusMessage = "OCR runtime missing.";
+            PreviewStatusMessage = ex.Message;
+            System.Windows.MessageBox.Show(
+                $"Failed to load Tesseract runtime:{Environment.NewLine}{ex.Message}",
+                "Region OCR",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+        catch (TesseractException ex)
+        {
+            StatusMessage = "OCR failed.";
+            PreviewStatusMessage = ex.Message;
+            System.Windows.MessageBox.Show(
+                $"Tesseract failed to process the selection:{Environment.NewLine}{ex.Message}",
+                "Region OCR",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = "OCR failed.";
+            PreviewStatusMessage = "OCR failed.";
+            System.Windows.MessageBox.Show(
+                $"Unexpected OCR failure:{Environment.NewLine}{ex.Message}",
+                "Region OCR",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+        finally
+        {
+            IsBusy = false;
+            RunRegionOcrCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    private bool CanRunRegionOcr()
+    {
+        return !IsBusy && !IsPreviewBusy && RoiSelection.HasSelection && PreviewBitmap is not null && SelectedPreviewPage.HasValue;
+    }
+
+    private System.Windows.Point ClampPoint(System.Windows.Point point)
+    {
+        var width = PreviewWidth;
+        var height = PreviewHeight;
+        var x = Math.Max(0, Math.Min(width, point.X));
+        var y = Math.Max(0, Math.Min(height, point.Y));
+        return new System.Windows.Point(x, y);
+    }
+
+    private static System.Windows.Rect NormalizeRect(System.Windows.Point start, System.Windows.Point end)
+    {
+        var x = Math.Min(start.X, end.X);
+        var y = Math.Min(start.Y, end.Y);
+        var width = Math.Abs(end.X - start.X);
+        var height = Math.Abs(end.Y - start.Y);
+        return new System.Windows.Rect(x, y, width, height);
+    }
+
+    private System.Windows.Int32Rect? CreateCrop(System.Windows.Rect rect)
+    {
+        if (_currentPageBitmap is null)
+        {
+            return null;
+        }
+
+        var x = (int)Math.Max(0, Math.Floor(rect.X));
+        var y = (int)Math.Max(0, Math.Floor(rect.Y));
+        var width = (int)Math.Min(_currentPageBitmap.PixelWidth - x, Math.Ceiling(rect.Width));
+        var height = (int)Math.Min(_currentPageBitmap.PixelHeight - y, Math.Ceiling(rect.Height));
+
+        if (width <= 0 || height <= 0)
+        {
+            return null;
+        }
+
+        return new System.Windows.Int32Rect(x, y, width, height);
+    }
+
+    private async Task<OcrRegionTableResult?> RecognizeRegionAsync(System.Windows.Int32Rect crop)
+    {
+        if (_currentPageBitmap is null)
+        {
+            return null;
+        }
+
+        var encoder = new System.Windows.Media.Imaging.PngBitmapEncoder();
+        var cropped = new System.Windows.Media.Imaging.CroppedBitmap(_currentPageBitmap, crop);
+        cropped.Freeze();
+        encoder.Frames.Add(System.Windows.Media.Imaging.BitmapFrame.Create(cropped));
+
+        await using var memory = new MemoryStream();
+        encoder.Save(memory);
+        var bytes = memory.ToArray();
+
+        return await Task.Run(() => ExecuteTesseract(bytes)).ConfigureAwait(false);
+    }
+
+    private OcrRegionTableResult? ExecuteTesseract(byte[] image)
+    {
+        var tessData = ResolveTessDataDirectory();
+        if (tessData is null)
+        {
+            throw new InvalidOperationException(
+                "Tesseract data directory was not found. Configure 'tessdata' under the workspace or set TESSDATA_PREFIX.");
+        }
+
+        using var engine = new TesseractEngine(tessData, "eng", EngineMode.Default);
+        using var pix = Pix.LoadFromMemory(image);
+        using var page = engine.Process(pix, PageSegMode.Table);
+
+        var tsv = page.GetTsvText();
+        var table = TesseractTableBuilder.Build(tsv);
+        if (table.ColumnCount == 0)
+        {
+            var text = page.GetText();
+            var lines = text.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            table = TesseractTableBuilder.FromPlainText(lines);
+        }
+
+        if (table.ColumnCount == 0)
+        {
+            return null;
+        }
+
+        var confidence = page.TryGetMeanConfidence(out var conf) ? conf : 0;
+        return new OcrRegionTableResult(table.Rows, table.ColumnCount, confidence);
+    }
+
+    private static System.Windows.Media.Imaging.RenderTargetBitmap RenderPageBitmap(Page page)
+    {
+        const double targetDpi = 144d;
+        var scale = targetDpi / 72d;
+        var pixelWidth = Math.Max(1, (int)Math.Ceiling(page.Width * scale));
+        var pixelHeight = Math.Max(1, (int)Math.Ceiling(page.Height * scale));
+
+        var visual = new System.Windows.Media.DrawingVisual();
+        using (var context = visual.RenderOpen())
+        {
+            context.DrawRectangle(System.Windows.Media.Brushes.White, null, new System.Windows.Rect(0, 0, pixelWidth, pixelHeight));
+            var typeface = new System.Windows.Media.Typeface("Segoe UI");
+
+            foreach (var letter in page.Letters)
+            {
+                if (string.IsNullOrWhiteSpace(letter.Value))
+                {
+                    continue;
+                }
+
+                var fontSize = Math.Max(letter.PointSize * scale, 6);
+                var formatted = new System.Windows.Media.FormattedText(
+                    letter.Value,
+                    CultureInfo.InvariantCulture,
+                    System.Windows.FlowDirection.LeftToRight,
+                    typeface,
+                    fontSize,
+                    System.Windows.Media.Brushes.Black,
+                    1.0);
+
+                var x = letter.GlyphRectangle.Left * scale;
+                var y = (page.Height - letter.GlyphRectangle.Top) * scale;
+                context.DrawText(formatted, new System.Windows.Point(x, y));
+            }
+        }
+
+        var bitmap = new System.Windows.Media.Imaging.RenderTargetBitmap(
+            pixelWidth,
+            pixelHeight,
+            targetDpi,
+            targetDpi,
+            System.Windows.Media.PixelFormats.Pbgra32);
+
+        bitmap.Render(visual);
+        bitmap.Freeze();
+        return bitmap;
+    }
+
+    private string? ResolveTessDataDirectory()
+    {
+        var candidates = new List<string?>
+        {
+            Environment.GetEnvironmentVariable("TESSDATA_PREFIX"),
+            _workspace.WorkspacePath is null ? null : Path.Combine(_workspace.WorkspacePath, ".knowledgeworks", "tessdata"),
+            _workspace.WorkspacePath is null ? null : Path.Combine(_workspace.WorkspacePath, "tessdata"),
+            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tessdata")
+        };
+
+        foreach (var candidate in candidates)
+        {
+            if (!string.IsNullOrWhiteSpace(candidate) && Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private async Task WriteRegionOcrChangeLogAsync(int pageNumber,
+                                                    System.Windows.Rect selection,
+                                                    int rows,
+                                                    int columns,
+                                                    double confidence)
+    {
+        if (_entryId is null)
+        {
+            return;
+        }
+
+        var tags = new List<string>
+        {
+            "mode:OcrRegion",
+            $"page:{pageNumber}",
+            $"rows:{rows}",
+            $"columns:{columns}",
+            $"confidence:{confidence.ToString("F0", CultureInfo.InvariantCulture)}",
+            $"roi:{selection.X.ToString("F0", CultureInfo.InvariantCulture)}-{selection.Y.ToString("F0", CultureInfo.InvariantCulture)}-{selection.Width.ToString("F0", CultureInfo.InvariantCulture)}-{selection.Height.ToString("F0", CultureInfo.InvariantCulture)}"
+        };
+
+        var hook = new HookM.EntryChangeLogHook
+        {
+            Events = new List<HookM.EntryChangeLogEvent>
+            {
+                new()
+                {
+                    EventId = Guid.NewGuid().ToString("N"),
+                    TimestampUtc = DateTime.UtcNow,
+                    PerformedBy = GetCurrentUser(),
+                    Action = "DataExtractionRegionOcr",
+                    Details = new HookM.ChangeLogAttachmentDetails
+                    {
+                        Title = DocumentTitle,
+                        LibraryPath = NormalizeLibraryPath(_pdfRelativePath ?? _pdfPath),
+                        Purpose = AttachmentKind.Metadata,
+                        AttachmentId = _pdfAttachmentId ?? string.Empty,
+                        Tags = tags
+                    }
+                }
+            }
+        };
+
+        try
+        {
+            await _hookOrchestrator.ProcessAsync(
+                _entryId,
+                new HookContext { ChangeLog = hook },
+                System.Threading.CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Ignore hook failures.
+        }
+    }
+
+    private sealed record OcrRegionTableResult(IReadOnlyList<IReadOnlyList<string>> Rows, int ColumnCount, double Confidence);
+}

--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.cs
@@ -31,6 +31,8 @@ internal sealed partial class DataExtractionPlaygroundViewModel : ViewModelBase
     private string? _pdfRelativePath;
     private string? _pdfAttachmentId;
 
+    partial void InitializePreviewState();
+
     public DataExtractionPlaygroundViewModel(HookOrchestrator hookOrchestrator,
                                              IWorkSpaceService workspace,
                                              IClipboardService clipboard)
@@ -61,6 +63,12 @@ internal sealed partial class DataExtractionPlaygroundViewModel : ViewModelBase
         HeaderRowOptions = new ObservableCollection<TableRowOption>();
         RemoveEmptyColumns = true;
         MergeSignColumns = true;
+
+        PreviewPages = new ObservableCollection<int>();
+        InitializePreviewState();
+        IdeaGroups = new ObservableCollection<OcrIdeaGroupViewModel>();
+        PopulateIdeaBoard();
+        OnPropertyChanged(nameof(HasIdeaGroups));
     }
 
     public IReadOnlyList<ExtractionModeOption> ModeOptions { get; }
@@ -113,6 +121,12 @@ internal sealed partial class DataExtractionPlaygroundViewModel : ViewModelBase
 
     public ObservableCollection<TableRowOption> HeaderRowOptions { get; }
 
+    public ObservableCollection<OcrIdeaGroupViewModel> IdeaGroups { get; }
+
+    public ObservableCollection<int> PreviewPages { get; }
+
+    public bool HasIdeaGroups => IdeaGroups.Count > 0;
+
     public bool HasResults => Tables.Count > 0;
 
     public bool HasPdf => PdfSource is not null;
@@ -162,6 +176,7 @@ internal sealed partial class DataExtractionPlaygroundViewModel : ViewModelBase
         {
             PageSelection = pageIndexes[0].ToString();
         }
+        ApplyPreviewPages(pageIndexes);
 
         StatusMessage = "Configure options and select Extract tables to begin.";
         Tables.Clear();
@@ -589,6 +604,8 @@ internal sealed partial class DataExtractionPlaygroundViewModel : ViewModelBase
         return path.Replace("\\", "/");
     }
 
+    partial void ApplyPreviewPages(IReadOnlyList<int> pages);
+
     private void ResetState()
     {
         Tables.Clear();
@@ -607,6 +624,7 @@ internal sealed partial class DataExtractionPlaygroundViewModel : ViewModelBase
         RemoveEmptyColumns = true;
         MergeSignColumns = true;
 
+        ResetPreviewState();
         OnPropertyChanged(nameof(HasResults));
         OnPropertyChanged(nameof(HasPdf));
         OnPropertyChanged(nameof(CanCopyTable));
@@ -614,6 +632,8 @@ internal sealed partial class DataExtractionPlaygroundViewModel : ViewModelBase
         ExtractTablesCommand.NotifyCanExecuteChanged();
         CopyTableCommand.NotifyCanExecuteChanged();
     }
+
+    partial void ResetPreviewState();
 
     private PdfSourceInfo? ResolvePdfSource(Entry entry)
     {

--- a/src/LM.App.Wpf/ViewModels/Library/RoiSelectionViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/RoiSelectionViewModel.cs
@@ -1,0 +1,87 @@
+#nullable enable
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace LM.App.Wpf.ViewModels.Library;
+
+internal sealed partial class RoiSelectionViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool isSelecting;
+
+    [ObservableProperty]
+    private bool hasSelection;
+
+    [ObservableProperty]
+    private double x;
+
+    [ObservableProperty]
+    private double y;
+
+    [ObservableProperty]
+    private double width;
+
+    [ObservableProperty]
+    private double height;
+
+    public bool HasVisibleSelection => IsSelecting || HasSelection;
+
+    partial void OnIsSelectingChanged(bool value)
+    {
+        OnPropertyChanged(nameof(HasVisibleSelection));
+    }
+
+    partial void OnHasSelectionChanged(bool value)
+    {
+        OnPropertyChanged(nameof(HasVisibleSelection));
+    }
+
+    public void Begin(System.Windows.Point start)
+    {
+        IsSelecting = true;
+        HasSelection = false;
+        X = start.X;
+        Y = start.Y;
+        Width = 0;
+        Height = 0;
+    }
+
+    public void Update(System.Windows.Rect rect)
+    {
+        if (!IsSelecting)
+        {
+            return;
+        }
+
+        X = rect.X;
+        Y = rect.Y;
+        Width = rect.Width;
+        Height = rect.Height;
+    }
+
+    public void Complete(System.Windows.Rect rect)
+    {
+        if (!IsSelecting)
+        {
+            return;
+        }
+
+        Update(rect);
+        IsSelecting = false;
+        HasSelection = rect.Width >= 4 && rect.Height >= 4;
+    }
+
+    public void Clear()
+    {
+        IsSelecting = false;
+        HasSelection = false;
+        X = 0;
+        Y = 0;
+        Width = 0;
+        Height = 0;
+    }
+
+    public System.Windows.Rect GetSelectionRect()
+    {
+        return new System.Windows.Rect(X, Y, Width, Height);
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Library/TesseractTableBuilder.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/TesseractTableBuilder.cs
@@ -1,0 +1,177 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace LM.App.Wpf.ViewModels.Library;
+
+internal static class TesseractTableBuilder
+{
+    internal static TesseractTableResult Build(string? tsv)
+    {
+        if (string.IsNullOrWhiteSpace(tsv))
+        {
+            return new TesseractTableResult(new List<IReadOnlyList<string>>(), 0);
+        }
+
+        var lines = tsv.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length <= 1)
+        {
+            return new TesseractTableResult(new List<IReadOnlyList<string>>(), 0);
+        }
+
+        var words = new List<TesseractWord>();
+        for (var i = 1; i < lines.Length; i++)
+        {
+            var columns = lines[i].Split('\t');
+            if (columns.Length < 12)
+            {
+                continue;
+            }
+
+            if (!int.TryParse(columns[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out var line))
+            {
+                continue;
+            }
+
+            if (!int.TryParse(columns[6], NumberStyles.Integer, CultureInfo.InvariantCulture, out var left))
+            {
+                continue;
+            }
+
+            if (!int.TryParse(columns[8], NumberStyles.Integer, CultureInfo.InvariantCulture, out var width))
+            {
+                continue;
+            }
+
+            var text = columns[11].Trim();
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                continue;
+            }
+
+            words.Add(new TesseractWord(line, left, width, text));
+        }
+
+        if (words.Count == 0)
+        {
+            return new TesseractTableResult(new List<IReadOnlyList<string>>(), 0);
+        }
+
+        var averageWidth = words.Average(static w => w.Width);
+        var gapThreshold = Math.Max(12, averageWidth * 1.25);
+        var rows = new List<IReadOnlyList<string>>();
+
+        foreach (var group in words.GroupBy(static w => w.Line).OrderBy(static g => g.Key))
+        {
+            var sorted = group.OrderBy(static w => w.Left).ToList();
+            var columns = new List<string>();
+            var buffer = new StringBuilder();
+            int? previousRight = null;
+
+            foreach (var word in sorted)
+            {
+                if (previousRight.HasValue && word.Left - previousRight.Value > gapThreshold)
+                {
+                    columns.Add(buffer.ToString().Trim());
+                    buffer.Clear();
+                }
+
+                if (buffer.Length > 0)
+                {
+                    buffer.Append(' ');
+                }
+
+                buffer.Append(word.Text);
+                previousRight = word.Left + word.Width;
+            }
+
+            if (buffer.Length > 0)
+            {
+                columns.Add(buffer.ToString().Trim());
+            }
+
+            if (columns.Count == 0)
+            {
+                columns.Add(string.Join(' ', sorted.Select(static w => w.Text))); 
+            }
+
+            rows.Add(columns);
+        }
+
+        return Normalize(rows);
+    }
+
+    internal static TesseractTableResult FromPlainText(IEnumerable<string> lines)
+    {
+        var materialized = lines?.Select(static line => line?.Trim() ?? string.Empty)
+            .Where(static line => !string.IsNullOrWhiteSpace(line))
+            .ToList() ?? new List<string>();
+
+        if (materialized.Count == 0)
+        {
+            return new TesseractTableResult(new List<IReadOnlyList<string>>(), 0);
+        }
+
+        var rows = new List<IReadOnlyList<string>>(materialized.Count);
+        foreach (var line in materialized)
+        {
+            var segments = line.Split('\t');
+            if (segments.Length == 0)
+            {
+                rows.Add(new[] { line });
+                continue;
+            }
+
+            rows.Add(segments.Select(static segment => segment.Trim()).ToList());
+        }
+
+        return Normalize(rows);
+    }
+
+    private static TesseractTableResult Normalize(IReadOnlyList<IReadOnlyList<string>> source)
+    {
+        if (source.Count == 0)
+        {
+            return new TesseractTableResult(new List<IReadOnlyList<string>>(), 0);
+        }
+
+        var maxColumns = source.Max(static row => row?.Count ?? 0);
+        if (maxColumns == 0)
+        {
+            maxColumns = 1;
+        }
+
+        var rows = new List<IReadOnlyList<string>>(source.Count);
+        foreach (var row in source)
+        {
+            if (row is null)
+            {
+                rows.Add(Enumerable.Repeat(string.Empty, maxColumns).ToArray());
+                continue;
+            }
+
+            if (row.Count == maxColumns)
+            {
+                rows.Add(row.ToArray());
+                continue;
+            }
+
+            var values = new List<string>(row);
+            while (values.Count < maxColumns)
+            {
+                values.Add(string.Empty);
+            }
+
+            rows.Add(values);
+        }
+
+        return new TesseractTableResult(rows, maxColumns);
+    }
+
+    private sealed record TesseractWord(int Line, int Left, int Width, string Text);
+}
+
+internal sealed record TesseractTableResult(IReadOnlyList<IReadOnlyList<string>> Rows, int ColumnCount);

--- a/src/LM.App.Wpf/Views/Library/DataExtractionPlaygroundWindow.xaml
+++ b/src/LM.App.Wpf/Views/Library/DataExtractionPlaygroundWindow.xaml
@@ -13,13 +13,16 @@
         WindowStartupLocation="CenterOwner"
         MinHeight="600"
         MinWidth="960">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </Window.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="3*" MinWidth="360" />
             <ColumnDefinition Width="4*" MinWidth="480" />
         </Grid.ColumnDefinitions>
 
-        <!-- PDF preview -->
+        <!-- PDF preview and ROI selection -->
         <Border Grid.Column="0"
                 Margin="16"
                 Padding="0"
@@ -27,20 +30,97 @@
                 BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
                 BorderThickness="1">
             <Grid>
-                <TextBlock Text="PDF preview"
-                           FontSize="16"
-                           FontWeight="SemiBold"
-                           Margin="12"
-                           HorizontalAlignment="Left"
-                           VerticalAlignment="Top" />
-                <Border Margin="12,40,12,12"
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <StackPanel Grid.Row="0" Margin="12">
+                    <TextBlock Text="PDF preview &amp; ROI"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource LibraryPrimaryForegroundBrush}" />
+                    <TextBlock Text="Select a page, drag a region, and run OCR to capture table-like snippets."
+                               Margin="0,4,0,0"
+                               TextWrapping="Wrap"
+                               Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                </StackPanel>
+
+                <Border Grid.Row="1"
+                        Margin="12,0,12,8"
+                        Padding="8"
+                        Background="{DynamicResource LibraryPanelSubtleBrush}"
+                        BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                        BorderThickness="1">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="Preview page"
+                                       FontWeight="SemiBold"
+                                       VerticalAlignment="Center" />
+                            <ComboBox ItemsSource="{Binding PreviewPages}"
+                                      SelectedItem="{Binding SelectedPreviewPage}"
+                                      Width="80"
+                                      Margin="8,0,0,0" />
+                            <ProgressBar Width="120"
+                                         Height="6"
+                                         Margin="12,0,0,0"
+                                         Visibility="{Binding IsPreviewBusy, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                         IsIndeterminate="True" />
+                        </StackPanel>
+                        <TextBlock Text="{Binding PreviewStatusMessage}"
+                                   Margin="0,8,0,0"
+                                   TextWrapping="Wrap"
+                                   Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                    </StackPanel>
+                </Border>
+
+                <Border Grid.Row="2"
+                        Margin="12,0,12,8"
                         Background="White"
                         BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
                         BorderThickness="1">
-                    <Grid>
-                        <WebBrowser x:Name="PdfBrowser" />
-                    </Grid>
+                    <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                  VerticalScrollBarVisibility="Auto">
+                        <Grid>
+                            <Image Source="{Binding PreviewBitmap}"
+                                   Stretch="None" />
+                            <Canvas x:Name="RoiCanvas"
+                                    Width="{Binding PreviewWidth}"
+                                    Height="{Binding PreviewHeight}"
+                                    Background="Transparent"
+                                    MouseLeftButtonDown="OnRoiCanvasMouseLeftButtonDown"
+                                    MouseMove="OnRoiCanvasMouseMove"
+                                    MouseLeftButtonUp="OnRoiCanvasMouseLeftButtonUp"
+                                    MouseLeave="OnRoiCanvasMouseLeave"
+                                    MouseRightButtonDown="OnRoiCanvasMouseRightButtonDown">
+                                <Rectangle Stroke="#FF1E88E5"
+                                           StrokeThickness="2"
+                                           Fill="#401E88E5"
+                                           Visibility="{Binding RoiSelection.HasVisibleSelection, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                           Width="{Binding RoiSelection.Width}"
+                                           Height="{Binding RoiSelection.Height}"
+                                           Canvas.Left="{Binding RoiSelection.X}"
+                                           Canvas.Top="{Binding RoiSelection.Y}" />
+                            </Canvas>
+                        </Grid>
+                    </ScrollViewer>
                 </Border>
+
+                <StackPanel Grid.Row="3"
+                            Orientation="Horizontal"
+                            Margin="12,0,12,12">
+                    <Button Content="Run region OCR"
+                            Width="140"
+                            Height="32"
+                            Command="{Binding RunRegionOcrCommand}" />
+                    <Button Content="Clear selection"
+                            Width="140"
+                            Height="32"
+                            Margin="8,0,0,0"
+                            Command="{Binding ClearRegionSelectionCommand}" />
+                </StackPanel>
             </Grid>
         </Border>
 
@@ -49,6 +129,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="2*" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
@@ -245,6 +326,142 @@
             </Grid>
 
             <Border Grid.Row="3"
+                    Margin="0,12,0,0"
+                    Padding="12"
+                    Background="{DynamicResource LibraryPanelBackgroundBrush}"
+                    BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                    BorderThickness="1"
+                    Visibility="{Binding HasIdeaGroups, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0"
+                               Text="OCR &amp; AI idea board"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource LibraryPrimaryForegroundBrush}" />
+
+                    <TextBlock Grid.Row="1"
+                               Text="Curated experiments that pair Tesseract OCR, cloud services, and automation concepts with the playground."
+                               Margin="0,4,0,0"
+                               TextWrapping="Wrap"
+                               Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+
+                    <ScrollViewer Grid.Row="2"
+                                  Margin="0,12,0,0"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled">
+                        <ItemsControl ItemsSource="{Binding IdeaGroups}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type viewModels:OcrIdeaGroupViewModel}">
+                                    <Expander IsExpanded="True" Margin="0,0,0,12">
+                                        <Expander.Header>
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                                                <TextBlock Text="{Binding Description}"
+                                                           TextWrapping="Wrap"
+                                                           Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                                            </StackPanel>
+                                        </Expander.Header>
+                                        <ItemsControl ItemsSource="{Binding Ideas}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate DataType="{x:Type viewModels:OcrIdeaViewModel}">
+                                                    <Border Margin="0,0,0,12"
+                                                            Padding="12"
+                                                            Background="{DynamicResource LibraryPanelSubtleBrush}"
+                                                            BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                                                            BorderThickness="1">
+                                                        <StackPanel>
+                                                            <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                                                            <TextBlock Text="{Binding Summary}"
+                                                                       Margin="0,4,0,0"
+                                                                       TextWrapping="Wrap"
+                                                                       Foreground="{DynamicResource LibraryPrimaryForegroundBrush}" />
+                                                            <ItemsControl ItemsSource="{Binding Steps}"
+                                                                          Margin="0,6,0,0"
+                                                                          Visibility="{Binding HasSteps, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                                <ItemsControl.ItemTemplate>
+                                                                    <DataTemplate>
+                                                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                                                                            <TextBlock Text="•"
+                                                                                       Margin="0,0,6,0"
+                                                                                       Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                                                                            <TextBlock Text="{Binding}"
+                                                                                       TextWrapping="Wrap"
+                                                                                       Foreground="{DynamicResource LibraryPrimaryForegroundBrush}" />
+                                                                        </StackPanel>
+                                                                    </DataTemplate>
+                                                                </ItemsControl.ItemTemplate>
+                                                            </ItemsControl>
+                                                            <ItemsControl ItemsSource="{Binding Tags}"
+                                                                          Margin="0,6,0,0"
+                                                                          Visibility="{Binding HasTags, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                                <ItemsControl.ItemsPanel>
+                                                                    <ItemsPanelTemplate>
+                                                                        <WrapPanel />
+                                                                    </ItemsPanelTemplate>
+                                                                </ItemsControl.ItemsPanel>
+                                                                <ItemsControl.ItemTemplate>
+                                                                    <DataTemplate>
+                                                                        <Border Background="{DynamicResource LibraryPanelBackgroundBrush}"
+                                                                                BorderBrush="{DynamicResource LibraryPanelBorderBrush}"
+                                                                                BorderThickness="1"
+                                                                                CornerRadius="4"
+                                                                                Padding="4"
+                                                                                Margin="0,0,6,6">
+                                                                            <TextBlock Text="{Binding}"
+                                                                                       FontSize="12"
+                                                                                       Foreground="{DynamicResource LibrarySecondaryForegroundBrush}" />
+                                                                        </Border>
+                                                                    </DataTemplate>
+                                                                </ItemsControl.ItemTemplate>
+                                                            </ItemsControl>
+                                                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                                                <Button Content="{Binding SnippetLabel}"
+                                                                        Visibility="{Binding HasSnippet, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                                        Command="{Binding DataContext.CopyIdeaSnippetCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                        CommandParameter="{Binding}"
+                                                                        Margin="0,0,8,0" />
+                                                                <Button Content="Copy plan"
+                                                                        Command="{Binding DataContext.CopyIdeaPlanCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                        CommandParameter="{Binding}"
+                                                                        Margin="0,0,8,0" />
+                                                                <ItemsControl ItemsSource="{Binding Resources}"
+                                                                              Visibility="{Binding HasResources, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                                    <ItemsControl.ItemsPanel>
+                                                                        <ItemsPanelTemplate>
+                                                                            <StackPanel Orientation="Horizontal" />
+                                                                        </ItemsPanelTemplate>
+                                                                    </ItemsControl.ItemsPanel>
+                                                                    <ItemsControl.ItemTemplate>
+                                                                        <DataTemplate DataType="{x:Type viewModels:IdeaResourceViewModel}">
+                                                                            <Button Content="{Binding Label}"
+                                                                                    Margin="0,0,8,0"
+                                                                                    Command="{Binding DataContext.OpenIdeaResourceCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                                    CommandParameter="{Binding}"
+                                                                                    IsEnabled="{Binding HasUri}" />
+                                                                        </DataTemplate>
+                                                                    </ItemsControl.ItemTemplate>
+                                                                </ItemsControl>
+                                                            </StackPanel>
+                                                        </StackPanel>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </Expander>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+
+            <Border Grid.Row="4"
                     Margin="0,12,0,0"
                     Padding="12"
                     Background="{DynamicResource LibraryPanelSubtleBrush}"


### PR DESCRIPTION
## Summary
- replace the static PDF browser with a rendered page preview that supports ROI selection and invokes a new Tesseract-backed OCR workflow
- capture region selections in a dedicated view model, surface parsed OCR tables alongside Tabula results, and log region runs through the changelog hook
- add a helper to translate Tesseract TSV/plain text into grid cells and pull in the Tesseract package for the WPF client

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: installed SDK 8.0.414 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d9570e980c832b8a9e49ab70df4d4a