### PR TITLE
Add PDF annotation domain models and factories

### DIFF
--- a/src/LM.Core/Models/Pdf/IPdfAnnotation.cs
+++ b/src/LM.Core/Models/Pdf/IPdfAnnotation.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Immutable;
+
+namespace LM.Core.Models.Pdf;
+
+public interface IPdfAnnotation
+{
+    Guid Id { get; }
+
+    DateTimeOffset CreatedAt { get; }
+
+    DateTimeOffset ModifiedAt { get; }
+
+    int PageIndex { get; }
+
+    ImmutableArray<PdfAnnotationRect> Rectangles { get; }
+
+    string? SelectedText { get; }
+
+    PdfAnnotationColor? Color { get; }
+
+    string? Notes { get; }
+
+    ImmutableArray<string> Tags { get; }
+
+    PdfAnnotationPreviewImage? Preview { get; }
+}

--- a/src/LM.Core/Models/Pdf/IPdfAnnotationFactory.cs
+++ b/src/LM.Core/Models/Pdf/IPdfAnnotationFactory.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace LM.Core.Models.Pdf;
+
+public interface IPdfAnnotationFactory
+{
+    PdfAnnotation Create(
+        Guid id,
+        DateTimeOffset createdAt,
+        int pageIndex,
+        IEnumerable<PdfAnnotationRect> rectangles,
+        string? selectedText = null,
+        PdfAnnotationColor? color = null,
+        string? notes = null,
+        IEnumerable<string>? tags = null,
+        PdfAnnotationPreviewImage? preview = null,
+        DateTimeOffset? modifiedAt = null);
+
+    PdfAnnotation UpdateRectangles(PdfAnnotation annotation, IEnumerable<PdfAnnotationRect> rectangles);
+
+    PdfAnnotation UpdateTags(PdfAnnotation annotation, IEnumerable<string>? tags);
+}

--- a/src/LM.Core/Models/Pdf/IPdfAnnotationOverlay.cs
+++ b/src/LM.Core/Models/Pdf/IPdfAnnotationOverlay.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace LM.Core.Models.Pdf;
+
+public interface IPdfAnnotationOverlay
+{
+    Guid AnnotationId { get; }
+
+    int PageIndex { get; }
+
+    PdfAnnotationRect Rect { get; }
+
+    PdfAnnotationColor? Color { get; }
+
+    string? Label { get; }
+}

--- a/src/LM.Core/Models/Pdf/IPdfAnnotationRect.cs
+++ b/src/LM.Core/Models/Pdf/IPdfAnnotationRect.cs
@@ -1,0 +1,12 @@
+namespace LM.Core.Models.Pdf;
+
+public interface IPdfAnnotationRect
+{
+    double X { get; }
+
+    double Y { get; }
+
+    double Width { get; }
+
+    double Height { get; }
+}

