### PR TITLE
Create lightweight PDF.js viewer for bridge integration

### DIFF
--- a/src/LM.App.Wpf/wwwroot/pdfjs/viewer.html
+++ b/src/LM.App.Wpf/wwwroot/pdfjs/viewer.html
@@ -3,11 +3,20 @@
   <head>
     <meta charset="utf-8" />
     <title>KnowledgeWorks PDF Viewer</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf_viewer.min.css"
+      referrerpolicy="no-referrer"
+    />
     <style>
       :root {
         color-scheme: light dark;
+      }
+
+      html,
+      body {
+        height: 100%;
       }
 
       body {
@@ -15,15 +24,24 @@
         font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
         background-color: #1e1e1e;
         color: #f5f5f5;
+        display: flex;
+      }
+
+      #app {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-height: 0;
       }
 
       header {
-        padding: 12px 16px;
+        padding: 10px 16px;
         display: flex;
+        justify-content: space-between;
         align-items: center;
         gap: 12px;
         background-color: #2d2d2d;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
       }
 
       header h1 {
@@ -32,93 +50,206 @@
         font-weight: 600;
       }
 
-      main {
-        height: calc(100vh - 58px);
+      #status {
+        font-size: 14px;
+        opacity: 0.85;
+      }
+
+      #viewerContainer {
+        flex: 1;
+        position: relative;
         overflow: auto;
-        padding: 16px;
-        box-sizing: border-box;
-        display: flex;
-        justify-content: center;
         background-color: #1e1e1e;
       }
 
       #viewer {
-        display: flex;
-        flex-direction: column;
-        gap: 24px;
-        align-items: center;
-        width: min(100%, 900px);
+        padding: 16px 0;
       }
 
