### PR TITLE
Use FileStreamOptions for PDF hashing

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.cs
@@ -269,12 +269,18 @@ namespace LM.App.Wpf.ViewModels.Pdf
                 }
                 else
                 {
-                    await using var stream = new FileStream(absolutePath,
-                                                            FileMode.Open,
-                                                            FileAccess.Read,
-                                                            FileShare.Read,
-                                                            bufferSize: 81920,
-                                                            useAsync: true);
+                    var streamOptions = new FileStreamOptions
+                    {
+                        Mode = FileMode.Open,
+                        Access = FileAccess.Read,
+                        Share = FileShare.Read,
+                        BufferSize = 81920,
+                        Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+                    };
+
+                    // Asynchronous file streams intentionally disable timeout semantics; debugger
+                    // inspection of ReadTimeout/WriteTimeout will surface InvalidOperationException.
+                    await using var stream = new FileStream(absolutePath, streamOptions);
                     using var sha = SHA256.Create();
                     var hashBytes = await sha.ComputeHashAsync(stream, CancellationToken.None).ConfigureAwait(false);
                     PdfHash = Convert.ToHexString(hashBytes).ToLowerInvariant();


### PR DESCRIPTION
## Summary
- use FileStreamOptions when opening the PDF stream so hashing opts into asynchronous sequential reads
- document why async file streams expose InvalidOperationException when inspecting timeout properties in the debugger

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: installed SDK 8.0.414 cannot build net9.0 targets)*

------
https://chatgpt.com/codex/tasks/task_e_68dba063e5f0832b8fcd4e8866c6a6e0