### PR TITLE
Ensure LM.App.Wpf targets WebView2 runtime

### DIFF
--- a/src/LM.App.Wpf/LM.App.Wpf.csproj
+++ b/src/LM.App.Wpf/LM.App.Wpf.csproj
@@ -8,6 +8,9 @@
     <Nullable>enable</Nullable>
     <!-- Enable Windows targeting when building on non-Windows agents -->
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <!-- WebView2 requires Windows 10 version 1809 (build 17763) or newer -->
+    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- target Windows 10 version 1809 to satisfy WebView2 runtime requirements for the WPF client

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: installed SDK 8.0.414 cannot build net9.0 projects)*

------
https://chatgpt.com/codex/tasks/task_e_68dad2770d6c832bb9d93ade156ffed0