-      canvas {
-        width: 100%;
-        height: auto;
-        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
-        background-color: #fff;
+      .pdfViewer .page {
+        margin: 0 auto 12px auto;
+        box-shadow: 0 4px 18px rgba(0, 0, 0, 0.45);
+        border-radius: 4px;
+        overflow: hidden;
       }
 
-      .message {
-        margin: auto;
-        font-size: 14px;
-        opacity: 0.8;
-        text-align: center;
+      .error {
+        color: #ff7777;
       }
     </style>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.min.js" integrity="sha512-0ypnUfzk0CqJPZEo3pzKJfStyid7mlYBfVZ3VAb9YSEuxsJJcwWabgZiE4OMlZP6eiC04nt8dYrCf6bMnOK0Pg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.min.js"
+      referrerpolicy="no-referrer"
+    ></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf_viewer.min.js"
+      referrerpolicy="no-referrer"
+    ></script>
   </head>
-  <body>
-    <header>
-      <h1>KnowledgeWorks PDF Viewer</h1>
-      <span id="status" class="message">Waiting for document&hellip;</span>
-    </header>
-    <main>
-      <div id="viewer"></div>
-    </main>
+  <body tabindex="1">
+    <div id="app">
+      <header>
+        <h1>KnowledgeWorks PDF Viewer</h1>
+        <span id="status">Waiting for document…</span>
+      </header>
+      <div id="viewerContainer" class="viewerContainer">
+        <div id="viewer" class="pdfViewer"></div>
+      </div>
+    </div>
     <script>
       (function () {
-        const status = document.getElementById("status");
-        const viewer = document.getElementById("viewer");
+        const statusEl = document.getElementById("status");
+        const viewerContainer = document.getElementById("viewerContainer");
         const params = new URLSearchParams(window.location.search);
-        const fileUrl = params.get("file");
+        const initialUrl = params.get("file");
 
-        if (!fileUrl) {
-          status.textContent = "No document provided.";
+        if (!window.pdfjsLib || !window.pdfjsViewer) {
+          statusEl.textContent = "PDF.js is unavailable.";
+          statusEl.classList.add("error");
           return;
         }
 
-        status.textContent = "Loading document&hellip;";
-        pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.worker.min.js";
+        const { AnnotationEditorType, AnnotationMode, TextLayerMode } =
+          window.pdfjsLib;
+        const { EventBus, PDFLinkService, PDFFindController, PDFViewer } =
+          window.pdfjsViewer;
 
-        function renderPage(page) {
-          return page.getViewport({ scale: 1.35 });
-        }
+        pdfjsLib.GlobalWorkerOptions.workerSrc =
+          "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.worker.min.js";
 
-        function drawPage(page) {
-          const viewport = renderPage(page);
-          const canvas = document.createElement("canvas");
-          const context = canvas.getContext("2d", { alpha: false });
-          canvas.width = viewport.width;
-          canvas.height = viewport.height;
-          viewer.appendChild(canvas);
+        const eventBus = new EventBus();
+        const linkService = new PDFLinkService({ eventBus });
+        const findController = new PDFFindController({
+          eventBus,
+          linkService,
+        });
 
-          return page.render({ canvasContext: context, viewport }).promise;
-        }
+        const pdfViewer = new PDFViewer({
+          container: viewerContainer,
+          eventBus,
+          linkService,
+          findController,
+          textLayerMode: TextLayerMode?.ENABLE ?? 1,
+          annotationMode: AnnotationMode?.ENABLE ?? 3,
+          annotationEditorMode: AnnotationEditorType?.HIGHLIGHT ?? 3,
+          enableHighlightFloatingButton: true,
+        });
 
-        pdfjsLib
-          .getDocument({ url: fileUrl, withCredentials: false })
-          .promise.then(async (doc) => {
-            status.textContent = `Rendering ${doc.numPages} page${doc.numPages > 1 ? "s" : ""}…`;
-            for (let pageNumber = 1; pageNumber <= doc.numPages; pageNumber += 1) {
-              const page = await doc.getPage(pageNumber);
-              await drawPage(page);
+        linkService.setViewer(pdfViewer);
+
+        const initializedPromise = Promise.resolve();
+
+        const app = {
+          eventBus,
+          pdfViewer,
+          linkService,
+          findController,
+          initializedPromise,
+          pdfDocument: null,
+          url: null,
+          appConfig: {
+            mainContainer: viewerContainer,
+            viewerContainer,
+          },
+          async open(options) {
+            const target = typeof options === "string" ? options : options?.url;
+            if (!target) {
+              return null;
             }
-            status.textContent = `Loaded ${doc.numPages} page${doc.numPages > 1 ? "s" : ""}.`;
-          })
-          .catch((error) => {
-            console.error("Failed to render PDF", error);
-            status.textContent = "Unable to display the PDF document.";
-          });
+
+            await this.close();
+            statusEl.classList.remove("error");
+            statusEl.textContent = "Loading document…";
+
+            try {
+              const loadingTask = pdfjsLib.getDocument({
+                url: target,
+                withCredentials: false,
+              });
+
+              const pdfDocument = await loadingTask.promise;
+              this.pdfDocument = pdfDocument;
+              this.url = target;
+
+              pdfViewer.setDocument(pdfDocument);
+              linkService.setDocument(pdfDocument, null);
+
+              eventBus.dispatch("documentloaded", { source: this });
+
+              if (
+                AnnotationEditorType &&
+                pdfViewer.annotationEditorMode !== AnnotationEditorType.DISABLE
+              ) {
+                try {
+                  pdfViewer.annotationEditorMode = {
+                    mode: AnnotationEditorType.HIGHLIGHT,
+                    mustEnterInEditMode: false,
+                  };
+                } catch (error) {
+                  console.warn("Unable to enable highlight editor", error);
+                }
+              }
+
+              statusEl.classList.remove("error");
+              statusEl.textContent = `Page 1 of ${pdfDocument.numPages}`;
+              return pdfDocument;
+            } catch (error) {
+              console.error("Failed to open PDF", error);
+              statusEl.textContent = "Unable to load document.";
+              statusEl.classList.add("error");
+              throw error;
+            }
+          },
+          async close() {
+            if (!this.pdfDocument) {
+              return;
+            }
+
+            const previous = this.pdfDocument;
+            try {
+              pdfViewer.setDocument(null);
+              linkService.setDocument(null, null);
+              findController.setDocument(null);
+              await previous.destroy();
+            } catch (error) {
+              console.warn("Failed to destroy previous document", error);
+            }
+
+            this.pdfDocument = null;
+            this.url = null;
+            pdfViewer.cleanup();
+          },
+        };
+
+        window.PDFViewerApplication = app;
+
+        eventBus.on("pagesinit", () => {
+          pdfViewer.currentScaleValue = "page-width";
+        });
+
+        eventBus.on("pagechanging", evt => {
+          if (app.pdfDocument) {
+            statusEl.textContent = `Page ${evt?.pageNumber ?? 1} of ${app.pdfDocument.numPages}`;
+          }
+        });
+
+        eventBus.on("documentloaded", () => {
+          if (app.pdfDocument) {
+            statusEl.textContent = `Page 1 of ${app.pdfDocument.numPages}`;
+          }
+        });
+
+        if (initialUrl) {
+          initializedPromise
+            .then(() => app.open({ url: initialUrl, originalUrl: initialUrl }))
+            .catch(error => {
+              console.error("Failed to load initial PDF", error);
+              statusEl.textContent = "Unable to load document.";
+              statusEl.classList.add("error");
+            });
+        }
       })();
     </script>
+    <script src="./knowledgeworks-bridge.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the existing PDF viewer page with a lightweight PDF.js setup that exposes `PDFViewerApplication`
- wire up PDF.js services (event bus, link service, annotation editor) so knowledgeworks-bridge.js can interact with the viewer
- improve status messaging and error handling while keeping the layout minimal

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc3dad12b0832bb2a7857681ab29b5