### PR TITLE
Add PDF viewer with annotation support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <!-- === WPF infrastructure === -->
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
   </ItemGroup>
 </Project>
 

--- a/src/LM.App.Wpf/App.xaml.cs
+++ b/src/LM.App.Wpf/App.xaml.cs
@@ -172,6 +172,7 @@ namespace LM.App.Wpf
                                         .AddModule(new AddModule())
                                         .AddModule(new LibraryModule())
                                         .AddModule(new ReviewModule())
+                                        .AddModule(new PdfModule())
                                         .AddModule(new SearchModule())
                                         .Build();
 

--- a/src/LM.App.Wpf/Composition/Modules/PdfModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/PdfModule.cs
@@ -1,0 +1,25 @@
+using LM.App.Wpf.ViewModels.Pdf;
+using LM.App.Wpf.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace LM.App.Wpf.Composition.Modules
+{
+    internal sealed class PdfModule : IAppModule
+    {
+        public void ConfigureServices(HostApplicationBuilder builder)
+        {
+            var services = builder.Services;
+
+            services.AddSingleton<PdfViewerViewModel>();
+            services.AddTransient<PdfViewer>(sp =>
+            {
+                var view = new PdfViewer
+                {
+                    DataContext = sp.GetRequiredService<PdfViewerViewModel>()
+                };
+                return view;
+            });
+        }
+    }
+}

--- a/src/LM.App.Wpf/LM.App.Wpf.csproj
+++ b/src/LM.App.Wpf/LM.App.Wpf.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" />
+    <PackageReference Include="Microsoft.Web.WebView2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -159,6 +159,27 @@ LM.App.Wpf.Common.StringJoinConverter.ConvertBack(object? value, System.Type! ta
 LM.App.Wpf.Common.StringJoinConverter.StringJoinConverter() -> void
 LM.App.Wpf.Common.ViewModelBase
 LM.App.Wpf.Common.ViewModelBase.ViewModelBase() -> void
+LM.App.Wpf.ViewModels.Pdf.PdfAnnotationViewModel
+LM.App.Wpf.ViewModels.Pdf.PdfAnnotationViewModel.Content.get -> string?
+LM.App.Wpf.ViewModels.Pdf.PdfAnnotationViewModel.Content.set -> void
+LM.App.Wpf.ViewModels.Pdf.PdfAnnotationViewModel.Id.get -> string!
+LM.App.Wpf.ViewModels.Pdf.PdfAnnotationViewModel.PdfAnnotationViewModel(string! id, string! title) -> void
+LM.App.Wpf.ViewModels.Pdf.PdfAnnotationViewModel.Title.get -> string!
+LM.App.Wpf.ViewModels.Pdf.PdfAnnotationViewModel.Title.set -> void
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.Annotations.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.Pdf.PdfAnnotationViewModel!>!
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.DocumentSource.get -> System.Uri?
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.EntryId.get -> string?
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.EntryId.set -> void
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.IsBusy.get -> bool
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.LoadPdfCommand.get -> LM.App.Wpf.Common.IAsyncRelayCommand!
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.PdfHash.get -> string?
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.PdfPath.get -> string?
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.PdfPath.set -> void
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.PdfViewerViewModel(LM.Infrastructure.Hooks.HookOrchestrator! hookOrchestrator, LM.App.Wpf.Services.IUserContext! userContext) -> void
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.RecordAnnotationChangeCommand.get -> LM.App.Wpf.Common.IAsyncRelayCommand!
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.SelectedAnnotation.get -> LM.App.Wpf.ViewModels.Pdf.PdfAnnotationViewModel?
+LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.SelectedAnnotation.set -> void
 LM.App.Wpf.Library.LibraryFilterPreset
 LM.App.Wpf.Library.LibraryFilterPreset.LibraryFilterPreset() -> void
 LM.App.Wpf.Library.LibraryFilterPreset.Name.get -> string!
@@ -755,6 +776,9 @@ LM.App.Wpf.Views.LibraryPresetSaveDialog.ViewModel.get -> LM.App.Wpf.ViewModels.
 LM.App.Wpf.Views.LibraryView
 LM.App.Wpf.Views.LibraryView.InitializeComponent() -> void
 LM.App.Wpf.Views.LibraryView.LibraryView() -> void
+LM.App.Wpf.Views.PdfViewer
+LM.App.Wpf.Views.PdfViewer.InitializeComponent() -> void
+LM.App.Wpf.Views.PdfViewer.PdfViewer() -> void
 LM.App.Wpf.Views.Library.TagTokenSelector
 LM.App.Wpf.Views.Library.TagTokenSelector.InitializeComponent() -> void
 LM.App.Wpf.Views.Library.TagTokenSelector.FilteredSuggestions.get -> System.Collections.ObjectModel.ObservableCollection<string!>!

