### PR TITLE
Fix region OCR changelog dispatch threading

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.Preview.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/DataExtractionPlaygroundViewModel.Preview.cs
@@ -256,7 +256,7 @@ internal sealed partial class DataExtractionPlaygroundViewModel
                 region,
                 ocrResult.Rows.Count,
                 ocrResult.ColumnCount,
-                ocrResult.Confidence).ConfigureAwait(false);
+                ocrResult.Confidence).ConfigureAwait(true);
         }
         catch (InvalidOperationException ex)
         {


### PR DESCRIPTION
## Summary
- ensure the region OCR changelog write awaits on the UI dispatcher

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: current container only has the .NET 8 SDK while the solution targets .NET 9)*

------
https://chatgpt.com/codex/tasks/task_e_68d98285936c832bb53dddb93a7c6c9c