### PR TITLE
Handle missing WebView2 host object removal

### DIFF
--- a/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
+++ b/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
@@ -173,6 +173,12 @@ namespace LM.App.Wpf.Views
                 // viewer closes before the host object is disposed. Ignore it
                 // and continue registering a new bridge instance.
             }
+            catch (COMException ex) when ((uint)ex.ErrorCode == 0x80070490)
+            {
+                // WebView2 returns ERROR_NOT_FOUND (0x80070490) if the
+                // host object has already been removed. Treat it the same
+                // as a missing registration and continue.
+            }
 
             _hostObject ??= new PdfViewerHostObject(this);
 


### PR DESCRIPTION
## Summary
- suppress WebView2 ERROR_NOT_FOUND when removing the existing host object before registering the bridge again

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: NETSDK1045 – installed SDK 8.0.414 does not support net9.0 projects)*

------
https://chatgpt.com/codex/tasks/task_e_68db19602bbc832bbd5e12f192c46fe3