### PR TITLE
Fix annotation tool toggle bindings to avoid write attempts

### DIFF
--- a/src/LM.App.Wpf/Views/Library/PdfViewerWindow.xaml
+++ b/src/LM.App.Wpf/Views/Library/PdfViewerWindow.xaml
@@ -103,7 +103,8 @@
                     <ToggleButton.IsChecked>
                         <Binding Path="ActiveAnnotationTool"
                                  Converter="{StaticResource EnumEqualsConverter}"
-                                 ConverterParameter="Highlight" />
+                                 ConverterParameter="Highlight"
+                                 Mode="OneWay" />
                     </ToggleButton.IsChecked>
                 </ToggleButton>
                 <ToggleButton Content="Underline"
@@ -112,7 +113,8 @@
                     <ToggleButton.IsChecked>
                         <Binding Path="ActiveAnnotationTool"
                                  Converter="{StaticResource EnumEqualsConverter}"
-                                 ConverterParameter="Underline" />
+                                 ConverterParameter="Underline"
+                                 Mode="OneWay" />
                     </ToggleButton.IsChecked>
                 </ToggleButton>
                 <ToggleButton Content="Rectangle"
@@ -121,7 +123,8 @@
                     <ToggleButton.IsChecked>
                         <Binding Path="ActiveAnnotationTool"
                                  Converter="{StaticResource EnumEqualsConverter}"
-                                 ConverterParameter="Rectangle" />
+                                 ConverterParameter="Rectangle"
+                                 Mode="OneWay" />
                     </ToggleButton.IsChecked>
                 </ToggleButton>
                 <ToggleButton Content="Note"
@@ -130,7 +133,8 @@
                     <ToggleButton.IsChecked>
                         <Binding Path="ActiveAnnotationTool"
                                  Converter="{StaticResource EnumEqualsConverter}"
-                                 ConverterParameter="Note" />
+                                 ConverterParameter="Note"
+                                 Mode="OneWay" />
                     </ToggleButton.IsChecked>
                 </ToggleButton>
             </ToolBar>


### PR DESCRIPTION
## Summary
- mark the annotation tool toggle bindings as one-way so they no longer try to write back to the read-only ActiveAnnotationTool property

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: current container only has the .NET 8 SDK, but the solution targets net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68da89a04ce0832b91bf587421d52aca