--- a/src/LM.Core/Models/Pdf/PdfAnnotation.cs
+++ b/src/LM.Core/Models/Pdf/PdfAnnotation.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace LM.Core.Models.Pdf;
+
+public sealed record PdfAnnotation : IPdfAnnotation
+{
+    public PdfAnnotation(
+        Guid id,
+        DateTimeOffset createdAt,
+        DateTimeOffset modifiedAt,
+        int pageIndex,
+        ImmutableArray<PdfAnnotationRect> rectangles,
+        string? selectedText,
+        PdfAnnotationColor? color,
+        string? notes,
+        ImmutableArray<string> tags,
+        PdfAnnotationPreviewImage? preview)
+    {
+        Id = PdfAnnotationValidators.EnsureValidId(id);
+        CreatedAt = createdAt;
+        ModifiedAt = PdfAnnotationValidators.EnsureValidModification(createdAt, modifiedAt);
+        PageIndex = PdfAnnotationValidators.EnsureValidPageIndex(pageIndex);
+        var sourceRectangles = rectangles.IsDefault
+            ? Array.Empty<PdfAnnotationRect>()
+            : rectangles.AsEnumerable();
+
+        Rectangles = PdfAnnotationCollectionUtilities.NormalizeRectangles(sourceRectangles);
+        SelectedText = PdfAnnotationValidators.NormalizeOptionalText(selectedText);
+        Color = color;
+        Notes = PdfAnnotationValidators.NormalizeOptionalText(notes);
+        Tags = PdfAnnotationCollectionUtilities.NormalizeTags(tags.IsDefault ? null : tags.AsEnumerable());
+        Preview = preview;
+    }
+
+    public Guid Id { get; }
+
+    public DateTimeOffset CreatedAt { get; }
+
+    public DateTimeOffset ModifiedAt { get; init; }
+
+    public int PageIndex { get; }
+
+    public ImmutableArray<PdfAnnotationRect> Rectangles { get; init; }
+
+    public string? SelectedText { get; }
+
+    public PdfAnnotationColor? Color { get; }
+
+    public string? Notes { get; }
+
+    public ImmutableArray<string> Tags { get; init; }
+
+    public PdfAnnotationPreviewImage? Preview { get; }
+
+    public PdfAnnotation WithRectangles(IEnumerable<PdfAnnotationRect> rectangles)
+    {
+        if (rectangles is null)
+        {
+            throw new ArgumentNullException(nameof(rectangles));
+        }
+
+        var normalized = PdfAnnotationCollectionUtilities.NormalizeRectangles(rectangles);
+        return this with { Rectangles = normalized };
+    }
+
+    public PdfAnnotation WithTags(IEnumerable<string>? tags)
+    {
+        var normalizedTags = PdfAnnotationCollectionUtilities.NormalizeTags(tags);
+        return this with { Tags = normalizedTags };
+    }
+}

