### PR TITLE
Add PDF viewer window with navigation pane and commands

### DIFF
--- a/docs/pdf-viewer-toolbar-automation.ps1
+++ b/docs/pdf-viewer-toolbar-automation.ps1
@@ -1,0 +1,78 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ExePath
+)
+
+Add-Type -AssemblyName UIAutomationClient
+
+$process = Start-Process -FilePath $ExePath -PassThru
+try {
+    $root = [System.Windows.Automation.AutomationElement]::RootElement
+    $windowCondition = New-Object System.Windows.Automation.PropertyCondition([System.Windows.Automation.AutomationElement]::NameProperty, "PDF Viewer")
+    $window = $null
+    for ($i = 0; $i -lt 60 -and -not $window; $i++) {
+        Start-Sleep -Milliseconds 250
+        $window = $root.FindFirst([System.Windows.Automation.TreeScope]::Children, $windowCondition)
+    }
+
+    if (-not $window) {
+        throw "PDF Viewer window was not found."
+    }
+
+    function Invoke-AutomationButton {
+        param([System.Windows.Automation.AutomationElement]$scope, [string]$automationId)
+        $condition = New-Object System.Windows.Automation.PropertyCondition([System.Windows.Automation.AutomationElement]::AutomationIdProperty, $automationId)
+        $element = $scope.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $condition)
+        if (-not $element) {
+            throw "Automation element '$automationId' was not located."
+        }
+
+        $pattern = $element.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern)
+        $pattern.Invoke()
+        Start-Sleep -Milliseconds 200
+    }
+
+    function Select-AutomationTab {
+        param([System.Windows.Automation.AutomationElement]$scope, [string]$automationId)
+        $condition = New-Object System.Windows.Automation.PropertyCondition([System.Windows.Automation.AutomationElement]::AutomationIdProperty, $automationId)
+        $tab = $scope.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $condition)
+        if (-not $tab) {
+            throw "Tab '$automationId' was not located."
+        }
+
+        $pattern = $tab.GetCurrentPattern([System.Windows.Automation.SelectionItemPattern]::Pattern)
+        $pattern.Select()
+        Start-Sleep -Milliseconds 200
+    }
+
+    Invoke-AutomationButton $window "ToolbarPagesButton"
+    Invoke-AutomationButton $window "ToolbarZoomInButton"
+    Invoke-AutomationButton $window "ToolbarZoomOutButton"
+    Invoke-AutomationButton $window "AnnotationHighlightToggle"
+    Invoke-AutomationButton $window "AnnotationUnderlineToggle"
+
+    Select-AutomationTab $window "NavigationAnnotationsTab"
+    Select-AutomationTab $window "NavigationOutlineTab"
+
+    $tabControlCondition = New-Object System.Windows.Automation.PropertyCondition([System.Windows.Automation.AutomationElement]::AutomationIdProperty, "NavigationTabControl")
+    $tabControl = $window.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $tabControlCondition)
+    if (-not $tabControl) {
+        throw "NavigationTabControl was not found."
+    }
+
+    $selectionPattern = $tabControl.GetCurrentPattern([System.Windows.Automation.SelectionPattern]::Pattern)
+    $selected = $selectionPattern.Current.GetSelection()
+    if ($selected.Length -eq 0 -or $selected[0].Current.AutomationId -ne "NavigationOutlineTab") {
+        throw "Outline tab was not selected after automation interaction."
+    }
+
+    Write-Output "Toolbar and navigation interactions completed successfully."
+}
+finally {
+    if ($process -and -not $process.HasExited) {
+        $process.CloseMainWindow() | Out-Null
+        if (-not $process.WaitForExit(2000)) {
+            $process.Kill()
+        }
+    }
+}

--- a/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
@@ -37,6 +37,7 @@ namespace LM.App.Wpf.Composition.Modules
             services.AddTransient<EntryEditorViewModel>();
             services.AddSingleton<ILibraryEntryEditor, LibraryEntryEditor>();
             services.AddTransient<PdfViewerViewModel>();
+            services.AddTransient<PdfViewerWindow>();
             services.AddSingleton<IPdfViewerLauncher, PdfViewerLauncher>();
             services.AddSingleton<ILibraryDocumentService, LibraryDocumentService>();
             services.AddTransient<DataExtractionPlaygroundViewModel>();

--- a/src/LM.App.Wpf/Library/PdfViewerLauncher.cs
+++ b/src/LM.App.Wpf/Library/PdfViewerLauncher.cs
@@ -63,19 +63,19 @@ namespace LM.App.Wpf.Library
                 return false;
             }
 
-            using var scope = _services.CreateScope();
+            var scope = _services.CreateScope();
             var viewModel = scope.ServiceProvider.GetRequiredService<PdfViewerViewModel>();
             var initialized = await viewModel.InitializeAsync(entry, absolutePath, attachmentId).ConfigureAwait(true);
             if (!initialized)
             {
+                scope.Dispose();
                 return false;
             }
 
