### PR TITLE
Fix invalid WPF properties in PDF annotation views

### DIFF
--- a/src/LM.App.Wpf/Views/Pdf/PdfAnnotationList.xaml
+++ b/src/LM.App.Wpf/Views/Pdf/PdfAnnotationList.xaml
@@ -30,11 +30,11 @@
     <ListView ItemsSource="{Binding Source={StaticResource AnnotationsView}}"
               SelectedItem="{Binding SelectedAnnotation, Mode=TwoWay}"
               ItemTemplate="{StaticResource PdfAnnotationItemTemplate}"
-              SelectionChanged="OnSelectionChanged">
+              SelectionChanged="OnSelectionChanged"
+              ScrollViewer.VerticalScrollBarVisibility="Auto">
       <ListView.GroupStyle>
         <GroupStyle ContainerStyle="{StaticResource PdfAnnotationGroupStyle}" />
       </ListView.GroupStyle>
-      <ListView.ScrollViewer.VerticalScrollBarVisibility>Auto</ListView.ScrollViewer.VerticalScrollBarVisibility>
     </ListView>
   </Grid>
 </UserControl>

--- a/src/LM.App.Wpf/Views/Pdf/PdfAnnotationTemplates.xaml
+++ b/src/LM.App.Wpf/Views/Pdf/PdfAnnotationTemplates.xaml
@@ -39,17 +39,18 @@
         </Border>
 
         <StackPanel Grid.Column="2"
-                    Orientation="Vertical"
-                    Spacing="4">
+                    Orientation="Vertical">
           <TextBlock Text="{Binding Title}"
                      FontWeight="SemiBold"
                      TextTrimming="CharacterEllipsis" />
           <TextBlock Text="{Binding TextSnippet}"
+                     Margin="0,4,0,0"
                      FontStyle="Italic"
                      Foreground="#FF555555"
                      TextWrapping="Wrap"
                      MaxHeight="60" />
           <TextBox Text="{Binding Note, UpdateSourceTrigger=PropertyChanged}"
+                   Margin="0,4,0,0"
                    AcceptsReturn="True"
                    TextWrapping="Wrap"
                    MinHeight="48"


### PR DESCRIPTION
## Summary
- use the ScrollViewer.VerticalScrollBarVisibility attached property on the PDF annotation list view to avoid MC3074 design-time errors
- remove the unsupported StackPanel Spacing property from the PDF annotation template and replace it with explicit margins so the resource dictionary parses

## Testing
- dotnet build src/LM.App.Wpf/LM.App.Wpf.csproj -c Debug *(fails: LM.App.Wpf/ViewModels/Pdf/PdfAnnotation.cs(163,33): error CS0115: 'PdfAnnotation.Dispose(bool)' : no suitable method found to override)*

------
https://chatgpt.com/codex/tasks/task_e_68daf84db41c832ba5fbee499f2e3521