### PR TITLE
Ensure PDF reload triggers after viewer readiness

### DIFF
--- a/src/LM.App.Wpf.Tests/Pdf/PdfViewerViewModelTests.cs
+++ b/src/LM.App.Wpf.Tests/Pdf/PdfViewerViewModelTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.App.Wpf.Common;
+using LM.App.Wpf.Services;
+using LM.App.Wpf.ViewModels.Pdf;
+using LM.Core.Abstractions;
+using LM.Infrastructure.Hooks;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.Pdf
+{
+    public sealed class PdfViewerViewModelTests
+    {
+        [Fact]
+        public void HandleViewerReady_ReloadsDocumentWhenViewerReinitializes()
+        {
+            using var workspace = new TestWorkspaceService();
+            var orchestrator = new HookOrchestrator(workspace);
+            var viewModel = new PdfViewerViewModel(
+                orchestrator,
+                new TestUserContext(),
+                new TestPreviewStorage(),
+                workspace,
+                new TestClipboardService());
+
+            var bridge = new StubWebViewBridge();
+            viewModel.WebViewBridge = bridge;
+
+            var documentSourceProperty = typeof(PdfViewerViewModel).GetProperty(
+                nameof(PdfViewerViewModel.DocumentSource),
+                BindingFlags.Instance | BindingFlags.Public);
+            var setter = documentSourceProperty?.GetSetMethod(nonPublic: true);
+            Assert.NotNull(setter);
+
+            setter!.Invoke(viewModel, new object?[] { new Uri("file:///tmp/sample.pdf", UriKind.Absolute) });
+            viewModel.UpdateVirtualDocumentSource(new Uri("https://viewer-documents.knowledgeworks/token/sample.pdf", UriKind.Absolute));
+
+            viewModel.HandleViewerReady();
+            viewModel.HandleViewerReady();
+
+            Assert.Equal(2, bridge.RequestDocumentLoadAsyncCount);
+        }
+
+        private sealed class StubWebViewBridge : IPdfWebViewBridge
+        {
+            public int RequestDocumentLoadAsyncCount { get; private set; }
+
+            public Task RequestDocumentLoadAsync(CancellationToken cancellationToken)
+            {
+                RequestDocumentLoadAsyncCount++;
+                return Task.CompletedTask;
+            }
+
+            public Task ScrollToAnnotationAsync(string annotationId, CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class TestUserContext : IUserContext
+        {
+            public string UserName => "TestUser";
+        }
+
+        private sealed class TestPreviewStorage : IPdfAnnotationPreviewStorage
+        {
+            public Task<string> SaveAsync(string pdfHash, string annotationId, byte[] pngBytes, CancellationToken cancellationToken)
+            {
+                return Task.FromResult("preview.png");
+            }
+        }
+
+        private sealed class TestClipboardService : IClipboardService
+        {
+            public void SetText(string text)
+            {
+            }
+        }
+
+        private sealed class TestWorkspaceService : IWorkSpaceService, IDisposable
+        {
+            private readonly string _root;
+
+            public TestWorkspaceService()
+            {
+                _root = Path.Combine(Path.GetTempPath(), "kw-pdf-vm-tests", Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(_root);
+            }
+
+            public string? WorkspacePath => _root;
+
+            public void Dispose()
+            {
+                try
+                {
+                    if (Directory.Exists(_root))
+                    {
+                        Directory.Delete(_root, recursive: true);
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            public Task EnsureWorkspaceAsync(string absoluteWorkspacePath, CancellationToken ct = default)
+            {
+                Directory.CreateDirectory(absoluteWorkspacePath);
+                return Task.CompletedTask;
+            }
+
+            public string GetAbsolutePath(string relativePath)
+            {
+                return Path.Combine(_root, relativePath);
+            }
+
+            public string GetLocalDbPath()
+            {
+                return Path.Combine(_root, "local.db");
+            }
+
+            public string GetWorkspaceRoot()
+            {
+                return _root;
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.Bridge.cs
+++ b/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.Bridge.cs
@@ -142,6 +142,12 @@ namespace LM.App.Wpf.ViewModels.Pdf
         internal void HandleViewerReady()
         {
             IsViewerReady = true;
+
+            if (!_pendingDocumentLoadRequest && (DocumentSource is not null || _virtualDocumentSource is not null))
+            {
+                _pendingDocumentLoadRequest = true;
+            }
+
             TryRequestDocumentLoad();
         }
 


### PR DESCRIPTION
## Summary
- ensure the PDF viewer schedules a document load whenever readiness is signaled and a source is available
- add unit coverage that exercises repeated readiness notifications and verifies the bridge re-requests the document

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: missing Microsoft.WindowsDesktop.App runtime on linux)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdef21824832ba446da3835bba901