### PR TITLE
Fix pdf.js bridge to use the options overload

### DIFF
--- a/src/LM.App.Wpf.Tests/Services/Pdf/KnowledgeworksBridgeTests.cs
+++ b/src/LM.App.Wpf.Tests/Services/Pdf/KnowledgeworksBridgeTests.cs
@@ -206,12 +206,15 @@ namespace LM.App.Wpf.Tests.Services.Pdf
                         eventBus: { on: function() {} },
                         pdfViewer: {},
                         open: function(args) {
+                            if (typeof args === 'string') {
+                                throw new Error('string overload not supported');
+                            }
+
                             var next = '';
                             if (args && typeof args.url === 'string') {
                                 next = args.url;
-                            } else if (typeof args === 'string') {
-                                next = args;
                             }
+
                             this.url = next;
                             __kwRecordOpen(next);
                         }

--- a/src/LM.App.Wpf/wwwroot/pdfjs/knowledgeworks-bridge.js
+++ b/src/LM.App.Wpf/wwwroot/pdfjs/knowledgeworks-bridge.js
@@ -135,11 +135,10 @@ async function loadPdfInternal(targetUrl) {
       return;
     }
 
-    try {
-      await app.open({ url: url });
-    } catch (error) {
-      await app.open(url);
-    }
+    await app.open({
+      url: url,
+      originalUrl: url,
+    });
   } catch (error) {
     console.error("knowledgeworks-bridge: failed to load PDF", error);
   }


### PR DESCRIPTION
## Summary
- stop the pdf viewer bridge from retrying `PDFViewerApplication.open` with the deprecated string overload
- include the resolved URI as both `url` and `originalUrl` when opening the document
- update the pdf bridge tests so the mocked viewer throws when the string overload is used

## Testing
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: requires Microsoft.WindowsDesktop.App 9.0.0 on linux)*

------
https://chatgpt.com/codex/tasks/task_e_68dce62dae30832b977c61f3ad523418