--- a/src/LM.Core/Models/Pdf/PdfAnnotationCollectionUtilities.cs
+++ b/src/LM.Core/Models/Pdf/PdfAnnotationCollectionUtilities.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace LM.Core.Models.Pdf;
+
+internal static class PdfAnnotationCollectionUtilities
+{
+    public static ImmutableArray<PdfAnnotationRect> NormalizeRectangles(IEnumerable<PdfAnnotationRect> rectangles)
+    {
+        if (rectangles is null)
+        {
+            throw new ArgumentNullException(nameof(rectangles));
+        }
+
+        var normalized = rectangles
+            .Select(rect => rect ?? throw new ArgumentNullException(nameof(rectangles), "Rectangle entries cannot be null."))
+            .Select(rect => new PdfAnnotationRect(rect.X, rect.Y, rect.Width, rect.Height))
+            .ToImmutableArray();
+
+        return normalized.IsDefault ? ImmutableArray<PdfAnnotationRect>.Empty : normalized;
+    }
+
+    public static ImmutableArray<string> NormalizeTags(IEnumerable<string>? tags)
+    {
+        if (tags is null)
+        {
+            return ImmutableArray<string>.Empty;
+        }
+
+        var normalizedTags = tags
+            .Where(tag => !string.IsNullOrWhiteSpace(tag))
+            .Select(tag => tag.Trim())
+            .Where(tag => tag.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(tag => tag, StringComparer.OrdinalIgnoreCase)
+            .ToImmutableArray();
+
+        return normalizedTags.IsDefault ? ImmutableArray<string>.Empty : normalizedTags;
+    }
+}

--- a/src/LM.Core/Models/Pdf/PdfAnnotationColor.cs
+++ b/src/LM.Core/Models/Pdf/PdfAnnotationColor.cs
@@ -1,0 +1,35 @@
+namespace LM.Core.Models.Pdf;
+
+public sealed record PdfAnnotationColor
+{
+    public PdfAnnotationColor(byte alpha, byte red, byte green, byte blue, string? name = null)
+    {
+        Name = string.IsNullOrWhiteSpace(name) ? null : name.Trim();
+        Alpha = alpha;
+        Red = red;
+        Green = green;
+        Blue = blue;
+    }
+
+    public byte Alpha { get; }
+
+    public byte Red { get; }
+
+    public byte Green { get; }
+
+    public byte Blue { get; }
+
+    public string? Name { get; }
+
+    public uint ToArgb() => (uint)((Alpha << 24) | (Red << 16) | (Green << 8) | Blue);
+
+    public static PdfAnnotationColor FromArgb(uint argb, string? name = null)
+    {
+        var alpha = (byte)((argb & 0xFF000000) >> 24);
+        var red = (byte)((argb & 0x00FF0000) >> 16);
+        var green = (byte)((argb & 0x0000FF00) >> 8);
+        var blue = (byte)(argb & 0x000000FF);
+
+        return new PdfAnnotationColor(alpha, red, green, blue, name);
+    }
+}

--- a/src/LM.Core/Models/Pdf/PdfAnnotationFactory.cs
+++ b/src/LM.Core/Models/Pdf/PdfAnnotationFactory.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+
+namespace LM.Core.Models.Pdf;
+
+public sealed class PdfAnnotationFactory : IPdfAnnotationFactory
+{
+    public PdfAnnotation Create(
+        Guid id,
+        DateTimeOffset createdAt,
+        int pageIndex,
+        IEnumerable<PdfAnnotationRect> rectangles,
+        string? selectedText = null,
+        PdfAnnotationColor? color = null,
+        string? notes = null,
+        IEnumerable<string>? tags = null,
+        PdfAnnotationPreviewImage? preview = null,
+        DateTimeOffset? modifiedAt = null)
+    {
+        ArgumentNullException.ThrowIfNull(rectangles);
+
+        var normalizedRects = PdfAnnotationCollectionUtilities.NormalizeRectangles(rectangles);
+        var normalizedTags = PdfAnnotationCollectionUtilities.NormalizeTags(tags);
+
+        return new PdfAnnotation(
+            id,
+            createdAt,
+            modifiedAt ?? createdAt,
+            pageIndex,
+            normalizedRects,
+            selectedText,
+            color,
+            notes,
+            normalizedTags,
+            preview);
+    }
+
+    public PdfAnnotation UpdateRectangles(PdfAnnotation annotation, IEnumerable<PdfAnnotationRect> rectangles)
+    {
+        ArgumentNullException.ThrowIfNull(annotation);
+        ArgumentNullException.ThrowIfNull(rectangles);
+
+        var normalized = PdfAnnotationCollectionUtilities.NormalizeRectangles(rectangles);
+        return annotation with { Rectangles = normalized, ModifiedAt = DateTimeOffset.UtcNow };
+    }
+
+    public PdfAnnotation UpdateTags(PdfAnnotation annotation, IEnumerable<string>? tags)
+    {
+        ArgumentNullException.ThrowIfNull(annotation);
+
+        var normalized = PdfAnnotationCollectionUtilities.NormalizeTags(tags);
+        return annotation with { Tags = normalized, ModifiedAt = DateTimeOffset.UtcNow };
+    }
+}

--- a/src/LM.Core/Models/Pdf/PdfAnnotationOverlay.cs
+++ b/src/LM.Core/Models/Pdf/PdfAnnotationOverlay.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace LM.Core.Models.Pdf;
+
+public sealed record PdfAnnotationOverlay : IPdfAnnotationOverlay
+{
+    public PdfAnnotationOverlay(Guid annotationId, int pageIndex, PdfAnnotationRect rect, PdfAnnotationColor? color, string? label = null)
+    {
+        AnnotationId = PdfAnnotationValidators.EnsureValidId(annotationId);
+        PageIndex = PdfAnnotationValidators.EnsureValidPageIndex(pageIndex);
+        Rect = rect ?? throw new ArgumentNullException(nameof(rect));
+        Color = color;
+        Label = PdfAnnotationValidators.NormalizeOptionalText(label);
+    }
+
+    public Guid AnnotationId { get; }
+
+    public int PageIndex { get; }
+
+    public PdfAnnotationRect Rect { get; }
+
+    public PdfAnnotationColor? Color { get; }
+
+    public string? Label { get; }
+
+    public static ImmutableArray<PdfAnnotationOverlay> FromAnnotation(IPdfAnnotation annotation, Func<PdfAnnotationRect, string?>? labelSelector = null)
+    {
+        if (annotation is null)
+        {
+            throw new ArgumentNullException(nameof(annotation));
+        }
+
+        if (annotation.Rectangles.Length == 0)
+        {
+            return ImmutableArray<PdfAnnotationOverlay>.Empty;
+        }
+
+        var overlays = annotation.Rectangles
+            .Select(rect => new PdfAnnotationOverlay(annotation.Id, annotation.PageIndex, rect, annotation.Color, labelSelector?.Invoke(rect)))
+            .ToImmutableArray();
+
+        return overlays.IsDefault ? ImmutableArray<PdfAnnotationOverlay>.Empty : overlays;
+    }
+}

--- a/src/LM.Core/Models/Pdf/PdfAnnotationPreviewImage.cs
+++ b/src/LM.Core/Models/Pdf/PdfAnnotationPreviewImage.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace LM.Core.Models.Pdf;
+
+public sealed record PdfAnnotationPreviewImage
+{
+    public PdfAnnotationPreviewImage(string mimeType, int width, int height, long lengthBytes, string? hash = null)
+    {
+        if (string.IsNullOrWhiteSpace(mimeType))
+        {
+            throw new ArgumentException("Mime type cannot be null or whitespace.", nameof(mimeType));
+        }
+
+        if (width <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), "Width must be greater than zero.");
+        }
+
+        if (height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(height), "Height must be greater than zero.");
+        }
+
+        if (lengthBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(lengthBytes), "Length must be greater than zero.");
+        }
+
+        MimeType = mimeType.Trim();
+        Width = width;
+        Height = height;
+        LengthBytes = lengthBytes;
+        Hash = string.IsNullOrWhiteSpace(hash) ? null : hash.Trim();
+    }
+
+    public string MimeType { get; }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public long LengthBytes { get; }
+
+    public string? Hash { get; }
+}

