### PR TITLE
Fix Pdf annotation group style resource usage

### DIFF
--- a/src/LM.App.Wpf/Views/Pdf/PdfAnnotationList.xaml
+++ b/src/LM.App.Wpf/Views/Pdf/PdfAnnotationList.xaml
@@ -33,7 +33,7 @@
               SelectionChanged="OnSelectionChanged"
               ScrollViewer.VerticalScrollBarVisibility="Auto">
       <ListView.GroupStyle>
-        <GroupStyle ContainerStyle="{StaticResource PdfAnnotationGroupStyle}" />
+        <StaticResource ResourceKey="PdfAnnotationGroupStyle" />
       </ListView.GroupStyle>
     </ListView>
   </Grid>


### PR DESCRIPTION
## Summary
- reference the shared Pdf annotation group style resource correctly so the ListView can load without a XAML parse error

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: RS0016 public API baseline errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68db140130d0832b88dd8ee1a90daa4f