### PR TITLE
Relax PDF streaming file handles to avoid load failures

### DIFF
--- a/CombinedPublicAPI.txt
+++ b/CombinedPublicAPI.txt
@@ -1,0 +1,1 @@
+=== Combined Public API for KnowledgeWorks_20250820_082416 ===

--- a/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.cs
@@ -277,7 +277,7 @@ namespace LM.App.Wpf.ViewModels.Pdf
                     {
                         Mode = FileMode.Open,
                         Access = FileAccess.Read,
-                        Share = FileShare.Read,
+                        Share = FileShare.ReadWrite | FileShare.Delete,
                         BufferSize = 81920,
                         Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
                     };

--- a/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
+++ b/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
@@ -597,7 +597,16 @@ namespace LM.App.Wpf.Views
                     return;
                 }
 
-                var fileStream = new FileStream(resolvedPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                var fileStreamOptions = new FileStreamOptions
+                {
+                    Mode = FileMode.Open,
+                    Access = FileAccess.Read,
+                    Share = FileShare.ReadWrite | FileShare.Delete,
+                    BufferSize = 81920,
+                    Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+                };
+
+                var fileStream = new FileStream(resolvedPath, fileStreamOptions);
                 var headers = BuildResponseHeaders("application/pdf", fileInfo.Length, allowRange: true);
                 e.Response = environment.CreateWebResourceResponse(fileStream, 200, "OK", headers);
             }
@@ -693,7 +702,16 @@ namespace LM.App.Wpf.Views
 
             var length = (end - start) + 1;
 
-            var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var streamOptions = new FileStreamOptions
+            {
+                Mode = FileMode.Open,
+                Access = FileAccess.Read,
+                Share = FileShare.ReadWrite | FileShare.Delete,
+                BufferSize = 81920,
+                Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+            };
+
+            var stream = new FileStream(path, streamOptions);
             stream.Seek(start, SeekOrigin.Begin);
 
             var builder = new StringBuilder();


### PR DESCRIPTION
## Summary
- allow the PDF hash computation path to open documents with read/write/delete sharing so we can still inspect files that are held open elsewhere
- serve WebView PDF responses through FileStreamOptions that use the same relaxed sharing and sequential read settings

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: Microsoft.WindowsDesktop.App 9.0.0 runtime is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbabfc780c832bb500419632ffc2b9