--- a/src/LM.Core/Models/Pdf/PdfAnnotationRect.cs
+++ b/src/LM.Core/Models/Pdf/PdfAnnotationRect.cs
@@ -1,0 +1,42 @@
+namespace LM.Core.Models.Pdf;
+
+public sealed record PdfAnnotationRect : IPdfAnnotationRect
+{
+    public PdfAnnotationRect(double x, double y, double width, double height)
+    {
+        PdfAnnotationRectValidator.ThrowIfInvalidNormalized(x, y, width, height);
+
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+    }
+
+    public double X { get; }
+
+    public double Y { get; }
+
+    public double Width { get; }
+
+    public double Height { get; }
+
+    public PdfAnnotationRect WithNormalizedCoordinates(double x, double y, double width, double height)
+    {
+        return new PdfAnnotationRect(x, y, width, height);
+    }
+
+    public PdfAnnotationRect Translate(double deltaX, double deltaY)
+    {
+        var translatedX = X + deltaX;
+        var translatedY = Y + deltaY;
+
+        PdfAnnotationRectValidator.ThrowIfInvalidNormalized(translatedX, translatedY, Width, Height);
+
+        return new PdfAnnotationRect(translatedX, translatedY, Width, Height);
+    }
+
+    public static PdfAnnotationRect FromAbsolute(double x, double y, double width, double height, double pageWidth, double pageHeight)
+    {
+        return PdfAnnotationRectNormalizer.Normalize(x, y, width, height, pageWidth, pageHeight);
+    }
+}

--- a/src/LM.Core/Models/Pdf/PdfAnnotationRectNormalizer.cs
+++ b/src/LM.Core/Models/Pdf/PdfAnnotationRectNormalizer.cs
@@ -1,0 +1,16 @@
+namespace LM.Core.Models.Pdf;
+
+public static class PdfAnnotationRectNormalizer
+{
+    public static PdfAnnotationRect Normalize(double x, double y, double width, double height, double pageWidth, double pageHeight)
+    {
+        PdfAnnotationRectValidator.ThrowIfInvalidPageSize(pageWidth, pageHeight);
+
+        var normalizedX = x / pageWidth;
+        var normalizedY = y / pageHeight;
+        var normalizedWidth = width / pageWidth;
+        var normalizedHeight = height / pageHeight;
+
+        return new PdfAnnotationRect(normalizedX, normalizedY, normalizedWidth, normalizedHeight);
+    }
+}