--- a/src/LM.App.Wpf/ViewModels/Pdf/PdfAnnotationViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Pdf/PdfAnnotationViewModel.cs
@@ -1,0 +1,71 @@
+using System;
+using LM.App.Wpf.Common;
+
+namespace LM.App.Wpf.ViewModels.Pdf
+{
+    /// <summary>
+    /// Represents an annotation displayed in the PDF viewer sidebar.
+    /// </summary>
+    internal sealed class PdfAnnotationViewModel : ViewModelBase
+    {
+        private string _title;
+        private string? _content;
+
+        public PdfAnnotationViewModel(string id, string title)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("Annotation id cannot be empty.", nameof(id));
+            }
+
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                throw new ArgumentException("Annotation title cannot be empty.", nameof(title));
+            }
+
+            Id = id.Trim();
+            _title = title.Trim();
+        }
+
+        /// <summary>
+        /// Gets the unique annotation identifier.
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// Gets or sets the human-friendly title for the annotation.
+        /// </summary>
+        public string Title
+        {
+            get => _title;
+            set
+            {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                var sanitized = value.Trim();
+                if (sanitized.Length == 0)
+                {
+                    throw new ArgumentException("Annotation title cannot be empty.", nameof(value));
+                }
+
+                SetProperty(ref _title, sanitized);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the optional annotation body text.
+        /// </summary>
+        public string? Content
+        {
+            get => _content;
+            set
+            {
+                var sanitized = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+                SetProperty(ref _content, sanitized);
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.App.Wpf.Common;
+using LM.App.Wpf.Services;
+using LM.App.Wpf.ViewModels.Review;
+using LM.Infrastructure.Hooks;
+
+namespace LM.App.Wpf.ViewModels.Pdf
+{
+    /// <summary>
+    /// Coordinates PDF rendering and annotation metadata for the viewer surface.
+    /// </summary>
+    internal sealed class PdfViewerViewModel : ViewModelBase
+    {
+        private readonly HookOrchestrator _hookOrchestrator;
+        private readonly IUserContext _userContext;
+
+        private string? _entryId;
+        private string? _pdfPath;
+        private string? _pdfHash;
+        private System.Uri? _documentSource;
+        private PdfAnnotationViewModel? _selectedAnnotation;
+        private bool _isBusy;
+
+        public PdfViewerViewModel(HookOrchestrator hookOrchestrator, IUserContext userContext)
+        {
+            _hookOrchestrator = hookOrchestrator ?? throw new ArgumentNullException(nameof(hookOrchestrator));
+            _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+
+            Annotations = new ObservableCollection<PdfAnnotationViewModel>();
+
+            LoadPdfCommand = new AsyncRelayCommand(LoadPdfAsync, () => !IsBusy);
+            RecordAnnotationChangeCommand = new AsyncRelayCommand(RecordAnnotationChangeAsync, CanRecordAnnotationChange);
+        }
+
+        /// <summary>
+        /// Gets the collection of annotations displayed in the sidebar.
+        /// </summary>
+        public ObservableCollection<PdfAnnotationViewModel> Annotations { get; }
+
+        /// <summary>
+        /// Gets or sets the workspace entry identifier backing the viewer session.
+        /// </summary>
+        public string? EntryId
+        {
+            get => _entryId;
+            set
+            {
+                var sanitized = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+                if (SetProperty(ref _entryId, sanitized))
+                {
+                    RecordAnnotationChangeCommand?.RaiseCanExecuteChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the PDF file path requested by the user.
+        /// </summary>
+        public string? PdfPath
+        {
+            get => _pdfPath;
+            set
+            {
+                var sanitized = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+                SetProperty(ref _pdfPath, sanitized);
+            }
+        }
+
+        /// <summary>
+        /// Gets the SHA-256 hash of the currently loaded PDF file.
+        /// </summary>
+        public string? PdfHash
+        {
+            get => _pdfHash;
+            private set => SetProperty(ref _pdfHash, value);
+        }
+
+        /// <summary>
+        /// Gets the URI provided to the WebView2 control for rendering.
+        /// </summary>
+        public System.Uri? DocumentSource
+        {
+            get => _documentSource;
+            private set => SetProperty(ref _documentSource, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the annotation currently selected in the UI.
+        /// </summary>
+        public PdfAnnotationViewModel? SelectedAnnotation
+        {
+            get => _selectedAnnotation;
+            set
+            {
+                if (SetProperty(ref _selectedAnnotation, value))
+                {
+                    RecordAnnotationChangeCommand?.RaiseCanExecuteChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether the viewer is performing a background operation.
+        /// </summary>
+        public bool IsBusy
+        {
+            get => _isBusy;
+            private set
+            {
+                if (SetProperty(ref _isBusy, value))
+                {
+                    LoadPdfCommand.RaiseCanExecuteChanged();
+                    RecordAnnotationChangeCommand.RaiseCanExecuteChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Command invoked to load the current <see cref="PdfPath"/> into the viewer.
+        /// </summary>
+        public IAsyncRelayCommand LoadPdfCommand { get; }
+
+        /// <summary>
+        /// Command invoked to persist annotation changes to the changelog hook.
+        /// </summary>
+        public IAsyncRelayCommand RecordAnnotationChangeCommand { get; }
+
+        private async Task LoadPdfAsync()
+        {
+            var path = PdfPath;
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                DocumentSource = null;
+                PdfHash = null;
+                return;
+            }
+
+            try
+            {
+                IsBusy = true;
+
+                var absolutePath = Path.GetFullPath(path);
+                if (!File.Exists(absolutePath))
+                {
+                    DocumentSource = null;
+                    PdfHash = null;
+                    return;
+                }
+
+                await using var stream = new FileStream(absolutePath,
+                                                        FileMode.Open,
+                                                        FileAccess.Read,
+                                                        FileShare.Read,
+                                                        bufferSize: 81920,
+                                                        useAsync: true);
+                using var sha = SHA256.Create();
+                var hashBytes = await sha.ComputeHashAsync(stream, CancellationToken.None).ConfigureAwait(false);
+                PdfHash = Convert.ToHexString(hashBytes);
+                DocumentSource = new Uri(absolutePath, UriKind.Absolute);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                DocumentSource = null;
+                PdfHash = null;
+                Trace.TraceError("Failed to load PDF '{0}': {1}", path, ex);
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async Task RecordAnnotationChangeAsync()
+        {
+            if (string.IsNullOrWhiteSpace(EntryId) || SelectedAnnotation is null)
+            {
+                return;
+            }
+
+            var tags = new List<string>
+            {
+                "annotationId:" + SelectedAnnotation.Id
+            };
+
+            if (!string.IsNullOrWhiteSpace(SelectedAnnotation.Title))
+            {
+                tags.Add("annotationTitle:" + SelectedAnnotation.Title);
+            }
+
+            await ReviewChangeLogWriter.WriteAsync(_hookOrchestrator,
+                                                   EntryId,
+                                                   _userContext.UserName,
+                                                   "annotation-change",
+                                                   tags,
+                                                   CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private bool CanRecordAnnotationChange()
+            => !IsBusy && !string.IsNullOrWhiteSpace(EntryId) && SelectedAnnotation is not null;
+    }
+}

--- a/src/LM.App.Wpf/Views/PdfViewer.xaml
+++ b/src/LM.App.Wpf/Views/PdfViewer.xaml
@@ -1,0 +1,70 @@
+<UserControl x:Class="LM.App.Wpf.Views.PdfViewer"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:webview2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+             mc:Ignorable="d">
+  <DockPanel>
+    <ToolBar DockPanel.Dock="Top">
+      <TextBox x:Name="PdfPathBox"
+               Width="320"
+               Margin="0,0,8,0"
+               Text="{Binding PdfPath, UpdateSourceTrigger=PropertyChanged}" />
+      <Button Content="Load"
+              Margin="0,0,8,0"
+              Command="{Binding LoadPdfCommand}" />
+      <Separator />
+      <TextBlock Text="SHA-256:"
+                 Margin="8,0,4,0"
+                 VerticalAlignment="Center"
+                 FontWeight="SemiBold" />
+      <TextBlock Text="{Binding PdfHash}" VerticalAlignment="Center" />
+    </ToolBar>
+
+    <Grid>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="300"
+                          MinWidth="180" />
+        <ColumnDefinition Width="5" />
+        <ColumnDefinition Width="*" />
+      </Grid.ColumnDefinitions>
+
+      <Border Grid.Column="0"
+              BorderBrush="#FFE0E0E0"
+              BorderThickness="0,0,1,0"
+              Background="#FFF7F7F7">
+        <DockPanel Margin="12">
+          <TextBlock DockPanel.Dock="Top"
+                     Text="Annotations"
+                     FontSize="14"
+                     FontWeight="SemiBold"
+                     Margin="0,0,0,8" />
+
+          <Button DockPanel.Dock="Bottom"
+                  Content="Log Annotation Change"
+                  Margin="0,8,0,0"
+                  Padding="8,4"
+                  Command="{Binding RecordAnnotationChangeCommand}" />
+
+          <ListBox ItemsSource="{Binding Annotations}"
+                   SelectedItem="{Binding SelectedAnnotation, Mode=TwoWay}"
+                   DisplayMemberPath="Title"
+                   ScrollViewer.VerticalScrollBarVisibility="Auto" />
+        </DockPanel>
+      </Border>
+
+      <GridSplitter Grid.Column="1"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Background="#FFE0E0E0"
+                    ShowsPreview="True" />
+
+      <Border Grid.Column="2"
+              Background="#FFFFFFFF"
+              Padding="0">
+        <webview2:WebView2 Source="{Binding DocumentSource}" />
+      </Border>
+    </Grid>
+  </DockPanel>
+</UserControl>

--- a/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
+++ b/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
@@ -1,0 +1,10 @@
+namespace LM.App.Wpf.Views
+{
+    public partial class PdfViewer : System.Windows.Controls.UserControl
+    {
+        public PdfViewer()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the Microsoft.Web.WebView2 dependency and register a PdfModule so the viewer can be resolved through DI
- create the PdfViewer XAML layout with a WebView2 surface, toolbar, and resizable annotation pane
- implement PdfViewerViewModel and related annotation view model with hashing, selection tracking, and changelog logging support

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: missing Microsoft.WindowsDesktop.App runtime on linux-x64 and existing LM.Infrastructure.Tests.SaveAssignmentAsync_RemovesLegacyLockFile assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68dab6fe9f7c832b983592b4a6493187