-            var window = new PdfViewerWindow
-            {
-                Owner = System.Windows.Application.Current?.MainWindow,
-                DataContext = viewModel
-            };
+            var window = scope.ServiceProvider.GetRequiredService<PdfViewerWindow>();
+            window.Owner = System.Windows.Application.Current?.MainWindow;
+            window.DataContext = viewModel;
+            window.Closed += (_, _) => scope.Dispose();
 
             window.Show();
             return true;

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -475,13 +475,101 @@ LM.App.Wpf.Library.LibraryDocumentService
 LM.App.Wpf.Library.LibraryDocumentService.LibraryDocumentService(LM.Core.Abstractions.IWorkSpaceService! workspace, LM.App.Wpf.Library.IPdfViewerLauncher! pdfViewerLauncher) -> void
 LM.App.Wpf.Library.LibraryDocumentService.OpenEntryAsync(LM.Core.Models.Entry! entry) -> System.Threading.Tasks.Task!
 LM.App.Wpf.Library.LibraryDocumentService.OpenAttachmentAsync(LM.Core.Models.Entry! entry, LM.Core.Models.Attachment! attachment) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface.PageChanged -> System.EventHandler<int>?
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface.PageCount.get -> int
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface.ZoomIn() -> void
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface.ZoomOut() -> void
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface.SetZoom(double zoom) -> void
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface.SetZoomMode(PdfiumViewer.Enums.PdfViewerZoomMode mode) -> void
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface.RotateClockwise() -> void
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface.RotateCounterClockwise() -> void
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface.TryNavigateToPage(int pageNumber) -> bool
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface.Search(string! text, bool matchCase, bool wholeWord) -> System.Collections.IList?
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface.ScrollIntoView(object! match) -> void
+LM.App.Wpf.ViewModels.Library.IPdfViewerSurface.FocusViewer() -> void
+LM.App.Wpf.ViewModels.Library.PdfAnnotationListItemViewModel
+LM.App.Wpf.ViewModels.Library.PdfAnnotationListItemViewModel.PdfAnnotationListItemViewModel(System.Guid annotationId, string! title, string? tags, System.Windows.Media.Brush! accentBrush, int pageNumber, CommunityToolkit.Mvvm.Input.IRelayCommand! navigateCommand, CommunityToolkit.Mvvm.Input.IRelayCommand! deleteCommand) -> void
+LM.App.Wpf.ViewModels.Library.PdfAnnotationListItemViewModel.AnnotationId.get -> System.Guid
+LM.App.Wpf.ViewModels.Library.PdfAnnotationListItemViewModel.Title.get -> string!
+LM.App.Wpf.ViewModels.Library.PdfAnnotationListItemViewModel.Tags.get -> string?
+LM.App.Wpf.ViewModels.Library.PdfAnnotationListItemViewModel.AccentBrush.get -> System.Windows.Media.Brush!
+LM.App.Wpf.ViewModels.Library.PdfAnnotationListItemViewModel.PageNumber.get -> int
+LM.App.Wpf.ViewModels.Library.PdfAnnotationListItemViewModel.NavigateCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfAnnotationListItemViewModel.DeleteCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfAnnotationTool
+LM.App.Wpf.ViewModels.Library.PdfAnnotationTool.None = 0 -> LM.App.Wpf.ViewModels.Library.PdfAnnotationTool
+LM.App.Wpf.ViewModels.Library.PdfAnnotationTool.Highlight = 1 -> LM.App.Wpf.ViewModels.Library.PdfAnnotationTool
+LM.App.Wpf.ViewModels.Library.PdfAnnotationTool.Underline = 2 -> LM.App.Wpf.ViewModels.Library.PdfAnnotationTool
+LM.App.Wpf.ViewModels.Library.PdfAnnotationTool.Rectangle = 3 -> LM.App.Wpf.ViewModels.Library.PdfAnnotationTool
+LM.App.Wpf.ViewModels.Library.PdfAnnotationTool.Note = 4 -> LM.App.Wpf.ViewModels.Library.PdfAnnotationTool
+LM.App.Wpf.ViewModels.Library.PdfOutlineNodeViewModel
+LM.App.Wpf.ViewModels.Library.PdfOutlineNodeViewModel.PdfOutlineNodeViewModel(string! title, int? pageNumber, string? targetUri, CommunityToolkit.Mvvm.Input.IRelayCommand! navigateCommand, System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.Library.PdfOutlineNodeViewModel!>! children) -> void
+LM.App.Wpf.ViewModels.Library.PdfOutlineNodeViewModel.Title.get -> string!
+LM.App.Wpf.ViewModels.Library.PdfOutlineNodeViewModel.PageNumber.get -> int?
+LM.App.Wpf.ViewModels.Library.PdfOutlineNodeViewModel.TargetUri.get -> string?
+LM.App.Wpf.ViewModels.Library.PdfOutlineNodeViewModel.Children.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.Library.PdfOutlineNodeViewModel!>!
+LM.App.Wpf.ViewModels.Library.PdfOutlineNodeViewModel.NavigateCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfOutlineNodeViewModel.HasDestination.get -> bool
+LM.App.Wpf.ViewModels.Library.PdfPageThumbnailViewModel
+LM.App.Wpf.ViewModels.Library.PdfPageThumbnailViewModel.PdfPageThumbnailViewModel(int pageNumber, System.Windows.Media.ImageSource! thumbnail) -> void
+LM.App.Wpf.ViewModels.Library.PdfPageThumbnailViewModel.PageNumber.get -> int
+LM.App.Wpf.ViewModels.Library.PdfPageThumbnailViewModel.Thumbnail.get -> System.Windows.Media.ImageSource!
+LM.App.Wpf.ViewModels.Library.PdfPageThumbnailViewModel.IsCurrent.get -> bool
+LM.App.Wpf.ViewModels.Library.PdfPageThumbnailViewModel.IsCurrent.set -> void
+LM.App.Wpf.ViewModels.Library.PdfViewerPaneTab
+LM.App.Wpf.ViewModels.Library.PdfViewerPaneTab.Thumbnails = 0 -> LM.App.Wpf.ViewModels.Library.PdfViewerPaneTab
+LM.App.Wpf.ViewModels.Library.PdfViewerPaneTab.Annotations = 1 -> LM.App.Wpf.ViewModels.Library.PdfViewerPaneTab
+LM.App.Wpf.ViewModels.Library.PdfViewerPaneTab.Outline = 2 -> LM.App.Wpf.ViewModels.Library.PdfViewerPaneTab
 LM.App.Wpf.ViewModels.Library.PdfViewerViewModel
-LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.PdfViewerViewModel() -> void
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.PdfViewerViewModel(LM.Core.Abstractions.Configuration.IUserPreferencesStore! preferencesStore) -> void
 LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.Entry.get -> LM.Core.Models.Entry?
 LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.Attachment.get -> LM.Core.Models.Attachment?
 LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.DocumentPath.get -> string?
 LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.WindowTitle.get -> string!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.Thumbnails.get -> System.Collections.ObjectModel.ReadOnlyObservableCollection<LM.App.Wpf.ViewModels.Library.PdfPageThumbnailViewModel!>!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.AnnotationItems.get -> System.Collections.ObjectModel.ReadOnlyObservableCollection<LM.App.Wpf.ViewModels.Library.PdfAnnotationListItemViewModel!>!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.OutlineItems.get -> System.Collections.ObjectModel.ReadOnlyObservableCollection<LM.App.Wpf.ViewModels.Library.PdfOutlineNodeViewModel!>!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.IsSidePaneVisible.get -> bool
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.SidePaneWidth.get -> System.Windows.GridLength
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.SelectedPaneTab.get -> LM.App.Wpf.ViewModels.Library.PdfViewerPaneTab
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.SelectedPaneTab.set -> void
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.ActiveAnnotationTool.get -> LM.App.Wpf.ViewModels.Library.PdfAnnotationTool
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.SelectedThumbnail.get -> LM.App.Wpf.ViewModels.Library.PdfPageThumbnailViewModel?
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.SelectedThumbnail.set -> void
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.SelectedAnnotation.get -> LM.App.Wpf.ViewModels.Library.PdfAnnotationListItemViewModel?
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.SelectedAnnotation.set -> void
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.SelectedOutline.get -> LM.App.Wpf.ViewModels.Library.PdfOutlineNodeViewModel?
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.SelectedOutline.set -> void
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.CurrentPageNumber.get -> int
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.SearchText.get -> string!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.SearchText.set -> void
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.MatchCase.get -> bool
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.MatchCase.set -> void
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.MatchWholeWord.get -> bool
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.MatchWholeWord.set -> void
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.ToggleSidePaneCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.ShowPageListCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.ZoomInCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.ZoomOutCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.FitWidthCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.FitHeightCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.ActualSizeCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.RotateClockwiseCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.RotateCounterClockwiseCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.FindNextCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.FindPreviousCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.FocusViewerCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.ActivateHighlightCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.ActivateUnderlineCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.ActivateRectangleCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.ActivateNoteCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.ClearSearchCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.BeginSearchCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.AttachSurface(LM.App.Wpf.ViewModels.Library.IPdfViewerSurface! surface) -> void
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.DetachSurface() -> void
 LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.InitializeAsync(LM.Core.Models.Entry! entry, string! absolutePath, string? attachmentId) -> System.Threading.Tasks.Task<bool>!
