### PR TITLE
Fix PDF viewer crash caused by color command parameter visibility

### DIFF
--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -182,6 +182,11 @@ LM.App.Wpf.ViewModels.Pdf.PdfAnnotation.DeleteCommand.set -> void
 LM.App.Wpf.ViewModels.Pdf.PdfAnnotation.Id.get -> string!
 LM.App.Wpf.ViewModels.Pdf.PdfAnnotation.Note.get -> string?
 LM.App.Wpf.ViewModels.Pdf.PdfAnnotation.Note.set -> void
+LM.App.Wpf.ViewModels.Pdf.PdfAnnotationColorCommandParameter
+LM.App.Wpf.ViewModels.Pdf.PdfAnnotationColorCommandParameter.Annotation.get -> LM.App.Wpf.ViewModels.Pdf.PdfAnnotation?
+LM.App.Wpf.ViewModels.Pdf.PdfAnnotationColorCommandParameter.Annotation.set -> void
+LM.App.Wpf.ViewModels.Pdf.PdfAnnotationColorCommandParameter.ColorName.get -> string?
+LM.App.Wpf.ViewModels.Pdf.PdfAnnotationColorCommandParameter.ColorName.set -> void
 LM.App.Wpf.ViewModels.Pdf.PdfAnnotation.PageNumber.get -> int
 LM.App.Wpf.ViewModels.Pdf.PdfAnnotation.PageNumber.set -> void
 LM.App.Wpf.ViewModels.Pdf.PdfAnnotation.PdfAnnotation(string! id, string! title) -> void

--- a/src/LM.App.Wpf/ViewModels/Pdf/PdfAnnotationColorCommandParameter.cs
+++ b/src/LM.App.Wpf/ViewModels/Pdf/PdfAnnotationColorCommandParameter.cs
@@ -1,6 +1,10 @@
 namespace LM.App.Wpf.ViewModels.Pdf
 {
-    internal sealed class PdfAnnotationColorCommandParameter
+    /// <summary>
+    /// Represents the payload passed from XAML menu items to the
+    /// <see cref="PdfViewerViewModel.ChangeAnnotationColorCommand"/>.
+    /// </summary>
+    public sealed class PdfAnnotationColorCommandParameter
     {
         public PdfAnnotation? Annotation { get; set; }
 


### PR DESCRIPTION
## Summary
- expose `PdfAnnotationColorCommandParameter` so the context menu command parameter can be created from XAML
- document the new public type in `PublicAPI.Unshipped.txt`

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: NETSDK1045 current SDK does not support net9.0 targeting)*
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: NETSDK1045 current SDK does not support net9.0 targeting)*

------
https://chatgpt.com/codex/tasks/task_e_68db0ee94bcc832ba3cca30f97b2406c