### PR TITLE
Serve PDF.js modules with correct MIME type

### DIFF
--- a/src/LM.App.Wpf/wwwroot/pdfjs/web/viewer.html
+++ b/src/LM.App.Wpf/wwwroot/pdfjs/web/viewer.html
@@ -49,52 +49,6 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--<script src="resource://pdf.js/web/viewer.mjs" type="module"></script>-->
 <!--#elif !MOZCENTRAL-->
 <!--<script src="viewer.mjs" type="module"></script>-->
-<!--#elif /* Development mode. */-->
-    <link rel="resource" type="application/l10n" href="locale/locale.json">
-
-    <script type="importmap">
-      {
-        "imports": {
-          "pdfjs/": "../src/",
-          "pdfjs-lib": "../src/pdf.js",
-          "pdfjs-web/": "./",
-
-          "fluent-bundle": "../node_modules/@fluent/bundle/esm/index.js",
-          "fluent-dom": "../node_modules/@fluent/dom/esm/index.js",
-          "cached-iterable": "../node_modules/cached-iterable/src/index.mjs",
-
-          "display-cmap_reader_factory": "../src/display/cmap_reader_factory.js",
-          "display-standard_fontdata_factory": "../src/display/standard_fontdata_factory.js",
-          "display-wasm_factory": "../src/display/wasm_factory.js",
-          "display-fetch_stream": "../src/display/fetch_stream.js",
-          "display-network": "../src/display/network.js",
-          "display-node_stream": "../src/display/stubs.js",
-          "display-node_utils": "../src/display/stubs.js",
-
-          "web-alt_text_manager": "./alt_text_manager.js",
-          "web-annotation_editor_params": "./annotation_editor_params.js",
-          "web-download_manager": "./download_manager.js",
-          "web-external_services": "./genericcom.js",
-          "web-new_alt_text_manager": "./new_alt_text_manager.js",
-          "web-null_l10n": "./genericl10n.js",
-          "web-pdf_attachment_viewer": "./pdf_attachment_viewer.js",
-          "web-pdf_cursor_tools": "./pdf_cursor_tools.js",
-          "web-pdf_document_properties": "./pdf_document_properties.js",
-          "web-pdf_find_bar": "./pdf_find_bar.js",
-          "web-pdf_layer_viewer": "./pdf_layer_viewer.js",
-          "web-pdf_outline_viewer": "./pdf_outline_viewer.js",
-          "web-pdf_presentation_mode": "./pdf_presentation_mode.js",
-          "web-pdf_sidebar": "./pdf_sidebar.js",
-          "web-pdf_thumbnail_viewer": "./pdf_thumbnail_viewer.js",
-          "web-preferences": "./genericcom.js",
-          "web-print_service": "./pdf_print_service.js",
-          "web-secondary_toolbar": "./secondary_toolbar.js",
-          "web-signature_manager": "./signature_manager.js",
-          "web-toolbar": "./toolbar.js"
-        }
-      }
-    </script>
-    <script type="module" src="viewer.js"></script>
 <!--#endif-->
   </head>
 


### PR DESCRIPTION
## Summary
- intercept viewer asset requests inside the WebView host so `.mjs` modules are served with a script content type
- detach the module request handler when the viewer unloads to avoid duplicate filters

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: NETSDK1045 – container SDK does not support net9.0 projects)*

------
https://chatgpt.com/codex/tasks/task_e_68dc25fd28c0832b91cf718e576c035c