+LM.App.Wpf.ViewModels.Library.PdfViewerViewModel.SearchRequested -> System.EventHandler?
 LM.App.Wpf.Library.IAttachmentMetadataPrompt
 LM.App.Wpf.Library.IAttachmentMetadataPrompt.RequestMetadataAsync(LM.App.Wpf.Library.AttachmentMetadataPromptContext! context) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.AttachmentMetadataPromptResult?>!
 LM.App.Wpf.Library.AttachmentMetadataPromptContext

--- a/src/LM.App.Wpf/ViewModels/Library/IPdfViewerSurface.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/IPdfViewerSurface.cs
@@ -1,0 +1,33 @@
+#nullable enable
+using System;
+using System.Collections;
+using PdfiumViewer.Enums;
+
+namespace LM.App.Wpf.ViewModels.Library;
+
+public interface IPdfViewerSurface
+{
+    event EventHandler<int>? PageChanged;
+
+    int PageCount { get; }
+
+    void ZoomIn();
+
+    void ZoomOut();
+
+    void SetZoom(double zoom);
+
+    void SetZoomMode(PdfViewerZoomMode mode);
+
+    void RotateClockwise();
+
+    void RotateCounterClockwise();
+
+    bool TryNavigateToPage(int pageNumber);
+
+    IList? Search(string text, bool matchCase, bool wholeWord);
+
+    void ScrollIntoView(object match);
+
+    void FocusViewer();
+}

--- a/src/LM.App.Wpf/ViewModels/Library/PdfAnnotationListItemViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/PdfAnnotationListItemViewModel.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace LM.App.Wpf.ViewModels.Library;
+
+public sealed partial class PdfAnnotationListItemViewModel : ObservableObject
+{
+    public PdfAnnotationListItemViewModel(Guid annotationId,
+                                          string title,
+                                          string? tags,
+                                          System.Windows.Media.Brush accentBrush,
+                                          int pageNumber,
+                                          IRelayCommand navigateCommand,
+                                          IRelayCommand deleteCommand)
+    {
+        AnnotationId = annotationId;
+        Title = title ?? throw new ArgumentNullException(nameof(title));
+        Tags = tags;
+        AccentBrush = accentBrush ?? throw new ArgumentNullException(nameof(accentBrush));
+        PageNumber = pageNumber;
+        NavigateCommand = navigateCommand ?? throw new ArgumentNullException(nameof(navigateCommand));
+        DeleteCommand = deleteCommand ?? throw new ArgumentNullException(nameof(deleteCommand));
+    }
+
+    public Guid AnnotationId { get; }
+
+    public string Title { get; }
+
+    public string? Tags { get; }
+
+    public System.Windows.Media.Brush AccentBrush { get; }
+
+    public int PageNumber { get; }
+
+    public IRelayCommand NavigateCommand { get; }
+
+    public IRelayCommand DeleteCommand { get; }
+}

--- a/src/LM.App.Wpf/ViewModels/Library/PdfOutlineNodeViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/PdfOutlineNodeViewModel.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace LM.App.Wpf.ViewModels.Library;
+
+public sealed partial class PdfOutlineNodeViewModel : ObservableObject
+{
+    public PdfOutlineNodeViewModel(string title,
+                                   int? pageNumber,
+                                   string? targetUri,
+                                   IRelayCommand navigateCommand,
+                                   ObservableCollection<PdfOutlineNodeViewModel> children)
+    {
+        Title = title ?? throw new ArgumentNullException(nameof(title));
+        PageNumber = pageNumber;
+        TargetUri = targetUri;
+        NavigateCommand = navigateCommand ?? throw new ArgumentNullException(nameof(navigateCommand));
+        Children = children ?? throw new ArgumentNullException(nameof(children));
+    }
+
+    public string Title { get; }
+
+    public int? PageNumber { get; }
+
+    public string? TargetUri { get; }
+
+    public ObservableCollection<PdfOutlineNodeViewModel> Children { get; }
+
+    public IRelayCommand NavigateCommand { get; }
+
+    public bool HasDestination => PageNumber.HasValue || !string.IsNullOrWhiteSpace(TargetUri);
+}

--- a/src/LM.App.Wpf/ViewModels/Library/PdfPageThumbnailViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/PdfPageThumbnailViewModel.cs
@@ -1,0 +1,20 @@
+#nullable enable
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace LM.App.Wpf.ViewModels.Library;
+
+public sealed partial class PdfPageThumbnailViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool _isCurrent;
+
+    public PdfPageThumbnailViewModel(int pageNumber, System.Windows.Media.ImageSource thumbnail)
+    {
+        PageNumber = pageNumber;
+        Thumbnail = thumbnail ?? throw new System.ArgumentNullException(nameof(thumbnail));
+    }
+
+    public int PageNumber { get; }
+
+    public System.Windows.Media.ImageSource Thumbnail { get; }
+}

