### PR TITLE
Add infrastructure for persisting PDF annotations

### DIFF
--- a/src/LM.App.Wpf/Composition/Modules/PdfModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/PdfModule.cs
@@ -1,5 +1,7 @@
 using LM.App.Wpf.ViewModels.Pdf;
 using LM.App.Wpf.Views;
+using LM.Core.Abstractions;
+using LM.Infrastructure.Pdf;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -11,6 +13,7 @@ namespace LM.App.Wpf.Composition.Modules
         {
             var services = builder.Services;
 
+            services.AddSingleton<IPdfAnnotationPersistenceService, PdfAnnotationPersistenceService>();
             services.AddSingleton<PdfViewerViewModel>();
             services.AddTransient<PdfViewer>(sp =>
             {

--- a/src/LM.Core/Abstractions/IPdfAnnotationPersistenceService.cs
+++ b/src/LM.Core/Abstractions/IPdfAnnotationPersistenceService.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LM.Core.Abstractions
+{
+    /// <summary>
+    /// Persists PDF annotation overlays and preview images into the active workspace.
+    /// </summary>
+    public interface IPdfAnnotationPersistenceService
+    {
+        /// <summary>
+        /// Writes the overlay JSON and preview images for a PDF entry, then records the update in the entry changelog.
+        /// </summary>
+        /// <param name="entryId">The workspace entry identifier backing the PDF.</param>
+        /// <param name="pdfHash">The SHA-256 hash of the PDF file as produced by <see cref="IHasher"/>.</param>
+        /// <param name="overlayJson">Serialized annotation overlay metadata.</param>
+        /// <param name="previewImages">PNG preview images keyed by annotation identifier.</param>
+        /// <param name="overlaySidecarRelativePath">Optional workspace-relative path for the overlay sidecar JSON. When omitted, a default path is chosen.</param>
+        /// <param name="cancellationToken">Token used to observe cancellation.</param>
+        Task PersistAsync(
+            string entryId,
+            string pdfHash,
+            string overlayJson,
+            IReadOnlyDictionary<string, byte[]> previewImages,
+            string? overlaySidecarRelativePath,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/LM.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Core/PublicAPI.Unshipped.txt
@@ -24,6 +24,8 @@ LM.Core.Abstractions.IFileStorageRepository
 LM.Core.Abstractions.IFileStorageRepository.SaveNewAsync(string! sourcePath, string! relativeTargetDir, string? preferredFileName = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
 LM.Core.Abstractions.IHasher
 LM.Core.Abstractions.IHasher.ComputeSha256Async(string! filePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.Core.Abstractions.IPdfAnnotationPersistenceService
+LM.Core.Abstractions.IPdfAnnotationPersistenceService.PersistAsync(string! entryId, string! pdfHash, string! overlayJson, System.Collections.Generic.IReadOnlyDictionary<string!, byte[]!>! previewImages, string? overlaySidecarRelativePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 LM.Core.Abstractions.IMetadataDebugSlideExporter
 LM.Core.Abstractions.IMetadataDebugSlideExporter.ExportAsync(System.Collections.Generic.IEnumerable<LM.Core.Models.FileMetadata!>! items, string! outputPath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
 LM.Core.Abstractions.IMetadataExtractor

--- a/src/LM.HubAndSpoke/Models/PdfAnnotationsHook.cs
+++ b/src/LM.HubAndSpoke/Models/PdfAnnotationsHook.cs
@@ -1,0 +1,27 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace LM.HubSpoke.Models
+{
+    public sealed class PdfAnnotationsHook
+    {
+        [JsonPropertyName("schemaVersion")]
+        public string SchemaVersion { get; init; } = "1.0";
+
+        [JsonPropertyName("overlayPath")]
+        public string OverlayPath { get; init; } = string.Empty;
+
+        [JsonPropertyName("previews")]
+        public List<PdfAnnotationPreview> Previews { get; init; } = new();
+    }
+
+    public sealed class PdfAnnotationPreview
+    {
+        [JsonPropertyName("annotationId")]
+        public string AnnotationId { get; init; } = string.Empty;
+
+        [JsonPropertyName("imagePath")]
+        public string ImagePath { get; init; } = string.Empty;
+    }
+}

--- a/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
+++ b/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
@@ -297,6 +297,18 @@ LM.HubSpoke.Models.EntryChangeLogHook.Events.get -> System.Collections.Generic.L
 LM.HubSpoke.Models.EntryChangeLogHook.Events.set -> void
 LM.HubSpoke.Models.EntryChangeLogHook.SchemaVersion.get -> string!
 LM.HubSpoke.Models.EntryChangeLogHook.SchemaVersion.init -> void
+LM.HubSpoke.Models.PdfAnnotationPreview
+LM.HubSpoke.Models.PdfAnnotationPreview.AnnotationId.get -> string!
+LM.HubSpoke.Models.PdfAnnotationPreview.AnnotationId.init -> void
+LM.HubSpoke.Models.PdfAnnotationPreview.ImagePath.get -> string!
+LM.HubSpoke.Models.PdfAnnotationPreview.ImagePath.init -> void
+LM.HubSpoke.Models.PdfAnnotationsHook
+LM.HubSpoke.Models.PdfAnnotationsHook.OverlayPath.get -> string!
+LM.HubSpoke.Models.PdfAnnotationsHook.OverlayPath.init -> void
+LM.HubSpoke.Models.PdfAnnotationsHook.Previews.get -> System.Collections.Generic.List<LM.HubSpoke.Models.PdfAnnotationPreview!>!
+LM.HubSpoke.Models.PdfAnnotationsHook.Previews.init -> void
+LM.HubSpoke.Models.PdfAnnotationsHook.SchemaVersion.get -> string!
+LM.HubSpoke.Models.PdfAnnotationsHook.SchemaVersion.init -> void
 LM.HubSpoke.Models.EntryHooks
 LM.HubSpoke.Models.EntryHooks.Article.get -> string?
 LM.HubSpoke.Models.EntryHooks.Article.init -> void

--- a/src/LM.Infrastructure.Tests/Pdf/PdfAnnotationPersistenceServiceTests.cs
+++ b/src/LM.Infrastructure.Tests/Pdf/PdfAnnotationPersistenceServiceTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.HubSpoke.Models;
+using LM.Infrastructure.FileSystem;
+using LM.Infrastructure.Pdf;
+using Xunit;
+
+namespace LM.Infrastructure.Tests.Pdf
+{
+    public sealed class PdfAnnotationPersistenceServiceTests
+    {
+        [Fact]
+        public async Task PersistAsync_WritesArtifactsToDefaultLocations()
+        {
+            using var temp = new TempDir();
+
+            var workspace = new WorkspaceService();
+            await workspace.EnsureWorkspaceAsync(temp.Path);
+
+            var service = new PdfAnnotationPersistenceService(workspace);
+
+            const string entryId = "entry-123";
+            const string hash = "ABCDEF123456";
+            const string overlayJson = "{\"hello\":\"world\"}";
+
+            var previews = new Dictionary<string, byte[]>
+            {
+                ["ann1"] = new byte[] { 1, 2, 3 },
+                ["ann2"] = new byte[] { 4, 5, 6 }
+            };
+
+            await service.PersistAsync(entryId, hash, overlayJson, previews, null, CancellationToken.None);
+
+            var overlayPath = Path.Combine(temp.Path, "library", hash[..2], hash, hash + ".json");
+            Assert.True(File.Exists(overlayPath), $"Expected overlay at: {overlayPath}");
+            Assert.Equal(overlayJson, await File.ReadAllTextAsync(overlayPath));
+
+            foreach (var previewId in previews.Keys)
+            {
+                var previewPath = Path.Combine(temp.Path, "extraction", hash, previewId + ".png");
+                Assert.True(File.Exists(previewPath), $"Expected preview at: {previewPath}");
+                Assert.Equal(previews[previewId], await File.ReadAllBytesAsync(previewPath));
+            }
+
+            var hookPath = Path.Combine(temp.Path, "entries", entryId, "hooks", "pdf_annotations.json");
+            Assert.True(File.Exists(hookPath));
+
+            var hook = JsonSerializer.Deserialize<PdfAnnotationsHook>(await File.ReadAllTextAsync(hookPath));
+            Assert.NotNull(hook);
+            Assert.Equal($"library/{hash[..2]}/{hash}/{hash}.json", hook!.OverlayPath);
+            Assert.Equal(2, hook.Previews.Count);
+            Assert.Contains(hook.Previews, p => p.AnnotationId == "ann1" && p.ImagePath == $"extraction/{hash}/ann1.png");
+            Assert.Contains(hook.Previews, p => p.AnnotationId == "ann2" && p.ImagePath == $"extraction/{hash}/ann2.png");
+
+            var changeLogPath = Path.Combine(temp.Path, "entries", entryId, "hooks", "changelog.json");
+            var changeLog = JsonSerializer.Deserialize<EntryChangeLogHook>(await File.ReadAllTextAsync(changeLogPath));
+            Assert.NotNull(changeLog);
+            var changeEvent = Assert.Single(changeLog!.Events);
+            Assert.Equal("pdf-annotations-updated", changeEvent.Action);
+            Assert.Equal(Environment.UserName, changeEvent.PerformedBy);
+        }
+
+        [Fact]
+        public async Task PersistAsync_UsesProvidedSidecarPath()
+        {
+            using var temp = new TempDir();
+
+            var workspace = new WorkspaceService();
+            await workspace.EnsureWorkspaceAsync(temp.Path);
+
+            var service = new PdfAnnotationPersistenceService(workspace);
+
+            const string entryId = "entry-456";
+            const string hash = "A1B2C3D4";
+            const string overlayJson = "{}";
+            const string sidecar = "annotations/custom_overlay.json";
+
+            await service.PersistAsync(entryId, hash, overlayJson, new Dictionary<string, byte[]>(), sidecar, CancellationToken.None);
+
+            var overlayPath = Path.Combine(temp.Path, sidecar);
+            Assert.True(File.Exists(overlayPath));
+
+            var hookPath = Path.Combine(temp.Path, "entries", entryId, "hooks", "pdf_annotations.json");
+            var hook = JsonSerializer.Deserialize<PdfAnnotationsHook>(await File.ReadAllTextAsync(hookPath));
+            Assert.NotNull(hook);
+            Assert.Equal(sidecar.Replace('\', '/'), hook!.OverlayPath);
+        }
+
+        [Fact]
+        public async Task PersistAsync_ThrowsWhenSidecarIsAbsolute()
+        {
+            using var temp = new TempDir();
+
+            var workspace = new WorkspaceService();
+            await workspace.EnsureWorkspaceAsync(temp.Path);
+
+            var service = new PdfAnnotationPersistenceService(workspace);
+
+            var absoluteSidecar = Path.Combine(temp.Path, "overlay.json");
+
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                service.PersistAsync(
+                    "entry-789",
+                    "ABCD1234",
+                    "{}",
+                    new Dictionary<string, byte[]>(),
+                    absoluteSidecar,
+                    CancellationToken.None));
+        }
+
+        private sealed class TempDir : IDisposable
+        {
+            public string Path { get; }
+
+            public TempDir()
+            {
+                Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "lm_pdf_annotations_" + Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(Path);
+            }
+
+            public void Dispose()
+            {
+                try { Directory.Delete(Path, recursive: true); } catch { /* ignore */ }
+            }
+        }
+    }
+}

--- a/src/LM.Infrastructure/Pdf/PdfAnnotationPersistenceService.cs
+++ b/src/LM.Infrastructure/Pdf/PdfAnnotationPersistenceService.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Abstractions;
+using LM.HubSpoke.Models;
+using LM.Infrastructure.Hooks;
+
+namespace LM.Infrastructure.Pdf
+{
+    /// <summary>
+    /// Stores PDF annotation overlays and preview assets into the current workspace.
+    /// </summary>
+    public sealed class PdfAnnotationPersistenceService : IPdfAnnotationPersistenceService
+    {
+        private const string OverlayExtension = ".json";
+        private const string PreviewExtension = ".png";
+
+        private readonly IWorkSpaceService _workspace;
+        private readonly HookWriter _hookWriter;
+
+        public PdfAnnotationPersistenceService(IWorkSpaceService workspace)
+        {
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+            _hookWriter = new HookWriter(_workspace);
+        }
+
+        public async Task PersistAsync(
+            string entryId,
+            string pdfHash,
+            string overlayJson,
+            IReadOnlyDictionary<string, byte[]> previewImages,
+            string? overlaySidecarRelativePath,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(entryId))
+                throw new ArgumentException("Entry identifier must be provided.", nameof(entryId));
+            if (string.IsNullOrWhiteSpace(pdfHash))
+                throw new ArgumentException("PDF hash must be provided.", nameof(pdfHash));
+            if (pdfHash.Length < 2)
+                throw new ArgumentException("PDF hash must contain at least two characters.", nameof(pdfHash));
+            if (overlayJson is null)
+                throw new ArgumentNullException(nameof(overlayJson));
+
+            var safePreviewImages = previewImages ?? new Dictionary<string, byte[]>(capacity: 0);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var overlayRelativePath = ResolveOverlayRelativePath(pdfHash, overlaySidecarRelativePath);
+            var overlayAbsolutePath = _workspace.GetAbsolutePath(overlayRelativePath);
+            EnsureDirectoryForFile(overlayAbsolutePath);
+
+            var overlayBytes = Encoding.UTF8.GetBytes(overlayJson);
+            await File.WriteAllBytesAsync(overlayAbsolutePath, overlayBytes, cancellationToken).ConfigureAwait(false);
+
+            var previewRootRelative = Path.Combine("extraction", pdfHash);
+            var previewRootAbsolute = _workspace.GetAbsolutePath(previewRootRelative);
+            Directory.CreateDirectory(previewRootAbsolute);
+
+            var previews = new List<PdfAnnotationPreview>(safePreviewImages.Count);
+
+            foreach (var kvp in safePreviewImages)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var annotationId = NormalizeAnnotationId(kvp.Key);
+                if (annotationId is null || kvp.Value is null)
+                {
+                    continue;
+                }
+
+                var previewRelativePath = NormalizeRelativePath(Path.Combine(previewRootRelative, annotationId + PreviewExtension));
+                var previewAbsolutePath = Path.Combine(previewRootAbsolute, annotationId + PreviewExtension);
+
+                await File.WriteAllBytesAsync(previewAbsolutePath, kvp.Value, cancellationToken).ConfigureAwait(false);
+
+                previews.Add(new PdfAnnotationPreview
+                {
+                    AnnotationId = annotationId,
+                    ImagePath = previewRelativePath
+                });
+            }
+
+            var hook = new PdfAnnotationsHook
+            {
+                OverlayPath = NormalizeRelativePath(overlayRelativePath),
+                Previews = previews
+            };
+
+            await _hookWriter.SavePdfAnnotationsAsync(entryId, hook, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static string ResolveOverlayRelativePath(string pdfHash, string? sidecar)
+        {
+            if (!string.IsNullOrWhiteSpace(sidecar))
+            {
+                var trimmed = sidecar.Trim();
+                if (Path.IsPathRooted(trimmed))
+                {
+                    throw new ArgumentException("Overlay sidecar path must be workspace-relative.", nameof(sidecar));
+                }
+
+                return NormalizeRelativePath(trimmed);
+            }
+
+            var folder = pdfHash[..2];
+            var fileName = pdfHash + OverlayExtension;
+            return NormalizeRelativePath(Path.Combine("library", folder, pdfHash, fileName));
+        }
+
+        private static string? NormalizeAnnotationId(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return null;
+            }
+
+            var trimmed = raw.Trim();
+            var sanitized = Path.GetFileName(trimmed);
+            return string.IsNullOrWhiteSpace(sanitized) ? null : sanitized;
+        }
+
+        private static string NormalizeRelativePath(string path)
+        {
+            var interim = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            return interim.Replace(Path.DirectorySeparatorChar, '/');
+        }
+
+        private static void EnsureDirectoryForFile(string filePath)
+        {
+            var directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+        }
+    }
+}

--- a/src/LM.Infrastructure/PublicAPI.Unshipped.txt
+++ b/src/LM.Infrastructure/PublicAPI.Unshipped.txt
@@ -65,6 +65,9 @@ LM.Infrastructure.Search.ClinicalTrialsGovSearchProvider.SearchAsync(string! que
 LM.Infrastructure.PubMed.PubMedClient
 LM.Infrastructure.PubMed.PubMedClient.PubMedClient() -> void
 LM.Infrastructure.PubMed.PubMedClient.TryGetByDoiAsync(string! doi, bool includeCitedBy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<LM.Core.Models.PublicationRecord?>!
+LM.Infrastructure.Pdf.PdfAnnotationPersistenceService
+LM.Infrastructure.Pdf.PdfAnnotationPersistenceService.PdfAnnotationPersistenceService(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.Infrastructure.Pdf.PdfAnnotationPersistenceService.PersistAsync(string! entryId, string! pdfHash, string! overlayJson, System.Collections.Generic.IReadOnlyDictionary<string!, byte[]!>! previewImages, string? overlaySidecarRelativePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 LM.Infrastructure.Search.PubMedSearchProvider
 LM.Infrastructure.Search.PubMedSearchProvider.PubMedSearchProvider() -> void
 LM.Infrastructure.Search.PubMedSearchProvider.Database.get -> LM.Core.Models.SearchDatabase


### PR DESCRIPTION
## Summary
- add a PDF annotation persistence service and supporting abstractions to store overlay JSON and preview images in the workspace
- extend HookWriter with a pdf-annotations hook that records changelog entries and add coverage for the new behavior
- register the service in the WPF composition module and cover persistence logic with new infrastructure tests

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: repository currently has unresolved PublicAPI analyzer errors for existing PDF annotation models)*
- `dotnet test src/LM.Infrastructure.Tests/LM.Infrastructure.Tests.csproj -c Debug` *(fails: repository currently has unresolved PublicAPI analyzer errors for existing PDF annotation models)*

------
https://chatgpt.com/codex/tasks/task_e_68dade289408832b967f9fea72d6e953