### PR TITLE
Fix PDF bridge load guard and add regression test

### DIFF
--- a/src/LM.App.Wpf.Tests/Services/Pdf/KnowledgeworksBridgeTests.cs
+++ b/src/LM.App.Wpf.Tests/Services/Pdf/KnowledgeworksBridgeTests.cs
@@ -31,6 +31,29 @@ namespace LM.App.Wpf.Tests.Services.Pdf
             Assert.False(harness.RunNextTimer());
         }
 
+        [Fact]
+        public void LoadPdfFromHostRequestsHostWhenUrlChanges()
+        {
+            using var harness = KnowledgeworksBridgeHarness.Create();
+
+            harness.SetPdfViewerApplication();
+            harness.SetHostObject("app://first.pdf");
+
+            harness.InvokeLoadPdfFromHost();
+            harness.DrainTimers();
+
+            Assert.Equal(1, harness.LoadPdfInvocationCount);
+            Assert.Equal("app://first.pdf", harness.OpenedUrl);
+
+            harness.SetHostObject("app://second.pdf");
+
+            harness.InvokeLoadPdfFromHost();
+            harness.DrainTimers();
+
+            Assert.Equal(2, harness.LoadPdfInvocationCount);
+            Assert.Equal("app://second.pdf", harness.OpenedUrl);
+        }
+
         private sealed class KnowledgeworksBridgeHarness : IDisposable
         {
             private readonly Engine _engine;
@@ -116,6 +139,12 @@ namespace LM.App.Wpf.Tests.Services.Pdf
             {
                 var initialize = _engine.GetValue("initializeBridge");
                 _engine.Invoke(initialize);
+            }
+
+            public void InvokeLoadPdfFromHost()
+            {
+                var loadPdf = _engine.GetValue("loadPdfFromHost");
+                _engine.Invoke(loadPdf);
             }
 
             public bool HasPendingTimers => GetQueueLength() > 0;


### PR DESCRIPTION
## Summary
- track the last requested PDF URL in the bridge so a host request is only skipped when the viewer is already displaying that document
- reset the PDF load completion flag whenever a new document is requested and mark completion only after the viewer URL matches the host target
- add a regression test that ensures consecutive LoadPdfAsync calls for different URLs both reach the host

## Testing
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: .NET 9.0 target requires a newer SDK than 8.0.414)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb697d9ac832bb1ce974d103e97e6