--- a/src/LM.App.Wpf/ViewModels/Library/PdfViewerViewModel.Commands.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/PdfViewerViewModel.Commands.cs
@@ -1,0 +1,123 @@
+#nullable enable
+using System;
+using CommunityToolkit.Mvvm.Input;
+using PdfiumViewer.Enums;
+
+namespace LM.App.Wpf.ViewModels.Library;
+
+public sealed partial class PdfViewerViewModel
+{
+    [RelayCommand]
+    private void ToggleSidePane()
+    {
+        IsSidePaneVisible = !IsSidePaneVisible;
+    }
+
+    [RelayCommand]
+    private void ShowPageList()
+    {
+        SelectedPaneTab = PdfViewerPaneTab.Thumbnails;
+        if (!IsSidePaneVisible)
+        {
+            IsSidePaneVisible = true;
+        }
+    }
+
+    [RelayCommand]
+    private void ZoomIn()
+    {
+        _surface?.ZoomIn();
+    }
+
+    [RelayCommand]
+    private void ZoomOut()
+    {
+        _surface?.ZoomOut();
+    }
+
+    [RelayCommand]
+    private void FitWidth()
+    {
+        _surface?.SetZoomMode(PdfViewerZoomMode.FitWidth);
+    }
+
+    [RelayCommand]
+    private void FitHeight()
+    {
+        _surface?.SetZoomMode(PdfViewerZoomMode.FitHeight);
+    }
+
+    [RelayCommand]
+    private void ActualSize()
+    {
+        _surface?.SetZoomMode(PdfViewerZoomMode.None);
+        _surface?.SetZoom(1.0);
+    }
+
+    [RelayCommand]
+    private void RotateClockwise()
+    {
+        _surface?.RotateClockwise();
+    }
+
+    [RelayCommand]
+    private void RotateCounterClockwise()
+    {
+        _surface?.RotateCounterClockwise();
+    }
+
+    [RelayCommand]
+    private void FindNext()
+    {
+        NavigateSearch(true);
+    }
+
+    [RelayCommand]
+    private void FindPrevious()
+    {
+        NavigateSearch(false);
+    }
+
+    [RelayCommand]
+    private void FocusViewer()
+    {
+        _surface?.FocusViewer();
+    }
+
+    [RelayCommand]
+    private void ActivateHighlight()
+    {
+        ActiveAnnotationTool = PdfAnnotationTool.Highlight;
+    }
+
+    [RelayCommand]
+    private void ActivateUnderline()
+    {
+        ActiveAnnotationTool = PdfAnnotationTool.Underline;
+    }
+
+    [RelayCommand]
+    private void ActivateRectangle()
+    {
+        ActiveAnnotationTool = PdfAnnotationTool.Rectangle;
+    }
+
+    [RelayCommand]
+    private void ActivateNote()
+    {
+        ActiveAnnotationTool = PdfAnnotationTool.Note;
+    }
+
+    [RelayCommand]
+    private void ClearSearch()
+    {
+        SearchText = string.Empty;
+        ResetSearchState();
+    }
+
+    [RelayCommand]
+    private void BeginSearch()
+    {
+        SearchRequested?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Library/PdfViewerViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/PdfViewerViewModel.cs
@@ -1,75 +1,594 @@
 #nullable enable
 using System;
+using System.Collections.ObjectModel;
+using System.Collections;
+using System.Drawing.Imaging;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using LM.App.Wpf.Common;
+using LM.Core.Abstractions.Configuration;
 using LM.Core.Models;
+using PdfiumViewer;
+using PdfiumViewer.Enums;
+using UglyToad.PdfPig.Outline;
 
-namespace LM.App.Wpf.ViewModels.Library
+namespace LM.App.Wpf.ViewModels.Library;
+
+public enum PdfViewerPaneTab
 {
-    public sealed class PdfViewerViewModel : ViewModelBase
+    Thumbnails,
+    Annotations,
+    Outline
+}
+
+public enum PdfAnnotationTool
+{
+    None,
+    Highlight,
+    Underline,
+    Rectangle,
+    Note
+}
+
+public sealed partial class PdfViewerViewModel : ViewModelBase
+{
+    private const double DefaultSidePaneWidth = 320;
+
+    private readonly IUserPreferencesStore _preferencesStore;
+    private readonly ObservableCollection<PdfPageThumbnailViewModel> _thumbnails = new();
+    private readonly ObservableCollection<PdfAnnotationListItemViewModel> _annotations = new();
+    private readonly ObservableCollection<PdfOutlineNodeViewModel> _outlineNodes = new();
+
+    private Entry? _entry;
+    private Attachment? _attachment;
+    private string? _documentPath;
+    private bool _isSidePaneVisible = true;
+    private System.Windows.GridLength _sidePaneWidth = new System.Windows.GridLength(DefaultSidePaneWidth);
+    private PdfViewerPaneTab _selectedPaneTab = PdfViewerPaneTab.Thumbnails;
+    private PdfAnnotationTool _activeAnnotationTool = PdfAnnotationTool.Highlight;
+    private PdfPageThumbnailViewModel? _selectedThumbnail;
+    private PdfAnnotationListItemViewModel? _selectedAnnotation;
+    private PdfOutlineNodeViewModel? _selectedOutline;
+    private int _currentPageNumber = 1;
+    private string _searchText = string.Empty;
+    private bool _matchCase;
+    private bool _matchWholeWord;
+    private IList? _searchMatches;
+    private string _searchSignature = string.Empty;
+    private int _searchMatchIndex = -1;
+    private bool _suppressThumbnailSync;
+    private IPdfViewerSurface? _surface;
+    private UserPreferences _preferences = new();
+
+    public event EventHandler? SearchRequested;
+
+    public PdfViewerViewModel(IUserPreferencesStore preferencesStore)
     {
-        private Entry? _entry;
-        private Attachment? _attachment;
-        private string? _documentPath;
+        _preferencesStore = preferencesStore ?? throw new ArgumentNullException(nameof(preferencesStore));
 
-        public Entry? Entry => _entry;
+        Thumbnails = new ReadOnlyObservableCollection<PdfPageThumbnailViewModel>(_thumbnails);
+        AnnotationItems = new ReadOnlyObservableCollection<PdfAnnotationListItemViewModel>(_annotations);
+        OutlineItems = new ReadOnlyObservableCollection<PdfOutlineNodeViewModel>(_outlineNodes);
 
-        public Attachment? Attachment => _attachment;
+        _ = LoadPreferencesAsync();
+    }
 
-        public string? DocumentPath
+    public Entry? Entry => _entry;
+
+    public Attachment? Attachment => _attachment;
+
+    public string? DocumentPath
+    {
+        get => _documentPath;
+        private set
         {
-            get => _documentPath;
-            private set => SetProperty(ref _documentPath, value);
-        }
-
-        public string WindowTitle
-        {
-            get
+            if (SetProperty(ref _documentPath, value))
             {
-                if (_entry is null)
-                {
-                    return "PDF Viewer";
-                }
-
-                if (_attachment is not null && !string.IsNullOrWhiteSpace(_attachment.Title))
-                {
-                    return string.IsNullOrWhiteSpace(_entry.Title)
-                        ? _attachment.Title
-                        : $"{_attachment.Title} — {_entry.Title}";
-                }
-
-                return string.IsNullOrWhiteSpace(_entry.Title) ? "PDF Viewer" : _entry.Title;
+                ResetSearchState();
             }
         }
+    }
 
-        public Task<bool> InitializeAsync(Entry entry, string absolutePath, string? attachmentId)
+    public string WindowTitle
+    {
+        get
         {
-            ArgumentNullException.ThrowIfNull(entry);
-
-            if (string.IsNullOrWhiteSpace(absolutePath))
+            if (_entry is null)
             {
-                return Task.FromResult(false);
+                return "PDF Viewer";
             }
 
-            _entry = entry;
-            _attachment = null;
-
-            if (!string.IsNullOrWhiteSpace(attachmentId))
+            if (_attachment is not null && !string.IsNullOrWhiteSpace(_attachment.Title))
             {
-                _attachment = entry.Attachments.FirstOrDefault(a => a.Id == attachmentId);
-                if (_attachment is null)
+                return string.IsNullOrWhiteSpace(_entry.Title)
+                    ? _attachment.Title
+                    : $"{_attachment.Title} — {_entry.Title}";
+            }
+
+            return string.IsNullOrWhiteSpace(_entry.Title) ? "PDF Viewer" : _entry.Title;
+        }
+    }
+
+    public ReadOnlyObservableCollection<PdfPageThumbnailViewModel> Thumbnails { get; }
+
+    public ReadOnlyObservableCollection<PdfAnnotationListItemViewModel> AnnotationItems { get; }
+
+    public ReadOnlyObservableCollection<PdfOutlineNodeViewModel> OutlineItems { get; }
+
+    public bool IsSidePaneVisible
+    {
+        get => _isSidePaneVisible;
+        private set
+        {
+            if (SetProperty(ref _isSidePaneVisible, value))
+            {
+                UpdateSidePaneWidth();
+                _ = PersistPreferencesAsync();
+            }
+        }
+    }
+
+    public System.Windows.GridLength SidePaneWidth
+    {
+        get => _sidePaneWidth;
+        private set => SetProperty(ref _sidePaneWidth, value);
+    }
+
+    public PdfViewerPaneTab SelectedPaneTab
+    {
+        get => _selectedPaneTab;
+        set => SetProperty(ref _selectedPaneTab, value);
+    }
+
+    public PdfAnnotationTool ActiveAnnotationTool
+    {
+        get => _activeAnnotationTool;
+        private set => SetProperty(ref _activeAnnotationTool, value);
+    }
+
+    public PdfPageThumbnailViewModel? SelectedThumbnail
+    {
+        get => _selectedThumbnail;
+        set
+        {
+            if (SetProperty(ref _selectedThumbnail, value) && value is not null && !_suppressThumbnailSync)
+            {
+                _surface?.TryNavigateToPage(value.PageNumber);
+            }
+        }
+    }
+
+    public PdfAnnotationListItemViewModel? SelectedAnnotation
+    {
+        get => _selectedAnnotation;
+        set
+        {
+            if (SetProperty(ref _selectedAnnotation, value) && value is not null)
+            {
+                value.NavigateCommand.Execute(null);
+            }
+        }
+    }
+
+    public PdfOutlineNodeViewModel? SelectedOutline
+    {
+        get => _selectedOutline;
+        set
+        {
+            if (SetProperty(ref _selectedOutline, value) && value is not null && value.HasDestination)
+            {
+                value.NavigateCommand.Execute(null);
+            }
+        }
+    }
+
+    public int CurrentPageNumber
+    {
+        get => _currentPageNumber;
+        private set
+        {
+            if (SetProperty(ref _currentPageNumber, value))
+            {
+                SynchronizeThumbnailSelection(value);
+            }
+        }
+    }
+
+    public string SearchText
+    {
+        get => _searchText;
+        set
+        {
+            if (SetProperty(ref _searchText, value))
+            {
+                ResetSearchState();
+            }
+        }
+    }
+
+    public bool MatchCase
+    {
+        get => _matchCase;
+        set
+        {
+            if (SetProperty(ref _matchCase, value))
+            {
+                ResetSearchState();
+            }
+        }
+    }
+
+    public bool MatchWholeWord
+    {
+        get => _matchWholeWord;
+        set
+        {
+            if (SetProperty(ref _matchWholeWord, value))
+            {
+                ResetSearchState();
+            }
+        }
+    }
+
+    public void AttachSurface(IPdfViewerSurface surface)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+
+        if (_surface is not null)
+        {
+            _surface.PageChanged -= OnSurfacePageChanged;
+        }
+
+        _surface = surface;
+        _surface.PageChanged += OnSurfacePageChanged;
+        UpdateSidePaneWidth();
+    }
+
+    public void DetachSurface()
+    {
+        if (_surface is null)
+        {
+            return;
+        }
+
+        _surface.PageChanged -= OnSurfacePageChanged;
+        _surface = null;
+    }
+
+    public async Task<bool> InitializeAsync(Entry entry, string absolutePath, string? attachmentId)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        if (string.IsNullOrWhiteSpace(absolutePath))
+        {
+            return false;
+        }
+
+        _entry = entry;
+        _attachment = null;
+
+        if (!string.IsNullOrWhiteSpace(attachmentId))
+        {
+            _attachment = entry.Attachments.FirstOrDefault(a => a.Id == attachmentId);
+            if (_attachment is null)
+            {
+                return false;
+            }
+        }
+
+        DocumentPath = absolutePath;
+        OnPropertyChanged(nameof(Entry));
+        OnPropertyChanged(nameof(Attachment));
+        OnPropertyChanged(nameof(WindowTitle));
+
+        await LoadDocumentArtifactsAsync(absolutePath).ConfigureAwait(true);
+        SelectedPaneTab = PdfViewerPaneTab.Thumbnails;
+        _ = Thumbnails.FirstOrDefault();
+        return true;
+    }
+
+    private async Task LoadPreferencesAsync()
+    {
+        try
+        {
+            _preferences = await _preferencesStore.LoadAsync().ConfigureAwait(true);
+        }
+        catch
+        {
+            _preferences = new UserPreferences();
+        }
+
+        _isSidePaneVisible = _preferences.Library.ShowPdfNavigationPane;
+        UpdateSidePaneWidth();
+        OnPropertyChanged(nameof(IsSidePaneVisible));
+    }
+
+    private async Task PersistPreferencesAsync()
+    {
+        var updatedLibrary = _preferences.Library with
+        {
+            ShowPdfNavigationPane = IsSidePaneVisible,
+            LastUpdatedUtc = DateTimeOffset.UtcNow
+        };
+
+        _preferences = _preferences with { Library = updatedLibrary };
+
+        try
+        {
+            await _preferencesStore.SaveAsync(_preferences).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Swallow preference persistence failures.
+        }
+    }
+
+    private async Task LoadDocumentArtifactsAsync(string absolutePath)
+    {
+        await LoadThumbnailsAsync(absolutePath).ConfigureAwait(true);
+        await LoadOutlineAsync(absolutePath).ConfigureAwait(true);
+
+        if (_thumbnails.Count > 0)
+        {
+            CurrentPageNumber = 1;
+            _suppressThumbnailSync = true;
+            try
+            {
+                SelectedThumbnail = _thumbnails.FirstOrDefault();
+                UpdateThumbnailSelectionState(CurrentPageNumber);
+            }
+            finally
+            {
+                _suppressThumbnailSync = false;
+            }
+        }
+    }
+
+    private Task LoadThumbnailsAsync(string absolutePath)
+    {
+        _thumbnails.Clear();
+
+        try
+        {
+            var documentType = Type.GetType("PdfiumViewer.PdfDocument, PdfiumViewer");
+            if (documentType is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            var loadMethod = documentType.GetMethod("Load", new[] { typeof(string) });
+            if (loadMethod is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            dynamic? document = null;
+            try
+            {
+                document = loadMethod.Invoke(null, new object[] { absolutePath });
+                if (document is null)
                 {
-                    return Task.FromResult(false);
+                    return Task.CompletedTask;
+                }
+
+                int pageCount = document.PageCount;
+                for (var index = 0; index < pageCount; index++)
+                {
+                    dynamic pageSize = document.PageSizes[index];
+                    var width = Convert.ToDouble(pageSize.Width, CultureInfo.InvariantCulture);
+                    var height = Convert.ToDouble(pageSize.Height, CultureInfo.InvariantCulture);
+                    var targetWidth = 160;
+                    var targetHeight = (int)Math.Max(40, targetWidth * height / Math.Max(1d, width));
+                    using System.Drawing.Image image = document.Render(index, targetWidth, targetHeight, 96, 96, false);
+                    var bitmap = CreateBitmap(image);
+                    _thumbnails.Add(new PdfPageThumbnailViewModel(index + 1, bitmap));
                 }
             }
+            finally
+            {
+                if (document is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
+        }
+        catch
+        {
+            _thumbnails.Clear();
+        }
 
-            DocumentPath = absolutePath;
-            OnPropertyChanged(nameof(Entry));
-            OnPropertyChanged(nameof(Attachment));
-            OnPropertyChanged(nameof(WindowTitle));
+        return Task.CompletedTask;
+    }
 
-            return Task.FromResult(true);
+    private Task LoadOutlineAsync(string absolutePath)
+    {
+        _outlineNodes.Clear();
+
+        try
+        {
+            using var document = UglyToad.PdfPig.PdfDocument.Open(absolutePath);
+            if (document.TryGetBookmarks(out var bookmarks) && bookmarks?.Roots?.Count > 0)
+            {
+                foreach (var root in bookmarks.Roots)
+                {
+                    var node = CreateOutlineNode(root);
+                    _outlineNodes.Add(node);
+                }
+            }
+        }
+        catch
+        {
+            _outlineNodes.Clear();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private PdfOutlineNodeViewModel CreateOutlineNode(BookmarkNode node)
+    {
+        int? pageNumber = null;
+        string? uri = null;
+
+        if (node is DocumentBookmarkNode documentNode)
+        {
+            pageNumber = documentNode.PageNumber;
+        }
+        else if (node is UriBookmarkNode uriNode)
+        {
+            uri = uriNode.Uri;
+        }
+
+        var children = new ObservableCollection<PdfOutlineNodeViewModel>();
+        foreach (var child in node.Children)
+        {
+            children.Add(CreateOutlineNode(child));
+        }
+
+        var navigate = new CommunityToolkit.Mvvm.Input.RelayCommand(() => NavigateToOutlineDestination(pageNumber, uri));
+        return new PdfOutlineNodeViewModel(node.Title, pageNumber, uri, navigate, children);
+    }
+
+    private void NavigateToOutlineDestination(int? pageNumber, string? uri)
+    {
+        if (pageNumber.HasValue && pageNumber.Value > 0)
+        {
+            _surface?.TryNavigateToPage(pageNumber.Value);
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(uri))
+        {
+            TryLaunchUri(uri);
+        }
+    }
+
+    private static System.Windows.Media.Imaging.BitmapImage CreateBitmap(System.Drawing.Image image)
+    {
+        using var stream = new MemoryStream();
+        image.Save(stream, ImageFormat.Png);
+        stream.Position = 0;
+
+        using var imageStream = new MemoryStream(stream.ToArray());
+        var bitmap = new System.Windows.Media.Imaging.BitmapImage();
+        bitmap.BeginInit();
+        bitmap.CacheOption = System.Windows.Media.Imaging.BitmapCacheOption.OnLoad;
+        bitmap.StreamSource = imageStream;
+        bitmap.EndInit();
+        bitmap.Freeze();
+        return bitmap;
+    }
+
+    private void OnSurfacePageChanged(object? sender, int pageNumber)
+    {
+        if (pageNumber <= 0)
+        {
+            return;
+        }
+
+        CurrentPageNumber = pageNumber;
+    }
+
+    private void SynchronizeThumbnailSelection(int pageNumber)
+    {
+        if (_thumbnails.Count == 0)
+        {
+            return;
+        }
+
+        _suppressThumbnailSync = true;
+        try
+        {
+            var match = _thumbnails.FirstOrDefault(t => t.PageNumber == pageNumber);
+            if (match is not null)
+            {
+                SelectedThumbnail = match;
+            }
+            UpdateThumbnailSelectionState(pageNumber);
+        }
+        finally
+        {
+            _suppressThumbnailSync = false;
+        }
+    }
+
+    private void UpdateThumbnailSelectionState(int pageNumber)
+    {
+        foreach (var thumbnail in _thumbnails)
+        {
+            thumbnail.IsCurrent = thumbnail.PageNumber == pageNumber;
+        }
+    }
+
+    private void ResetSearchState()
+    {
+        _searchMatches = null;
+        _searchMatchIndex = -1;
+        _searchSignature = string.Empty;
+    }
+
+    private void UpdateSidePaneWidth()
+    {
+        SidePaneWidth = _isSidePaneVisible
+            ? new System.Windows.GridLength(DefaultSidePaneWidth)
+            : new System.Windows.GridLength(0);
+    }
+
+    private void NavigateSearch(bool forward)
+    {
+        if (_surface is null || string.IsNullOrWhiteSpace(SearchText))
+        {
+            return;
+        }
+
+        var signature = string.Format(CultureInfo.InvariantCulture, "{0}|{1}|{2}", SearchText, MatchCase, MatchWholeWord);
+        if (!string.Equals(_searchSignature, signature, StringComparison.Ordinal))
+        {
+            _searchMatches = _surface.Search(SearchText, MatchCase, MatchWholeWord);
+            _searchMatchIndex = -1;
+            _searchSignature = signature;
+        }
+
+        if (_searchMatches is null || _searchMatches.Count == 0)
+        {
+            return;
+        }
+
+        if (forward)
+        {
+            _searchMatchIndex = (_searchMatchIndex + 1) % _searchMatches.Count;
+        }
+        else
+        {
+            _searchMatchIndex = (_searchMatchIndex - 1 + _searchMatches.Count) % _searchMatches.Count;
+        }
+
+        var match = _searchMatches[_searchMatchIndex];
+        if (match is null)
+        {
+            return;
+        }
+
+        _surface.ScrollIntoView(match);
+    }
+
+    private static void TryLaunchUri(string uri)
+    {
+        try
+        {
+            var info = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = uri,
+                UseShellExecute = true
+            };
+            System.Diagnostics.Process.Start(info);
+        }
+        catch
+        {
+            // Ignore failures.
         }
     }
 }

--- a/src/LM.App.Wpf/Views/Library/Converters/EnumEqualsConverter.cs
+++ b/src/LM.App.Wpf/Views/Library/Converters/EnumEqualsConverter.cs
@@ -1,0 +1,57 @@
+#nullable enable
+using System;
+using System.Globalization;
+
+namespace LM.App.Wpf.Views.Library.Converters;
+
+internal sealed class EnumEqualsConverter : System.Windows.Data.IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is null || parameter is null)
+        {
+            return false;
+        }
+
+        var valueType = value.GetType();
+        if (!valueType.IsEnum)
+        {
+            return false;
+        }
+
+        if (parameter is string parameterString)
+        {
+            try
+            {
+                var parsed = Enum.Parse(valueType, parameterString, ignoreCase: true);
+                return value.Equals(parsed);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        if (parameter.GetType() == valueType)
+        {
+            return value.Equals(parameter);
+        }
+
+        return false;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (!targetType.IsEnum || value is not bool isChecked || !isChecked || parameter is null)
+        {
+            return System.Windows.Data.Binding.DoNothing;
+        }
+
+        if (parameter is string parameterString)
+        {
+            return Enum.Parse(targetType, parameterString, ignoreCase: true);
+        }
+
+        return parameter;
+    }
+}

--- a/src/LM.App.Wpf/Views/Library/PdfViewerWindow.xaml
+++ b/src/LM.App.Wpf/Views/Library/PdfViewerWindow.xaml
@@ -4,6 +4,9 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:controls="clr-namespace:LM.App.Wpf.Views.Library.Controls"
+        xmlns:converters="clr-namespace:LM.App.Wpf.Views.Library.Converters"
+        xmlns:vm="clr-namespace:LM.App.Wpf.ViewModels.Library"
+        xmlns:pr="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
         x:ClassModifier="internal"
         mc:Ignorable="d"
         Title="{Binding WindowTitle}"
@@ -11,7 +14,244 @@
         Height="720"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
-  <Grid Margin="12">
-    <controls:PdfInteractiveViewer SourcePath="{Binding DocumentPath}" />
-  </Grid>
+    <Window.Resources>
+        <converters:EnumEqualsConverter x:Key="EnumEqualsConverter" />
+        <pr:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <Style x:Key="ThumbnailBorderStyle" TargetType="Border">
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Margin" Value="4" />
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsCurrent}" Value="True">
+                    <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                    <Setter Property="BorderThickness" Value="2" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
+    <Window.InputBindings>
+        <KeyBinding Command="{Binding BeginSearchCommand}" Key="F" Modifiers="Control" />
+        <KeyBinding Command="{Binding ActivateHighlightCommand}" Key="H" Modifiers="Control" />
+        <KeyBinding Command="{Binding ActivateUnderlineCommand}" Key="U" Modifiers="Control" />
+        <KeyBinding Command="{Binding ActivateRectangleCommand}" Key="R" Modifiers="Control" />
+        <KeyBinding Command="{Binding ActivateNoteCommand}" Key="N" Modifiers="Control" />
+        <KeyBinding Command="{Binding FindNextCommand}" Key="F3" />
+        <KeyBinding Command="{Binding FindPreviousCommand}" Key="F3" Modifiers="Shift" />
+    </Window.InputBindings>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <ToolBarTray Grid.Row="0" Background="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}">
+            <ToolBar>
+                <Button Content="Pages"
+                        AutomationProperties.AutomationId="ToolbarPagesButton"
+                        Command="{Binding ShowPageListCommand}" />
+                <Separator />
+                <Button Content="-"
+                        AutomationProperties.AutomationId="ToolbarZoomOutButton"
+                        Command="{Binding ZoomOutCommand}" />
+                <Button Content="+"
+                        AutomationProperties.AutomationId="ToolbarZoomInButton"
+                        Command="{Binding ZoomInCommand}" />
+                <Button Content="Fit W"
+                        AutomationProperties.AutomationId="ToolbarFitWidthButton"
+                        Command="{Binding FitWidthCommand}" />
+                <Button Content="Fit H"
+                        AutomationProperties.AutomationId="ToolbarFitHeightButton"
+                        Command="{Binding FitHeightCommand}" />
+                <Button Content="Actual"
+                        AutomationProperties.AutomationId="ToolbarActualSizeButton"
+                        Command="{Binding ActualSizeCommand}" />
+                <Separator />
+                <Button Content="⟲"
+                        AutomationProperties.AutomationId="ToolbarRotateLeftButton"
+                        Command="{Binding RotateCounterClockwiseCommand}" />
+                <Button Content="⟳"
+                        AutomationProperties.AutomationId="ToolbarRotateRightButton"
+                        Command="{Binding RotateClockwiseCommand}" />
+                <Separator />
+                <TextBox x:Name="SearchTextBox"
+                         Width="180"
+                         Margin="4,0"
+                         AutomationProperties.AutomationId="ToolbarSearchTextBox"
+                         Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+                <CheckBox Content="Case"
+                          Margin="4,0"
+                          AutomationProperties.AutomationId="ToolbarMatchCaseCheckbox"
+                          IsChecked="{Binding MatchCase}" />
+                <CheckBox Content="Whole"
+                          Margin="4,0"
+                          AutomationProperties.AutomationId="ToolbarMatchWholeCheckbox"
+                          IsChecked="{Binding MatchWholeWord}" />
+                <Button Content="Find"
+                        AutomationProperties.AutomationId="ToolbarFindNextButton"
+                        Command="{Binding FindNextCommand}" />
+                <Button Content="Prev"
+                        AutomationProperties.AutomationId="ToolbarFindPreviousButton"
+                        Command="{Binding FindPreviousCommand}" />
+                <Button Content="Clear"
+                        AutomationProperties.AutomationId="ToolbarClearSearchButton"
+                        Command="{Binding ClearSearchCommand}" />
+            </ToolBar>
+            <ToolBar Band="1">
+                <ToggleButton Content="Highlight"
+                              AutomationProperties.AutomationId="AnnotationHighlightToggle"
+                              Command="{Binding ActivateHighlightCommand}">
+                    <ToggleButton.IsChecked>
+                        <Binding Path="ActiveAnnotationTool"
+                                 Converter="{StaticResource EnumEqualsConverter}"
+                                 ConverterParameter="Highlight" />
+                    </ToggleButton.IsChecked>
+                </ToggleButton>
+                <ToggleButton Content="Underline"
+                              AutomationProperties.AutomationId="AnnotationUnderlineToggle"
+                              Command="{Binding ActivateUnderlineCommand}">
+                    <ToggleButton.IsChecked>
+                        <Binding Path="ActiveAnnotationTool"
+                                 Converter="{StaticResource EnumEqualsConverter}"
+                                 ConverterParameter="Underline" />
+                    </ToggleButton.IsChecked>
+                </ToggleButton>
+                <ToggleButton Content="Rectangle"
+                              AutomationProperties.AutomationId="AnnotationRectangleToggle"
+                              Command="{Binding ActivateRectangleCommand}">
+                    <ToggleButton.IsChecked>
+                        <Binding Path="ActiveAnnotationTool"
+                                 Converter="{StaticResource EnumEqualsConverter}"
+                                 ConverterParameter="Rectangle" />
+                    </ToggleButton.IsChecked>
+                </ToggleButton>
+                <ToggleButton Content="Note"
+                              AutomationProperties.AutomationId="AnnotationNoteToggle"
+                              Command="{Binding ActivateNoteCommand}">
+                    <ToggleButton.IsChecked>
+                        <Binding Path="ActiveAnnotationTool"
+                                 Converter="{StaticResource EnumEqualsConverter}"
+                                 ConverterParameter="Note" />
+                    </ToggleButton.IsChecked>
+                </ToggleButton>
+            </ToolBar>
+        </ToolBarTray>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="{Binding SidePaneWidth}" />
+                <ColumnDefinition Width="4" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0"
+                    BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                    BorderThickness="0,0,1,0"
+                    Background="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}">
+                <TabControl SelectedValue="{Binding SelectedPaneTab}"
+                            AutomationProperties.AutomationId="NavigationTabControl"
+                            SelectedValuePath="Tag"
+                            BorderThickness="0"
+                            Padding="0">
+                    <TabItem Header="Thumbnails" Tag="Thumbnails" AutomationProperties.AutomationId="NavigationThumbnailsTab">
+                        <ListBox ItemsSource="{Binding Thumbnails}"
+                                 SelectedItem="{Binding SelectedThumbnail}"
+                                 BorderThickness="0"
+                                 Background="Transparent">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel>
+                                        <Border Style="{StaticResource ThumbnailBorderStyle}">
+                                            <Image Source="{Binding Thumbnail}"
+                                                   Height="140"
+                                                   Stretch="Uniform" />
+                                        </Border>
+                                        <TextBlock Text="{Binding PageNumber}"
+                                                   HorizontalAlignment="Center"
+                                                   FontSize="11" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </TabItem>
+                    <TabItem Header="Annotations" Tag="Annotations" AutomationProperties.AutomationId="NavigationAnnotationsTab">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <ListBox ItemsSource="{Binding AnnotationItems}"
+                                     SelectedItem="{Binding SelectedAnnotation}"
+                                     BorderThickness="0">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Padding="6"
+                                                Margin="2"
+                                                BorderBrush="{Binding AccentBrush}"
+                                                BorderThickness="1">
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Title}" FontWeight="Bold" />
+                                                <TextBlock Text="{Binding Tags}" FontSize="11" Foreground="Gray" />
+                                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                                    <Button Content="Go"
+                                                            Command="{Binding NavigateCommand}" />
+                                                    <Button Content="Delete"
+                                                            Margin="6,0,0,0"
+                                                            Command="{Binding DeleteCommand}" />
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                            <TextBlock Grid.Row="1"
+                                       Text="No annotations available"
+                                       FontStyle="Italic"
+                                       Foreground="Gray"
+                                       HorizontalAlignment="Center"
+                                       Margin="0,4,0,8">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding AnnotationItems.Count}" Value="0">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </Grid>
+                    </TabItem>
+                    <TabItem Header="Outline" Tag="Outline" AutomationProperties.AutomationId="NavigationOutlineTab">
+                        <TreeView x:Name="OutlineTree"
+                                  ItemsSource="{Binding OutlineItems}">
+                            <TreeView.Resources>
+                                <HierarchicalDataTemplate DataType="{x:Type vm:PdfOutlineNodeViewModel}" ItemsSource="{Binding Children}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="{Binding Title}" />
+                                        <Button Content="Go"
+                                                Margin="6,0,0,0"
+                                                Command="{Binding NavigateCommand}" />
+                                    </StackPanel>
+                                </HierarchicalDataTemplate>
+                            </TreeView.Resources>
+                        </TreeView>
+                    </TabItem>
+                </TabControl>
+            </Border>
+
+            <GridSplitter Grid.Column="1"
+                          Width="4"
+                          Background="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                          HorizontalAlignment="Center"
+                          VerticalAlignment="Stretch"
+                          Visibility="{Binding IsSidePaneVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+            <Border Grid.Column="2"
+                    Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
+                <controls:PdfInteractiveViewer x:Name="ViewerControl"
+                                               SourcePath="{Binding DocumentPath}" />
+            </Border>
+        </Grid>
+    </Grid>
 </Window>

--- a/src/LM.App.Wpf/Views/Library/PdfViewerWindow.xaml.cs
+++ b/src/LM.App.Wpf/Views/Library/PdfViewerWindow.xaml.cs
@@ -1,12 +1,105 @@
 #nullable enable
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using LM.App.Wpf.ViewModels.Library;
 
 namespace LM.App.Wpf.Views.Library
 {
-    internal sealed partial class PdfViewerWindow : System.Windows.Window
+    internal sealed partial class PdfViewerWindow : Window
     {
+        private PdfViewerSurfaceAdapter? _surfaceAdapter;
+
         public PdfViewerWindow()
         {
             InitializeComponent();
+            OutlineTree.SelectedItemChanged += OnOutlineTreeSelectedItemChanged;
+            DataContextChanged += OnDataContextChanged;
+        }
+
+        private void OnDataContextChanged(object? sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.OldValue is PdfViewerViewModel oldViewModel)
+            {
+                oldViewModel.SearchRequested -= OnSearchRequested;
+                oldViewModel.DetachSurface();
+            }
+
+            if (e.NewValue is PdfViewerViewModel viewModel)
+            {
+                EnsureSurfaceAdapter();
+                viewModel.AttachSurface(_surfaceAdapter!);
+                viewModel.SearchRequested += OnSearchRequested;
+            }
+        }
+
+        private void EnsureSurfaceAdapter()
+        {
+            if (_surfaceAdapter is not null)
+            {
+                return;
+            }
+
+            _surfaceAdapter = new PdfViewerSurfaceAdapter(ViewerControl);
+        }
+
+        private void OnSearchRequested(object? sender, EventArgs e)
+        {
+            SearchTextBox.Focus();
+            SearchTextBox.SelectAll();
+        }
+
+        private void OnOutlineTreeSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        {
+            if (DataContext is not PdfViewerViewModel viewModel)
+            {
+                return;
+            }
+
+            if (e.NewValue is PdfOutlineNodeViewModel node)
+            {
+                viewModel.SelectedOutline = node;
+            }
+        }
+
+        private sealed class PdfViewerSurfaceAdapter : IPdfViewerSurface
+        {
+            private readonly Controls.PdfInteractiveViewer _viewer;
+
+            public PdfViewerSurfaceAdapter(Controls.PdfInteractiveViewer viewer)
+            {
+                _viewer = viewer ?? throw new ArgumentNullException(nameof(viewer));
+                _viewer.PageChanged += OnViewerPageChanged;
+            }
+
+            public event EventHandler<int>? PageChanged;
+
+            public int PageCount => _viewer.GetPageCount();
+
+            public void ZoomIn() => _viewer.ZoomIn();
+
+            public void ZoomOut() => _viewer.ZoomOut();
+
+            public void SetZoom(double zoom) => _viewer.SetZoom(zoom);
+
+            public void SetZoomMode(PdfiumViewer.Enums.PdfViewerZoomMode mode) => _viewer.SetZoomMode(mode);
+
+            public void RotateClockwise() => _viewer.RotateClockwise();
+
+            public void RotateCounterClockwise() => _viewer.RotateCounterClockwise();
+
+            public bool TryNavigateToPage(int pageNumber) => _viewer.TryNavigateToPage(pageNumber);
+
+            public System.Collections.IList? Search(string text, bool matchCase, bool wholeWord) => _viewer.Search(text, matchCase, wholeWord);
+
+            public void ScrollIntoView(object match) => _viewer.ScrollIntoView(match);
+
+            public void FocusViewer() => _viewer.FocusViewer();
+
+            private void OnViewerPageChanged(object? sender, int e)
+            {
+                PageChanged?.Invoke(this, e);
+            }
         }
     }
 }

