### PR TITLE
Fix pdf.js viewer bootstrap script reference

### DIFF
--- a/entries/pdf-viewer/hooks/changelog.json
+++ b/entries/pdf-viewer/hooks/changelog.json
@@ -12,6 +12,12 @@
       "timestampUtc": "2025-09-30T19:43:01Z",
       "performedBy": "KnowledgeWorks\\root",
       "action": "pdf-viewer-html-updated"
+    },
+    {
+      "eventId": "b06342f74bca4997956883c2a2cdfed2",
+      "timestampUtc": "2025-09-30T20:28:28Z",
+      "performedBy": "KnowledgeWorks\\root",
+      "action": "pdf-viewer-html-updated"
     }
   ]
 }

--- a/src/LM.App.Wpf/wwwroot/pdfjs/web/viewer.html
+++ b/src/LM.App.Wpf/wwwroot/pdfjs/web/viewer.html
@@ -813,6 +813,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 
     </div> <!-- outerContainer -->
     <div id="printContainer"></div>
+    <script src="viewer.js"></script>
     <script type="module" src="knowledgeworks/highlight-previews.js"></script>
     <script type="module" src="knowledgeworks/annotation-bridge.js"></script>
     <script type="module" src="../knowledgeworks-bridge.js"></script>


### PR DESCRIPTION
## Summary
- point the pdf.js viewer HTML to the shipped `viewer.js` bundle so the viewer initializes correctly before the KnowledgeWorks bridge loads
- log the pdf viewer HTML change in the changelog hook for traceability

## Testing
- not run (WPF project requires Windows tooling unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc3b36c690832ba3c03c9a6619a772