### PR TITLE
Fix PDF viewer reload when reloading same source

### DIFF
--- a/src/LM.App.Wpf.Tests/ViewModels/Pdf/PdfViewerViewModelTests.cs
+++ b/src/LM.App.Wpf.Tests/ViewModels/Pdf/PdfViewerViewModelTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.App.Wpf.Common;
+using LM.App.Wpf.Services;
+using LM.App.Wpf.ViewModels.Pdf;
+using LM.Core.Abstractions;
+using LM.Infrastructure.Hooks;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.ViewModels.Pdf
+{
+    public sealed class PdfViewerViewModelTests
+    {
+        [Fact]
+        public async Task LoadPdfCoreAsync_ReassigningSameSource_RequestsDocumentReload()
+        {
+            using var workspace = new TemporaryWorkspace();
+            var orchestrator = new HookOrchestrator(workspace);
+            var viewModel = new PdfViewerViewModel(
+                orchestrator,
+                new FixedUserContext("test-user"),
+                new NoopPreviewStorage(),
+                workspace,
+                new NullClipboardService());
+
+            var bridge = new RecordingBridge();
+            viewModel.WebViewBridge = bridge;
+
+            var pdfPath = Path.Combine(workspace.Root, "sample.pdf");
+            Directory.CreateDirectory(Path.GetDirectoryName(pdfPath)!);
+            await File.WriteAllTextAsync(pdfPath, "pdf").ConfigureAwait(true);
+
+            viewModel.PdfPath = pdfPath;
+            await InvokeLoadPdfAsync(viewModel).ConfigureAwait(true);
+            viewModel.HandleViewerReady();
+            Assert.Equal(1, bridge.RequestCount);
+
+            await InvokeLoadPdfAsync(viewModel).ConfigureAwait(true);
+            viewModel.HandleViewerReady();
+
+            Assert.Equal(2, bridge.RequestCount);
+        }
+
+        private static Task InvokeLoadPdfAsync(PdfViewerViewModel viewModel)
+        {
+            var method = typeof(PdfViewerViewModel).GetMethod("LoadPdfCoreAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+            var task = method!.Invoke(viewModel, Array.Empty<object>()) as Task;
+            return task ?? Task.CompletedTask;
+        }
+
+        private sealed class RecordingBridge : IPdfWebViewBridge
+        {
+            public int RequestCount { get; private set; }
+
+            public Task ScrollToAnnotationAsync(string annotationId, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+
+            public Task RequestDocumentLoadAsync(CancellationToken cancellationToken)
+            {
+                RequestCount++;
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class TemporaryWorkspace : IWorkSpaceService, IDisposable
+        {
+            public string Root { get; } = Path.Combine(Path.GetTempPath(), "kw-pdf-viewer-tests-" + Guid.NewGuid().ToString("N"));
+
+            public TemporaryWorkspace()
+            {
+                Directory.CreateDirectory(Root);
+            }
+
+            public string? WorkspacePath => Root;
+
+            public string GetWorkspaceRoot() => Root;
+
+            public string GetLocalDbPath() => Path.Combine(Root, "local.db");
+
+            public string GetAbsolutePath(string relativePath)
+            {
+                var normalized = relativePath.Replace('/', Path.DirectorySeparatorChar);
+                return Path.Combine(Root, normalized);
+            }
+
+            public Task EnsureWorkspaceAsync(string absoluteWorkspacePath, CancellationToken ct = default)
+            {
+                Directory.CreateDirectory(absoluteWorkspacePath);
+                return Task.CompletedTask;
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    if (Directory.Exists(Root))
+                    {
+                        Directory.Delete(Root, recursive: true);
+                    }
+                }
+                catch
+                {
+                    // Best-effort cleanup.
+                }
+            }
+        }
+
+        private sealed class NoopPreviewStorage : IPdfAnnotationPreviewStorage
+        {
+            public Task<string> SaveAsync(string pdfHash, string annotationId, byte[] pngBytes, CancellationToken cancellationToken)
+                => Task.FromResult(string.Empty);
+        }
+
+        private sealed class NullClipboardService : IClipboardService
+        {
+            public void SetText(string text)
+            {
+            }
+        }
+
+        private sealed class FixedUserContext : IUserContext
+        {
+            public FixedUserContext(string userName)
+            {
+                UserName = userName;
+            }
+
+            public string UserName { get; }
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.cs
@@ -291,7 +291,14 @@ namespace LM.App.Wpf.ViewModels.Pdf
                 }
 
                 _precomputedHash = null;
-                DocumentSource = new Uri(absolutePath, UriKind.Absolute);
+
+                var absoluteUri = new Uri(absolutePath, UriKind.Absolute);
+                if (DocumentSource is { } existingSource && string.Equals(existingSource.AbsoluteUri, absoluteUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase))
+                {
+                    DocumentSource = null;
+                }
+
+                DocumentSource = absoluteUri;
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {


### PR DESCRIPTION
## Summary
- clear the PDF viewer DocumentSource before reassigning the same absolute URI so change notifications fire
- add a regression test ensuring the WebView bridge requests a document load when the same path is loaded twice

## Testing
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: NETSDK1045 current SDK 8.0.414 does not support net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dbde730794832ba497eb2d72c1feb4