--- a/src/LM.Core/Models/UserPreferences.cs
+++ b/src/LM.Core/Models/UserPreferences.cs
@@ -20,6 +20,7 @@ namespace LM.Core.Models
     public sealed record class LibraryPreferences
     {
         public string[] VisibleColumns { get; init; } = Array.Empty<string>();
+        public bool ShowPdfNavigationPane { get; init; } = true;
         public DateTimeOffset LastUpdatedUtc { get; init; } = DateTimeOffset.UtcNow;
     }
 }

--- a/src/LM.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Core/PublicAPI.Unshipped.txt
@@ -427,6 +427,8 @@ LM.Core.Models.SearchPreferences.LastUpdatedUtc.init -> void
 LM.Core.Models.LibraryPreferences
 LM.Core.Models.LibraryPreferences.VisibleColumns.get -> string![]!
 LM.Core.Models.LibraryPreferences.VisibleColumns.init -> void
+LM.Core.Models.LibraryPreferences.ShowPdfNavigationPane.get -> bool
+LM.Core.Models.LibraryPreferences.ShowPdfNavigationPane.init -> void
 LM.Core.Models.LibraryPreferences.LastUpdatedUtc.get -> System.DateTimeOffset
 LM.Core.Models.LibraryPreferences.LastUpdatedUtc.init -> void
 LM.Core.Models.WatchedFolderSettings


### PR DESCRIPTION
## Summary
- redesign the PDF viewer window with toolbars, keyboard shortcuts, and a collapsible navigation pane backed by thumbnails, annotations, and outline tabs
- add viewer-facing view models, commands, and surface abstraction plus UI automation coverage for toolbar and tab interactions
- register the window and view model in DI, persist the new navigation preference, and record the updated public APIs

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: LM.Infrastructure.Tests.Review.JsonReviewProjectStoreTests.SaveAssignmentAsync_RemovesLegacyLockFile)*

------
https://chatgpt.com/codex/tasks/task_e_68da7ecc7c34832bb7b9a8a70c679e7d