--- a/src/LM.Core/Models/Pdf/PdfAnnotationRectValidator.cs
+++ b/src/LM.Core/Models/Pdf/PdfAnnotationRectValidator.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace LM.Core.Models.Pdf;
+
+internal static class PdfAnnotationRectValidator
+{
+    private const double MinNormalizedCoordinate = 0d;
+    private const double MaxNormalizedCoordinate = 1d;
+
+    public static void ThrowIfInvalidNormalized(double x, double y, double width, double height)
+    {
+        if (double.IsNaN(x) || double.IsInfinity(x))
+        {
+            throw new ArgumentOutOfRangeException(nameof(x), "X must be a finite value.");
+        }
+
+        if (double.IsNaN(y) || double.IsInfinity(y))
+        {
+            throw new ArgumentOutOfRangeException(nameof(y), "Y must be a finite value.");
+        }
+
+        if (double.IsNaN(width) || double.IsInfinity(width))
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), "Width must be a finite value.");
+        }
+
+        if (double.IsNaN(height) || double.IsInfinity(height))
+        {
+            throw new ArgumentOutOfRangeException(nameof(height), "Height must be a finite value.");
+        }
+
+        if (width <= 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), "Width must be greater than zero.");
+        }
+
+        if (height <= 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(height), "Height must be greater than zero.");
+        }
+
+        if (x < MinNormalizedCoordinate || x > MaxNormalizedCoordinate)
+        {
+            throw new ArgumentOutOfRangeException(nameof(x), "X must be within the normalized range of 0 to 1.");
+        }
+
+        if (y < MinNormalizedCoordinate || y > MaxNormalizedCoordinate)
+        {
+            throw new ArgumentOutOfRangeException(nameof(y), "Y must be within the normalized range of 0 to 1.");
+        }
+
+        if (x + width > MaxNormalizedCoordinate + double.Epsilon)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), "X plus width must not exceed 1.");
+        }
+
+        if (y + height > MaxNormalizedCoordinate + double.Epsilon)
+        {
+            throw new ArgumentOutOfRangeException(nameof(height), "Y plus height must not exceed 1.");
+        }
+    }
+
+    public static void ThrowIfInvalidPageSize(double pageWidth, double pageHeight)
+    {
+        if (double.IsNaN(pageWidth) || double.IsInfinity(pageWidth) || pageWidth <= 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageWidth), "Page width must be a positive finite value.");
+        }
+
+        if (double.IsNaN(pageHeight) || double.IsInfinity(pageHeight) || pageHeight <= 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageHeight), "Page height must be a positive finite value.");
+        }
+    }
+}

--- a/src/LM.Core/Models/Pdf/PdfAnnotationValidators.cs
+++ b/src/LM.Core/Models/Pdf/PdfAnnotationValidators.cs
@@ -1,0 +1,35 @@
+using System;
+namespace LM.Core.Models.Pdf;
+
+internal static class PdfAnnotationValidators
+{
+    public static Guid EnsureValidId(Guid id)
+    {
+        if (id == Guid.Empty)
+        {
+            throw new ArgumentException("Annotation id cannot be empty.", nameof(id));
+        }
+
+        return id;
+    }
+
+    public static DateTimeOffset EnsureValidModification(DateTimeOffset createdAt, DateTimeOffset modifiedAt)
+    {
+        return modifiedAt < createdAt ? createdAt : modifiedAt;
+    }
+
+    public static int EnsureValidPageIndex(int pageIndex)
+    {
+        if (pageIndex < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageIndex), "Page index cannot be negative.");
+        }
+
+        return pageIndex;
+    }
+
+    public static string? NormalizeOptionalText(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+}

