### PR TITLE
Retry PDF bridge initialization until host is ready

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="Jint" Version="3.1.0" />
 
     <!-- === WPF infrastructure === -->
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />

--- a/src/LM.App.Wpf.Tests/LM.App.Wpf.Tests.csproj
+++ b/src/LM.App.Wpf.Tests/LM.App.Wpf.Tests.csproj
@@ -26,5 +26,6 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Jint" />
   </ItemGroup>
 </Project>

--- a/src/LM.App.Wpf.Tests/Services/Pdf/KnowledgeworksBridgeTests.cs
+++ b/src/LM.App.Wpf.Tests/Services/Pdf/KnowledgeworksBridgeTests.cs
@@ -1,0 +1,210 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Jint;
+using Jint.Native;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.Services.Pdf
+{
+    public sealed class KnowledgeworksBridgeTests
+    {
+        [Fact]
+        public void InitializeBridgeRetriesUntilHostObjectAvailable()
+        {
+            using var harness = KnowledgeworksBridgeHarness.Create();
+
+            harness.InvokeInitializeBridge();
+
+            Assert.True(harness.HasPendingTimers);
+
+            harness.SetPdfViewerApplication();
+
+            Assert.True(harness.RunNextTimer());
+
+            harness.SetHostObject("app://entry.pdf");
+
+            harness.DrainTimers();
+
+            Assert.Equal(1, harness.LoadPdfInvocationCount);
+            Assert.Equal("app://entry.pdf", harness.OpenedUrl);
+            Assert.False(harness.RunNextTimer());
+        }
+
+        private sealed class KnowledgeworksBridgeHarness : IDisposable
+        {
+            private readonly Engine _engine;
+            private readonly JsValue _window;
+            private bool _disposed;
+
+            private int _loadPdfInvocationCount;
+            private string? _openedUrl;
+
+            private KnowledgeworksBridgeHarness(string scriptPath)
+            {
+                _engine = new Engine(options => options.CatchClrExceptions());
+
+                _engine.Execute("var window = globalThis;");
+                _window = _engine.GetValue("window");
+
+                _engine.SetValue("__kwRecordLoad", new Action(() => _loadPdfInvocationCount++));
+                _engine.SetValue("__kwRecordOpen", new Action<string>(url => _openedUrl = url ?? string.Empty));
+
+                _engine.Execute(@"
+                    window.document = { readyState: 'loading', addEventListener: function() {} };
+                    window.addEventListener = function() {};
+                    window.__kwTimers = { nextId: 1, queue: [] };
+                    window.setTimeout = function(callback, delay) {
+                        var id = window.__kwTimers.nextId++;
+                        window.__kwTimers.queue.push({ id: id, callback: callback });
+                        return id;
+                    };
+                    window.clearTimeout = function(handle) {
+                        var id = Number(handle);
+                        if (!isFinite(id)) {
+                            return;
+                        }
+                        window.__kwTimers.queue = window.__kwTimers.queue.filter(function(entry) { return entry && entry.id !== id; });
+                    };
+                    window.__kwRunNextTimer = function() {
+                        while (window.__kwTimers.queue.length > 0) {
+                            var entry = window.__kwTimers.queue.shift();
+                            if (entry && typeof entry.callback === 'function') {
+                                entry.callback();
+                                return entry.id;
+                            }
+                        }
+                        return 0;
+                    };
+                    window.queueMicrotask = function(callback) {
+                        if (typeof callback === 'function') {
+                            callback();
+                        }
+                    };
+                    window.chrome = { webview: { hostObjects: {}, postMessage: function() {} } };
+                    window.console = { error: function() {}, log: function() {} };
+                    globalThis.document = window.document;
+                    globalThis.console = window.console;
+                    globalThis.Node = { ELEMENT_NODE: 1 };
+                    globalThis.CSS = undefined;
+                ");
+
+                var scriptContent = File.ReadAllText(scriptPath);
+                _engine.Execute(scriptContent);
+            }
+
+            public static KnowledgeworksBridgeHarness Create()
+            {
+                var baseDir = AppContext.BaseDirectory;
+                var scriptPath = Path.GetFullPath(Path.Combine(
+                    baseDir,
+                    "..",
+                    "..",
+                    "..",
+                    "..",
+                    "..",
+                    "src",
+                    "LM.App.Wpf",
+                    "wwwroot",
+                    "pdfjs",
+                    "knowledgeworks-bridge.js"));
+
+                return new KnowledgeworksBridgeHarness(scriptPath);
+            }
+
+            public void InvokeInitializeBridge()
+            {
+                var initialize = _engine.GetValue("initializeBridge");
+                _engine.Invoke(initialize);
+            }
+
+            public bool HasPendingTimers => GetQueueLength() > 0;
+
+            public bool RunNextTimer()
+            {
+                var result = _engine.GetValue("window.__kwRunNextTimer()");
+                return ConvertToNumber(result) > 0;
+            }
+
+            public void DrainTimers()
+            {
+                while (RunNextTimer())
+                {
+                }
+            }
+
+            public int LoadPdfInvocationCount => _loadPdfInvocationCount;
+
+            public string? OpenedUrl => _openedUrl;
+
+            public void SetPdfViewerApplication()
+            {
+                _engine.Execute(@"
+                    window.PDFViewerApplication = {
+                        url: '',
+                        initializedPromise: { then: function(callback) { if (callback) { callback(); } } },
+                        eventBus: { on: function() {} },
+                        pdfViewer: {},
+                        open: function(args) {
+                            var next = '';
+                            if (args && typeof args.url === 'string') {
+                                next = args.url;
+                            } else if (typeof args === 'string') {
+                                next = args;
+                            }
+                            this.url = next;
+                            __kwRecordOpen(next);
+                        }
+                    };
+                    globalThis.PDFViewerApplication = window.PDFViewerApplication;
+                ");
+            }
+
+            public void SetHostObject(string targetUrl)
+            {
+                var literal = JsonSerializer.Serialize(targetUrl ?? string.Empty);
+                _engine.Execute($@"
+                    window.chrome.webview.hostObjects.knowledgeworksBridge = {{
+                        LoadPdfAsync: function() {{
+                            __kwRecordLoad();
+                            return {literal};
+                        }},
+                        CreateHighlightAsync: function() {{ return null; }},
+                        GetCurrentSelectionAsync: function() {{ return null; }},
+                        SetOverlayAsync: function() {{ }}
+                    }};
+                ");
+            }
+
+            private double GetQueueLength()
+            {
+                var value = _engine.GetValue("window.__kwTimers.queue.length");
+                return ConvertToNumber(value);
+            }
+
+            private static double ConvertToNumber(JsValue value)
+            {
+                var obj = value.ToObject();
+                return obj switch
+                {
+                    double d => d,
+                    int i => i,
+                    long l => l,
+                    float f => f,
+                    decimal m => (double)m,
+                    _ => 0d,
+                };
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add retry and one-shot guards to the PDF bridge so `initializeBridge` and `loadPdfFromHost` keep rescheduling until the host object and viewer are ready
- introduce a WebView-style harness test (backed by Jint) that waits for a delayed host object and asserts `LoadPdfAsync` is invoked
- reference the Jint package from the WPF test project to enable the new harness

## Testing
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: missing Microsoft.WindowsDesktop.App 9.0.0 on linux runners)*

------
https://chatgpt.com/codex/tasks/task_e_68db97a2c964832bad4bb1d7995c77f5