### PR TITLE
Fix PDF viewer origin validation for virtual document host

### DIFF
--- a/entries/pdf-viewer/hooks/changelog.json
+++ b/entries/pdf-viewer/hooks/changelog.json
@@ -30,7 +30,12 @@
       "timestampUtc": "2025-10-01T06:16:29Z",
       "performedBy": "KnowledgeWorks\\root",
       "action": "pdf-viewer-environment-shim-added"
-
+    },
+    {
+      "eventId": "0a3f2148f2d847469c62e4c3e85743ac",
+      "timestampUtc": "2025-10-01T07:45:00Z",
+      "performedBy": "KnowledgeWorks\\root",
+      "action": "pdf-viewer-origin-policy-updated"
     }
   ]
 }

--- a/src/LM.App.Wpf/wwwroot/pdfjs/knowledgeworks-bridge.js
+++ b/src/LM.App.Wpf/wwwroot/pdfjs/knowledgeworks-bridge.js
@@ -9,6 +9,24 @@ var lastOverlayHash = null;
 var readyPosted = false;
 var knownAnnotationIds = new Set();
 
+function registerAllowedDocumentOrigins() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  var allowed = window.KnowledgeWorksAllowedDocumentOrigins;
+  var origins = Array.isArray(allowed) ? allowed.slice() : [];
+  var documentOrigin = "https://viewer-documents.knowledgeworks";
+
+  if (!origins.includes(documentOrigin)) {
+    origins.push(documentOrigin);
+  }
+
+  window.KnowledgeWorksAllowedDocumentOrigins = origins;
+}
+
+registerAllowedDocumentOrigins();
+
 function getChromeWebView() {
   if (typeof window === "undefined") {
     return null;

--- a/src/LM.App.Wpf/wwwroot/pdfjs/web/viewer.mjs
+++ b/src/LM.App.Wpf/wwwroot/pdfjs/web/viewer.mjs
@@ -21957,6 +21957,28 @@ initCom(PDFViewerApplication);
 }
 {
   const HOSTED_VIEWER_ORIGINS = new Set(["null", "http://mozilla.github.io", "https://mozilla.github.io"]);
+  let knowledgeWorksAllowedOrigins;
+  function getKnowledgeWorksAllowedOrigins() {
+    if (knowledgeWorksAllowedOrigins) {
+      return knowledgeWorksAllowedOrigins;
+    }
+    knowledgeWorksAllowedOrigins = new Set(["https://viewer-documents.knowledgeworks"]);
+    const globalScope = typeof globalThis !== "undefined" ? globalThis : typeof window !== "undefined" ? window : undefined;
+    const allowed = globalScope?.KnowledgeWorksAllowedDocumentOrigins;
+    if (Array.isArray(allowed)) {
+      for (const entry of allowed) {
+        if (typeof entry !== "string" || entry.trim() === "") {
+          continue;
+        }
+        const parsed = URL.parse(entry, window.location);
+        const origin = parsed?.origin;
+        if (origin) {
+          knowledgeWorksAllowedOrigins.add(origin);
+        }
+      }
+    }
+    return knowledgeWorksAllowedOrigins;
+  }
   var validateFileURL = function (file) {
     if (!file) {
       return;
@@ -21967,6 +21989,9 @@ initCom(PDFViewerApplication);
     }
     const fileOrigin = URL.parse(file, window.location)?.origin;
     if (fileOrigin === viewerOrigin) {
+      return;
+    }
+    if (getKnowledgeWorksAllowedOrigins().has(fileOrigin)) {
       return;
     }
     const ex = new Error("file origin does not match viewer's");


### PR DESCRIPTION
## Summary
- register the KnowledgeWorks virtual document origin before the WebView bridge loads PDFs
- allow pdf.js to treat the virtual document host as a trusted origin when validating file URLs
- record the update in the PDF viewer changelog hook

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: installed SDK 8.0.414 cannot target net9.0)*
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: installed SDK 8.0.414 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd9da305c832bb213954babb95647