### PR TITLE
Align WPF target platform for Windows 10 support

### DIFF
--- a/src/LM.App.Wpf/LM.App.Wpf.csproj
+++ b/src/LM.App.Wpf/LM.App.Wpf.csproj
@@ -3,6 +3,8 @@
     <OutputType>WinExe</OutputType>
     <!-- keep your target; net8.0-windows or net9.0-windows are both fine -->
     <TargetFramework>net9.0-windows</TargetFramework>
+    <!-- Align the target platform so the SupportedOSPlatformVersion stays valid -->
+    <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- set the LM.App.Wpf target platform version to Windows 10 build 19041 to match the supported platform declaration

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: SDK 8.0.414 does not support net9.0 targets in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dad521dcb4832b820f148b01cbeaf3