### PR TITLE
Handle WebView2 host removal COMException

### DIFF
--- a/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
+++ b/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
@@ -166,6 +166,13 @@ namespace LM.App.Wpf.Views
             {
                 // Older runtimes may not support removal; ignore.
             }
+            catch (COMException ex) when ((uint)ex.ErrorCode == 0x80070049)
+            {
+                // WebView2 returns ERROR_BAD_NET_NAME (0x80070049) when the
+                // script object is no longer available. This happens if the
+                // viewer closes before the host object is disposed. Ignore it
+                // and continue registering a new bridge instance.
+            }
 
             _hostObject ??= new PdfViewerHostObject(this);
 


### PR DESCRIPTION
## Summary
- guard the WebView2 host object removal against the ERROR_BAD_NET_NAME COM exception so reopening the PDF window no longer crashes

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: Public API analyzer RS0016 errors in LM.App.Wpf)*
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: Public API analyzer RS0016 errors in LM.App.Wpf)*

------
https://chatgpt.com/codex/tasks/task_e_68db15dd4f6c832b85eedc0e77e98a19