### PR TITLE
Fix data extraction playground Tesseract integration

### DIFF
--- a/src/LM.App.Wpf/LM.App.Wpf.csproj
+++ b/src/LM.App.Wpf/LM.App.Wpf.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" />
+    <PackageReference Include="Tesseract" />
     <PackageReference Include="Tabula" />
   </ItemGroup>
 

--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.IdeaBoard.Snippets.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.IdeaBoard.Snippets.cs
@@ -1,0 +1,61 @@
+namespace LM.App.Wpf.ViewModels.Library;
+
+internal sealed partial class DataExtractionPlaygroundViewModel
+{
+    private const string TesseractRegionSnippet = """
+    using Tesseract;
+
+    using var engine = new TesseractEngine(@"./tessdata", "eng", EngineMode.Default);
+    using var pix = Pix.LoadFromFile(pageImagePath);
+    using var region = pix.ClipRectangle(new System.Drawing.Rectangle(left, top, width, height));
+    using var page = engine.Process(region, PageSegMode.SingleBlock);
+
+    var tsv = page.GetTsvText(0);
+    var rows = tsv.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+    // Map TSV columns 11+ into cells and hydrate a DataTable.
+    """;
+
+    private const string HybridConfidenceSnippet = """
+    var engine = OcrEnginePool.Rent();
+    foreach (var cell in detectedCells)
+    {
+        using var pix = Pix.LoadFromMemory(cell.ImageBytes);
+        using var page = engine.Process(pix, PageSegMode.SingleBlock);
+        if (page.GetMeanConfidence() * 100 < 85)
+        {
+            cell.MarkAsLowConfidence();
+        }
+
+        cell.Text = page.GetText();
+    }
+    """;
+
+    private const string AzureLayoutSnippet = """
+    using Azure;
+    using Azure.AI.FormRecognizer.DocumentAnalysis;
+
+    var client = new DocumentAnalysisClient(new Uri(endpoint), new AzureKeyCredential(key));
+    AnalyzeDocumentOperation op = await client.AnalyzeDocumentFromUriAsync(WaitUntil.Completed, "prebuilt-layout", pdfUri);
+    foreach (var table in op.Value.Tables)
+    {
+        // Map table.Cells into your view model, using table.Cells[i].RowSpan etc.
+    }
+    """;
+
+    private const string BringYourOwnLlmSnippet = """"
+    var prompt = $$"""
+    You are cleaning an OCR table. Return strict JSON with fields rows, warnings.
+
+    {tsv}
+    """$$;
+
+    var response = await openAiClient.GetChatCompletionsAsync(deploymentId, new ChatCompletionsOptions
+    {
+        Messages =
+        {
+            new ChatRequestSystemMessage("Normalize table headers and units"),
+            new ChatRequestUserMessage(prompt)
+        }
+    });
+    """";
+}

--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.Preview.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.Preview.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LM.Core.Models;
 using LM.Infrastructure.Hooks;
@@ -377,9 +378,9 @@ internal sealed partial class DataExtractionPlaygroundViewModel
 
         using var engine = new TesseractEngine(tessData, "eng", EngineMode.Default);
         using var pix = Pix.LoadFromMemory(image);
-        using var page = engine.Process(pix, PageSegMode.Table);
+        using var page = engine.Process(pix, PageSegMode.SingleBlock);
 
-        var tsv = page.GetTsvText();
+        var tsv = page.GetTsvText(0);
         var table = TesseractTableBuilder.Build(tsv);
         if (table.ColumnCount == 0)
         {
@@ -393,11 +394,11 @@ internal sealed partial class DataExtractionPlaygroundViewModel
             return null;
         }
 
-        var confidence = page.TryGetMeanConfidence(out var conf) ? conf : 0;
+        var confidence = page.GetMeanConfidence() * 100d;
         return new OcrRegionTableResult(table.Rows, table.ColumnCount, confidence);
     }
 
-    private static System.Windows.Media.Imaging.RenderTargetBitmap RenderPageBitmap(Page page)
+    private static System.Windows.Media.Imaging.RenderTargetBitmap RenderPageBitmap(UglyToad.PdfPig.Content.Page page)
     {
         const double targetDpi = 144d;
         var scale = targetDpi / 72d;

--- a/src/LM.App.Wpf/Views/Library/DataExtractionPlaygroundWindow.xaml.cs
+++ b/src/LM.App.Wpf/Views/Library/DataExtractionPlaygroundWindow.xaml.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Windows.Input;
 using LM.App.Wpf.ViewModels.Library;
 
 namespace LM.App.Wpf.Views.Library
@@ -17,7 +16,7 @@ namespace LM.App.Wpf.Views.Library
             DataContext = _viewModel;
         }
 
-        private void OnRoiCanvasMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        private void OnRoiCanvasMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             var position = e.GetPosition(RoiCanvas);
             _viewModel.BeginRegionSelection(position);
@@ -30,7 +29,7 @@ namespace LM.App.Wpf.Views.Library
             }
         }
 
-        private void OnRoiCanvasMouseMove(object sender, MouseEventArgs e)
+        private void OnRoiCanvasMouseMove(object sender, System.Windows.Input.MouseEventArgs e)
         {
             if (!_isDragging)
             {
@@ -41,7 +40,7 @@ namespace LM.App.Wpf.Views.Library
             _viewModel.UpdateRegionSelection(position);
         }
 
-        private void OnRoiCanvasMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        private void OnRoiCanvasMouseLeftButtonUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             if (!_isDragging)
             {
@@ -55,7 +54,7 @@ namespace LM.App.Wpf.Views.Library
             e.Handled = true;
         }
 
-        private void OnRoiCanvasMouseLeave(object sender, MouseEventArgs e)
+        private void OnRoiCanvasMouseLeave(object sender, System.Windows.Input.MouseEventArgs e)
         {
             if (!_isDragging)
             {
@@ -68,7 +67,7 @@ namespace LM.App.Wpf.Views.Library
             _isDragging = false;
         }
 
-        private void OnRoiCanvasMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        private void OnRoiCanvasMouseRightButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             _viewModel.CancelRegionSelection();
             RoiCanvas.ReleaseMouseCapture();


### PR DESCRIPTION
## Summary
- move raw Tesseract sample strings into a dedicated partial class so the main idea board stays readable
- add the missing Tesseract dependency and adjust the preview pipeline to use the current wrapper API
- fully qualify WPF mouse event args to avoid namespace collisions

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: JsonReviewProjectStoreTests.SaveAssignmentAsync_RemovesLegacyLockFile expects old lock file removal)*

------
https://chatgpt.com/codex/tasks/task_e_68d9642d059c832b805940700fdf3d7f