### PR TITLE
Add PDF viewer launcher integration for library documents

### DIFF
--- a/src/LM.App.Wpf.Tests/Library/LibraryDocumentServiceTests.cs
+++ b/src/LM.App.Wpf.Tests/Library/LibraryDocumentServiceTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.App.Wpf.Library;
+using LM.Core.Abstractions;
+using LM.Core.Models;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.Library
+{
+    public sealed class LibraryDocumentServiceTests
+    {
+        [Fact]
+        public async Task OpenEntryAsync_UsesPdfViewerLauncherWhenAvailable()
+        {
+            var entry = new Entry
+            {
+                MainFilePath = "library/foo.pdf"
+            };
+
+            var workspace = new StubWorkspaceService();
+            var launcher = new RecordingLauncher
+            {
+                Result = true
+            };
+
+            var service = new LibraryDocumentService(workspace, launcher);
+
+            await service.OpenEntryAsync(entry);
+
+            Assert.Equal(1, launcher.CallCount);
+            Assert.Same(entry, launcher.Entry);
+            Assert.Null(launcher.AttachmentId);
+            Assert.Equal("library/foo.pdf", workspace.LastRelativePath);
+        }
+
+        [Fact]
+        public async Task OpenEntryAsync_ThrowsWhenPathMissing()
+        {
+            var entry = new Entry
+            {
+                MainFilePath = string.Empty
+            };
+
+            var workspace = new StubWorkspaceService();
+            var launcher = new RecordingLauncher();
+            var service = new LibraryDocumentService(workspace, launcher);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => service.OpenEntryAsync(entry));
+            Assert.Equal(0, launcher.CallCount);
+        }
+
+        private sealed class StubWorkspaceService : IWorkSpaceService
+        {
+            public string? WorkspacePath => "/workspace";
+
+            public string? LastRelativePath { get; private set; }
+
+            public string GetWorkspaceRoot() => WorkspacePath ?? throw new InvalidOperationException("Workspace not set.");
+
+            public string GetLocalDbPath() => Path.Combine(WorkspacePath ?? string.Empty, "library.db");
+
+            public string GetAbsolutePath(string relativePath)
+            {
+                LastRelativePath = relativePath;
+                return Path.Combine(WorkspacePath ?? string.Empty, relativePath);
+            }
+
+            public Task EnsureWorkspaceAsync(string absoluteWorkspacePath, CancellationToken ct = default)
+                => Task.CompletedTask;
+        }
+
+        private sealed class RecordingLauncher : IPdfViewerLauncher
+        {
+            public int CallCount { get; private set; }
+
+            public Entry? Entry { get; private set; }
+
+            public string? AttachmentId { get; private set; }
+
+            public bool Result { get; set; }
+
+            public Task<bool> LaunchAsync(Entry entry, string? attachmentId = null)
+            {
+                CallCount++;
+                Entry = entry;
+                AttachmentId = attachmentId;
+                return Task.FromResult(Result);
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf.Tests/LibraryViewModelFullTextTests.cs
+++ b/src/LM.App.Wpf.Tests/LibraryViewModelFullTextTests.cs
@@ -560,8 +560,8 @@ namespace LM.App.Wpf.Tests
 
         private sealed class NoopDocumentService : ILibraryDocumentService
         {
-            public void OpenEntry(Entry entry) { }
-            public void OpenAttachment(Attachment attachment) { }
+            public Task OpenEntryAsync(Entry entry) => Task.CompletedTask;
+            public Task OpenAttachmentAsync(Entry entry, Attachment attachment) => Task.CompletedTask;
         }
 
         private sealed class RecordingEntryEditor : ILibraryEntryEditor

--- a/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
@@ -36,7 +36,9 @@ namespace LM.App.Wpf.Composition.Modules
             services.AddTransient<LibraryPresetPickerDialog>();
             services.AddTransient<EntryEditorViewModel>();
             services.AddSingleton<ILibraryEntryEditor, LibraryEntryEditor>();
-            services.AddSingleton<ILibraryDocumentService>(sp => new LibraryDocumentService(sp.GetRequiredService<IWorkSpaceService>()));
+            services.AddTransient<PdfViewerViewModel>();
+            services.AddSingleton<IPdfViewerLauncher, PdfViewerLauncher>();
+            services.AddSingleton<ILibraryDocumentService, LibraryDocumentService>();
             services.AddTransient<DataExtractionPlaygroundViewModel>();
             services.AddSingleton<LibraryDataExtractionLauncher>();
             services.AddSingleton<Func<Entry, CancellationToken, Task<bool>>>(sp =>

--- a/src/LM.App.Wpf/Library/ILibraryDocumentService.cs
+++ b/src/LM.App.Wpf/Library/ILibraryDocumentService.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using LM.Core.Models;
 
 namespace LM.App.Wpf.Library
@@ -7,7 +8,7 @@ namespace LM.App.Wpf.Library
     /// </summary>
     public interface ILibraryDocumentService
     {
-        void OpenEntry(Entry entry);
-        void OpenAttachment(Attachment attachment);
+        Task OpenEntryAsync(Entry entry);
+        Task OpenAttachmentAsync(Entry entry, Attachment attachment);
     }
 }

--- a/src/LM.App.Wpf/Library/IPdfViewerLauncher.cs
+++ b/src/LM.App.Wpf/Library/IPdfViewerLauncher.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using LM.Core.Models;
+
+namespace LM.App.Wpf.Library
+{
+    public interface IPdfViewerLauncher
+    {
+        Task<bool> LaunchAsync(Entry entry, string? attachmentId = null);
+    }
+}

--- a/src/LM.App.Wpf/Library/PdfViewerLauncher.cs
+++ b/src/LM.App.Wpf/Library/PdfViewerLauncher.cs
@@ -1,0 +1,94 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using LM.App.Wpf.ViewModels.Library;
+using LM.App.Wpf.Views.Library;
+using LM.Core.Abstractions;
+using LM.Core.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LM.App.Wpf.Library
+{
+    internal sealed class PdfViewerLauncher : IPdfViewerLauncher
+    {
+        private readonly IServiceProvider _services;
+        private readonly IWorkSpaceService _workspace;
+
+        public PdfViewerLauncher(IServiceProvider services, IWorkSpaceService workspace)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(workspace);
+
+            _services = services;
+            _workspace = workspace;
+        }
+
+        public Task<bool> LaunchAsync(Entry entry, string? attachmentId = null)
+        {
+            ArgumentNullException.ThrowIfNull(entry);
+
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher is null)
+            {
+                throw new InvalidOperationException("Application dispatcher is not available.");
+            }
+
+            if (!dispatcher.CheckAccess())
+            {
+                var operation = dispatcher.InvokeAsync(() => LaunchInternalAsync(entry, attachmentId));
+                return operation.Task.Unwrap();
+            }
+
+            return LaunchInternalAsync(entry, attachmentId);
+        }
+
+        private async Task<bool> LaunchInternalAsync(Entry entry, string? attachmentId)
+        {
+            var relativePath = ResolveRelativePath(entry, attachmentId);
+            if (string.IsNullOrWhiteSpace(relativePath))
+            {
+                return false;
+            }
+
+            var absolutePath = _workspace.GetAbsolutePath(relativePath);
+            if (string.IsNullOrWhiteSpace(absolutePath) || !File.Exists(absolutePath))
+            {
+                return false;
+            }
+
+            if (!string.Equals(Path.GetExtension(absolutePath), ".pdf", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            using var scope = _services.CreateScope();
+            var viewModel = scope.ServiceProvider.GetRequiredService<PdfViewerViewModel>();
+            var initialized = await viewModel.InitializeAsync(entry, absolutePath, attachmentId).ConfigureAwait(true);
+            if (!initialized)
+            {
+                return false;
+            }
+
+            var window = new PdfViewerWindow
+            {
+                Owner = System.Windows.Application.Current?.MainWindow,
+                DataContext = viewModel
+            };
+
+            window.Show();
+            return true;
+        }
+
+        private static string? ResolveRelativePath(Entry entry, string? attachmentId)
+        {
+            if (!string.IsNullOrWhiteSpace(attachmentId))
+            {
+                return entry.Attachments.FirstOrDefault(a => a.Id == attachmentId)?.RelativePath;
+            }
+
+            return entry.MainFilePath;
+        }
+    }
+}

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -467,12 +467,21 @@ LM.App.Wpf.ViewModels.IAddPipeline
 LM.App.Wpf.ViewModels.IAddPipeline.CommitAsync(System.Collections.Generic.IEnumerable<LM.App.Wpf.ViewModels.StagingItem!>! selectedRows, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!>!
 LM.App.Wpf.ViewModels.IAddPipeline.StagePathsAsync(System.Collections.Generic.IEnumerable<string!>! paths, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.StagingItem!>!>!
 LM.App.Wpf.Library.ILibraryDocumentService
-LM.App.Wpf.Library.ILibraryDocumentService.OpenEntry(LM.Core.Models.Entry! entry) -> void
-LM.App.Wpf.Library.ILibraryDocumentService.OpenAttachment(LM.Core.Models.Attachment! attachment) -> void
+LM.App.Wpf.Library.ILibraryDocumentService.OpenEntryAsync(LM.Core.Models.Entry! entry) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.ILibraryDocumentService.OpenAttachmentAsync(LM.Core.Models.Entry! entry, LM.Core.Models.Attachment! attachment) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.IPdfViewerLauncher
+LM.App.Wpf.Library.IPdfViewerLauncher.LaunchAsync(LM.Core.Models.Entry! entry, string? attachmentId = null) -> System.Threading.Tasks.Task<bool>!
 LM.App.Wpf.Library.LibraryDocumentService
-LM.App.Wpf.Library.LibraryDocumentService.LibraryDocumentService(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
-LM.App.Wpf.Library.LibraryDocumentService.OpenEntry(LM.Core.Models.Entry! entry) -> void
-LM.App.Wpf.Library.LibraryDocumentService.OpenAttachment(LM.Core.Models.Attachment! attachment) -> void
+LM.App.Wpf.Library.LibraryDocumentService.LibraryDocumentService(LM.Core.Abstractions.IWorkSpaceService! workspace, LM.App.Wpf.Library.IPdfViewerLauncher! pdfViewerLauncher) -> void
+LM.App.Wpf.Library.LibraryDocumentService.OpenEntryAsync(LM.Core.Models.Entry! entry) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.LibraryDocumentService.OpenAttachmentAsync(LM.Core.Models.Entry! entry, LM.Core.Models.Attachment! attachment) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.PdfViewerViewModel() -> void
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.Entry.get -> LM.Core.Models.Entry?
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.Attachment.get -> LM.Core.Models.Attachment?
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.DocumentPath.get -> string?
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.WindowTitle.get -> string!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.InitializeAsync(LM.Core.Models.Entry! entry, string! absolutePath, string? attachmentId) -> System.Threading.Tasks.Task<bool>!
 LM.App.Wpf.Library.IAttachmentMetadataPrompt
 LM.App.Wpf.Library.IAttachmentMetadataPrompt.RequestMetadataAsync(LM.App.Wpf.Library.AttachmentMetadataPromptContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.AttachmentMetadataPromptResult?>!
 LM.App.Wpf.Library.AttachmentMetadataPromptContext

--- a/src/LM.App.Wpf/ViewModels/Library/LibraryResultsViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LibraryResultsViewModel.cs
@@ -402,10 +402,21 @@ namespace LM.App.Wpf.ViewModels.Library
         }
 
         [RelayCommand]
-        private void OpenAttachment(Attachment? attachment)
+        private async Task OpenAttachmentAsync(Attachment? attachment)
         {
             if (attachment is null)
                 return;
+
+            var entry = Selected?.Entry;
+            if (entry is null)
+            {
+                System.Windows.MessageBox.Show(
+                    "No entry is selected.",
+                    "Open Attachment",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Information);
+                return;
+            }
 
             if (string.IsNullOrWhiteSpace(attachment.RelativePath))
             {
@@ -430,7 +441,7 @@ namespace LM.App.Wpf.ViewModels.Library
 
             try
             {
-                _documentService.OpenAttachment(attachment);
+                await _documentService.OpenAttachmentAsync(entry, attachment).ConfigureAwait(true);
             }
             catch (Exception ex)
             {
@@ -494,14 +505,14 @@ namespace LM.App.Wpf.ViewModels.Library
         }
 
         [RelayCommand(CanExecute = nameof(CanModifySelected))]
-        private void Open()
+        private async Task OpenAsync()
         {
             var entry = Selected?.Entry;
             if (entry is null) return;
 
             try
             {
-                _documentService.OpenEntry(entry);
+                await _documentService.OpenEntryAsync(entry).ConfigureAwait(true);
             }
             catch (Exception ex)
             {

--- a/src/LM.App.Wpf/ViewModels/Library/PdfViewerViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/PdfViewerViewModel.cs
@@ -1,0 +1,75 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using LM.App.Wpf.Common;
+using LM.Core.Models;
+
+namespace LM.App.Wpf.ViewModels.Library
+{
+    public sealed class PdfViewerViewModel : ViewModelBase
+    {
+        private Entry? _entry;
+        private Attachment? _attachment;
+        private string? _documentPath;
+
+        public Entry? Entry => _entry;
+
+        public Attachment? Attachment => _attachment;
+
+        public string? DocumentPath
+        {
+            get => _documentPath;
+            private set => SetProperty(ref _documentPath, value);
+        }
+
+        public string WindowTitle
+        {
+            get
+            {
+                if (_entry is null)
+                {
+                    return "PDF Viewer";
+                }
+
+                if (_attachment is not null && !string.IsNullOrWhiteSpace(_attachment.Title))
+                {
+                    return string.IsNullOrWhiteSpace(_entry.Title)
+                        ? _attachment.Title
+                        : $"{_attachment.Title} — {_entry.Title}";
+                }
+
+                return string.IsNullOrWhiteSpace(_entry.Title) ? "PDF Viewer" : _entry.Title;
+            }
+        }
+
+        public Task<bool> InitializeAsync(Entry entry, string absolutePath, string? attachmentId)
+        {
+            ArgumentNullException.ThrowIfNull(entry);
+
+            if (string.IsNullOrWhiteSpace(absolutePath))
+            {
+                return Task.FromResult(false);
+            }
+
+            _entry = entry;
+            _attachment = null;
+
+            if (!string.IsNullOrWhiteSpace(attachmentId))
+            {
+                _attachment = entry.Attachments.FirstOrDefault(a => a.Id == attachmentId);
+                if (_attachment is null)
+                {
+                    return Task.FromResult(false);
+                }
+            }
+
+            DocumentPath = absolutePath;
+            OnPropertyChanged(nameof(Entry));
+            OnPropertyChanged(nameof(Attachment));
+            OnPropertyChanged(nameof(WindowTitle));
+
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/LibraryViewModel.Commands.cs
+++ b/src/LM.App.Wpf/ViewModels/LibraryViewModel.Commands.cs
@@ -178,7 +178,7 @@ namespace LM.App.Wpf.ViewModels
         private bool CanOpenEntry(LibrarySearchResult? result) => GetSelection(result, updateSelection: false) is not null;
 
         [RelayCommand(CanExecute = nameof(CanOpenEntry))]
-        private void OpenEntry(LibrarySearchResult? result)
+        private async Task OpenEntryAsync(LibrarySearchResult? result)
         {
             var target = GetSelection(result, updateSelection: true);
             if (target is null)
@@ -186,7 +186,7 @@ namespace LM.App.Wpf.ViewModels
 
             try
             {
-                _documentService.OpenEntry(target.Entry);
+                await _documentService.OpenEntryAsync(target.Entry).ConfigureAwait(true);
             }
             catch (Exception ex)
             {

--- a/src/LM.App.Wpf/Views/Library/PdfViewerWindow.xaml
+++ b/src/LM.App.Wpf/Views/Library/PdfViewerWindow.xaml
@@ -1,0 +1,17 @@
+<Window x:Class="LM.App.Wpf.Views.Library.PdfViewerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:controls="clr-namespace:LM.App.Wpf.Views.Library.Controls"
+        x:ClassModifier="internal"
+        mc:Ignorable="d"
+        Title="{Binding WindowTitle}"
+        Width="900"
+        Height="720"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
+  <Grid Margin="12">
+    <controls:PdfInteractiveViewer SourcePath="{Binding DocumentPath}" />
+  </Grid>
+</Window>

--- a/src/LM.App.Wpf/Views/Library/PdfViewerWindow.xaml.cs
+++ b/src/LM.App.Wpf/Views/Library/PdfViewerWindow.xaml.cs
@@ -1,0 +1,12 @@
+#nullable enable
+
+namespace LM.App.Wpf.Views.Library
+{
+    internal sealed partial class PdfViewerWindow : System.Windows.Window
+    {
+        public PdfViewerWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -429,6 +429,10 @@
             <i:InvokeCommandAction Command="{Binding HandleSelectionChangedCommand}"
                                    CommandParameter="{Binding SelectedItems, RelativeSource={RelativeSource AncestorType=DataGrid}}" />
           </i:EventTrigger>
+          <i:EventTrigger EventName="MouseDoubleClick">
+            <i:InvokeCommandAction Command="{Binding DataContext.OpenEntryCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                   CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=DataGrid}}" />
+          </i:EventTrigger>
         </i:Interaction.Triggers>
         <DataGrid.Columns>
           <StaticResource ResourceKey="LibraryResultsColumn.AttachmentIndicator" />


### PR DESCRIPTION
## Summary
- introduce an IPdfViewerLauncher contract with a PdfViewerLauncher implementation that resolves PDFs via the workspace and opens them in a new PdfViewerWindow
- update LibraryDocumentService, Library view models, and XAML to use the async PDF viewer flow, including double-click support and attachment handling
- add a PdfViewerViewModel/window pair and unit tests covering the new launcher and document service behavior while updating the public API declarations

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: requires Microsoft.WindowsDesktop.App runtime on Linux and one existing LM.Infrastructure.Tests failure)*

------
https://chatgpt.com/codex/tasks/task_e_68da7a0c6b34832ba32e3537fa89bd35