### PR TITLE
Restore pdf.js viewer bootstrap script

### DIFF
--- a/src/LM.App.Wpf/wwwroot/pdfjs/web/viewer.html
+++ b/src/LM.App.Wpf/wwwroot/pdfjs/web/viewer.html
@@ -813,6 +813,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 
     </div> <!-- outerContainer -->
     <div id="printContainer"></div>
+    <script type="module" src="viewer.mjs"></script>
     <script type="module" src="knowledgeworks/highlight-previews.js"></script>
     <script type="module" src="knowledgeworks/annotation-bridge.js"></script>
     <script type="module" src="../knowledgeworks-bridge.js"></script>


### PR DESCRIPTION
## Summary
- restore the pdf.js viewer bootstrap module reference so the viewer initializes before the KnowledgeWorks bridges load

## Testing
- not run (platform limitation)

------
https://chatgpt.com/codex/tasks/task_e_68dc3b36c690832ba3c03c9a6619a772