--- a/src/LM.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Core/PublicAPI.Unshipped.txt
@@ -384,6 +384,89 @@ LM.Core.Abstractions.Configuration.ISearchHistoryStore.SaveAsync(LM.Core.Models.
 LM.Core.Abstractions.Configuration.IUserPreferencesStore
 LM.Core.Abstractions.Configuration.IUserPreferencesStore.LoadAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.Core.Models.UserPreferences!>!
 LM.Core.Abstractions.Configuration.IUserPreferencesStore.SaveAsync(LM.Core.Models.UserPreferences! preferences, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.Core.Models.Pdf.IPdfAnnotation
+LM.Core.Models.Pdf.IPdfAnnotation.Color.get -> LM.Core.Models.Pdf.PdfAnnotationColor?
+LM.Core.Models.Pdf.IPdfAnnotation.CreatedAt.get -> System.DateTimeOffset
+LM.Core.Models.Pdf.IPdfAnnotation.Id.get -> System.Guid
+LM.Core.Models.Pdf.IPdfAnnotation.ModifiedAt.get -> System.DateTimeOffset
+LM.Core.Models.Pdf.IPdfAnnotation.Notes.get -> string?
+LM.Core.Models.Pdf.IPdfAnnotation.PageIndex.get -> int
+LM.Core.Models.Pdf.IPdfAnnotation.Preview.get -> LM.Core.Models.Pdf.PdfAnnotationPreviewImage?
+LM.Core.Models.Pdf.IPdfAnnotation.Rectangles.get -> System.Collections.Immutable.ImmutableArray<LM.Core.Models.Pdf.PdfAnnotationRect>
+LM.Core.Models.Pdf.IPdfAnnotation.SelectedText.get -> string?
+LM.Core.Models.Pdf.IPdfAnnotation.Tags.get -> System.Collections.Immutable.ImmutableArray<string>
+LM.Core.Models.Pdf.IPdfAnnotationFactory
+LM.Core.Models.Pdf.IPdfAnnotationFactory.Create(System.Guid id, System.DateTimeOffset createdAt, int pageIndex, System.Collections.Generic.IEnumerable<LM.Core.Models.Pdf.PdfAnnotationRect> rectangles, string? selectedText = null, LM.Core.Models.Pdf.PdfAnnotationColor? color = null, string? notes = null, System.Collections.Generic.IEnumerable<string>? tags = null, LM.Core.Models.Pdf.PdfAnnotationPreviewImage? preview = null, System.DateTimeOffset? modifiedAt = null) -> LM.Core.Models.Pdf.PdfAnnotation!
+LM.Core.Models.Pdf.IPdfAnnotationFactory.UpdateRectangles(LM.Core.Models.Pdf.PdfAnnotation! annotation, System.Collections.Generic.IEnumerable<LM.Core.Models.Pdf.PdfAnnotationRect> rectangles) -> LM.Core.Models.Pdf.PdfAnnotation!
+LM.Core.Models.Pdf.IPdfAnnotationFactory.UpdateTags(LM.Core.Models.Pdf.PdfAnnotation! annotation, System.Collections.Generic.IEnumerable<string>? tags) -> LM.Core.Models.Pdf.PdfAnnotation!
+LM.Core.Models.Pdf.IPdfAnnotationOverlay
+LM.Core.Models.Pdf.IPdfAnnotationOverlay.AnnotationId.get -> System.Guid
+LM.Core.Models.Pdf.IPdfAnnotationOverlay.Color.get -> LM.Core.Models.Pdf.PdfAnnotationColor?
+LM.Core.Models.Pdf.IPdfAnnotationOverlay.Label.get -> string?
+LM.Core.Models.Pdf.IPdfAnnotationOverlay.PageIndex.get -> int
+LM.Core.Models.Pdf.IPdfAnnotationOverlay.Rect.get -> LM.Core.Models.Pdf.PdfAnnotationRect
+LM.Core.Models.Pdf.IPdfAnnotationRect
+LM.Core.Models.Pdf.IPdfAnnotationRect.Height.get -> double
+LM.Core.Models.Pdf.IPdfAnnotationRect.Width.get -> double
+LM.Core.Models.Pdf.IPdfAnnotationRect.X.get -> double
+LM.Core.Models.Pdf.IPdfAnnotationRect.Y.get -> double
+LM.Core.Models.Pdf.PdfAnnotation
+LM.Core.Models.Pdf.PdfAnnotation.Color.get -> LM.Core.Models.Pdf.PdfAnnotationColor?
+LM.Core.Models.Pdf.PdfAnnotation.CreatedAt.get -> System.DateTimeOffset
+LM.Core.Models.Pdf.PdfAnnotation.Id.get -> System.Guid
+LM.Core.Models.Pdf.PdfAnnotation.ModifiedAt.get -> System.DateTimeOffset
+LM.Core.Models.Pdf.PdfAnnotation.ModifiedAt.init -> void
+LM.Core.Models.Pdf.PdfAnnotation.Notes.get -> string?
+LM.Core.Models.Pdf.PdfAnnotation.PageIndex.get -> int
+LM.Core.Models.Pdf.PdfAnnotation.PdfAnnotation(System.Guid id, System.DateTimeOffset createdAt, System.DateTimeOffset modifiedAt, int pageIndex, System.Collections.Immutable.ImmutableArray<LM.Core.Models.Pdf.PdfAnnotationRect> rectangles, string? selectedText, LM.Core.Models.Pdf.PdfAnnotationColor? color, string? notes, System.Collections.Immutable.ImmutableArray<string> tags, LM.Core.Models.Pdf.PdfAnnotationPreviewImage? preview) -> void
+LM.Core.Models.Pdf.PdfAnnotation.Preview.get -> LM.Core.Models.Pdf.PdfAnnotationPreviewImage?
+LM.Core.Models.Pdf.PdfAnnotation.Rectangles.get -> System.Collections.Immutable.ImmutableArray<LM.Core.Models.Pdf.PdfAnnotationRect>
+LM.Core.Models.Pdf.PdfAnnotation.Rectangles.init -> void
+LM.Core.Models.Pdf.PdfAnnotation.SelectedText.get -> string?
+LM.Core.Models.Pdf.PdfAnnotation.Tags.get -> System.Collections.Immutable.ImmutableArray<string>
+LM.Core.Models.Pdf.PdfAnnotation.Tags.init -> void
+LM.Core.Models.Pdf.PdfAnnotation.WithRectangles(System.Collections.Generic.IEnumerable<LM.Core.Models.Pdf.PdfAnnotationRect> rectangles) -> LM.Core.Models.Pdf.PdfAnnotation!
+LM.Core.Models.Pdf.PdfAnnotation.WithTags(System.Collections.Generic.IEnumerable<string>? tags) -> LM.Core.Models.Pdf.PdfAnnotation!
+LM.Core.Models.Pdf.PdfAnnotationColor
+LM.Core.Models.Pdf.PdfAnnotationColor.Alpha.get -> byte
+LM.Core.Models.Pdf.PdfAnnotationColor.Blue.get -> byte
+LM.Core.Models.Pdf.PdfAnnotationColor.FromArgb(uint argb, string? name = null) -> LM.Core.Models.Pdf.PdfAnnotationColor!
+LM.Core.Models.Pdf.PdfAnnotationColor.Green.get -> byte
+LM.Core.Models.Pdf.PdfAnnotationColor.Name.get -> string?
+LM.Core.Models.Pdf.PdfAnnotationColor.PdfAnnotationColor(byte alpha, byte red, byte green, byte blue, string? name = null) -> void
+LM.Core.Models.Pdf.PdfAnnotationColor.Red.get -> byte
+LM.Core.Models.Pdf.PdfAnnotationColor.ToArgb() -> uint
+LM.Core.Models.Pdf.PdfAnnotationFactory
+LM.Core.Models.Pdf.PdfAnnotationFactory.Create(System.Guid id, System.DateTimeOffset createdAt, int pageIndex, System.Collections.Generic.IEnumerable<LM.Core.Models.Pdf.PdfAnnotationRect> rectangles, string? selectedText = null, LM.Core.Models.Pdf.PdfAnnotationColor? color = null, string? notes = null, System.Collections.Generic.IEnumerable<string>? tags = null, LM.Core.Models.Pdf.PdfAnnotationPreviewImage? preview = null, System.DateTimeOffset? modifiedAt = null) -> LM.Core.Models.Pdf.PdfAnnotation!
+LM.Core.Models.Pdf.PdfAnnotationFactory.PdfAnnotationFactory() -> void
+LM.Core.Models.Pdf.PdfAnnotationFactory.UpdateRectangles(LM.Core.Models.Pdf.PdfAnnotation! annotation, System.Collections.Generic.IEnumerable<LM.Core.Models.Pdf.PdfAnnotationRect> rectangles) -> LM.Core.Models.Pdf.PdfAnnotation!
+LM.Core.Models.Pdf.PdfAnnotationFactory.UpdateTags(LM.Core.Models.Pdf.PdfAnnotation! annotation, System.Collections.Generic.IEnumerable<string>? tags) -> LM.Core.Models.Pdf.PdfAnnotation!
+LM.Core.Models.Pdf.PdfAnnotationOverlay
+LM.Core.Models.Pdf.PdfAnnotationOverlay.AnnotationId.get -> System.Guid
+LM.Core.Models.Pdf.PdfAnnotationOverlay.Color.get -> LM.Core.Models.Pdf.PdfAnnotationColor?
+LM.Core.Models.Pdf.PdfAnnotationOverlay.FromAnnotation(LM.Core.Models.Pdf.IPdfAnnotation! annotation, System.Func<LM.Core.Models.Pdf.PdfAnnotationRect, string?>? labelSelector = null) -> System.Collections.Immutable.ImmutableArray<LM.Core.Models.Pdf.PdfAnnotationOverlay>
+LM.Core.Models.Pdf.PdfAnnotationOverlay.Label.get -> string?
+LM.Core.Models.Pdf.PdfAnnotationOverlay.PageIndex.get -> int
+LM.Core.Models.Pdf.PdfAnnotationOverlay.PdfAnnotationOverlay(System.Guid annotationId, int pageIndex, LM.Core.Models.Pdf.PdfAnnotationRect rect, LM.Core.Models.Pdf.PdfAnnotationColor? color, string? label = null) -> void
+LM.Core.Models.Pdf.PdfAnnotationOverlay.Rect.get -> LM.Core.Models.Pdf.PdfAnnotationRect
+LM.Core.Models.Pdf.PdfAnnotationPreviewImage
+LM.Core.Models.Pdf.PdfAnnotationPreviewImage.Hash.get -> string?
+LM.Core.Models.Pdf.PdfAnnotationPreviewImage.Height.get -> int
+LM.Core.Models.Pdf.PdfAnnotationPreviewImage.LengthBytes.get -> long
+LM.Core.Models.Pdf.PdfAnnotationPreviewImage.MimeType.get -> string!
+LM.Core.Models.Pdf.PdfAnnotationPreviewImage.PdfAnnotationPreviewImage(string! mimeType, int width, int height, long lengthBytes, string? hash = null) -> void
+LM.Core.Models.Pdf.PdfAnnotationPreviewImage.Width.get -> int
+LM.Core.Models.Pdf.PdfAnnotationRect
+LM.Core.Models.Pdf.PdfAnnotationRect.FromAbsolute(double x, double y, double width, double height, double pageWidth, double pageHeight) -> LM.Core.Models.Pdf.PdfAnnotationRect!
+LM.Core.Models.Pdf.PdfAnnotationRect.Height.get -> double
+LM.Core.Models.Pdf.PdfAnnotationRect.PdfAnnotationRect(double x, double y, double width, double height) -> void
+LM.Core.Models.Pdf.PdfAnnotationRect.Translate(double deltaX, double deltaY) -> LM.Core.Models.Pdf.PdfAnnotationRect!
+LM.Core.Models.Pdf.PdfAnnotationRect.Width.get -> double
+LM.Core.Models.Pdf.PdfAnnotationRect.WithNormalizedCoordinates(double x, double y, double width, double height) -> LM.Core.Models.Pdf.PdfAnnotationRect!
+LM.Core.Models.Pdf.PdfAnnotationRect.X.get -> double
+LM.Core.Models.Pdf.PdfAnnotationRect.Y.get -> double
+LM.Core.Models.Pdf.PdfAnnotationRectNormalizer
+LM.Core.Models.Pdf.PdfAnnotationRectNormalizer.Normalize(double x, double y, double width, double height, double pageWidth, double pageHeight) -> LM.Core.Models.Pdf.PdfAnnotationRect!
 LM.Core.Models.Search.SearchHistoryDocument
 LM.Core.Models.Search.SearchHistoryDocument.Entries.get -> System.Collections.Generic.IReadOnlyList<LM.Core.Models.Search.SearchHistoryEntry!>!
 LM.Core.Models.Search.SearchHistoryDocument.Entries.init -> void


### PR DESCRIPTION
## Summary
- add immutable PDF annotation records for annotations, rectangles, colors, overlays, and preview metadata
- expose annotation-related interfaces and a factory to support infrastructure and UI layers
- add normalization and validation helpers for rectangle coordinates and tag collections

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: requires .NET 9 SDK which is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dad8a43620832b8bab81bc45a75c8b