### PR TITLE
Handle WebView2 host removal failures

### DIFF
--- a/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
+++ b/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
@@ -166,6 +166,13 @@ namespace LM.App.Wpf.Views
             {
                 // Older runtimes may not support removal; ignore.
             }
+            catch (COMException ex)
+            {
+                Trace.TraceWarning(
+                    "WebView2 failed to remove existing host object (HRESULT: 0x{0:X8}). {1}",
+                    ex.HResult,
+                    ex);
+            }
 
             _hostObject ??= new PdfViewerHostObject(this);
 


### PR DESCRIPTION
## Summary
- guard against COMException failures when removing the WebView2 host object so the PDF viewer no longer crashes

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: SDK 8.0.414 cannot target .NET 9.0 in container)*
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: SDK 8.0.414 cannot target .NET 9.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db17881c0c832baf60bdb1feea39e7