### PR TITLE
Ensure PDF viewer requests host-based loads

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Pdf/IPdfWebViewBridge.cs
+++ b/src/LM.App.Wpf/ViewModels/Pdf/IPdfWebViewBridge.cs
@@ -6,5 +6,7 @@ namespace LM.App.Wpf.ViewModels.Pdf
     internal interface IPdfWebViewBridge
     {
         Task ScrollToAnnotationAsync(string annotationId, CancellationToken cancellationToken);
+
+        Task RequestDocumentLoadAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.cs
@@ -209,7 +209,11 @@ namespace LM.App.Wpf.ViewModels.Pdf
         public IPdfWebViewBridge? WebViewBridge
         {
             private get => _webViewBridge;
-            set => _webViewBridge = value;
+            set
+            {
+                _webViewBridge = value;
+                TryRequestDocumentLoad();
+            }
         }
 
         public async Task HandleAnnotationSelectionAsync(PdfAnnotation? annotation, CancellationToken cancellationToken)

--- a/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
+++ b/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
@@ -810,6 +810,22 @@ namespace LM.App.Wpf.Views
                 }).Task.ConfigureAwait(false);
             }
 
+            public async Task RequestDocumentLoadAsync(CancellationToken cancellationToken)
+            {
+                await EnsureCoreAsync().ConfigureAwait(false);
+
+                await _webView.Dispatcher.InvokeAsync(() =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (_webView.CoreWebView2 is null)
+                    {
+                        return;
+                    }
+
+                    _ = _webView.CoreWebView2.ExecuteScriptAsync("window?.PdfBridge?.loadPdf?.()");
+                }).Task.ConfigureAwait(false);
+            }
+
             private async Task EnsureCoreAsync()
             {
                 if (_webView.CoreWebView2 is not null)


### PR DESCRIPTION
## Summary
- extend the PDF WebView bridge so the host can trigger document loads
- queue PDF load requests until the viewer is ready and the bridge is attached, then invoke the JavaScript loader
- wire the view-model and view to request the host-based load path whenever the document source changes

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: .NET SDK 8.0.414 cannot target net9.0)*
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: .NET SDK 8.0.414 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68db9fbf99fc832b8e8f1dfed27aa16d