### PR TITLE
Fix PDF viewer local load flow

### DIFF
--- a/entries/pdf-viewer/hooks/changelog.json
+++ b/entries/pdf-viewer/hooks/changelog.json
@@ -42,6 +42,12 @@
       "timestampUtc": "2025-10-01T08:21:18Z",
       "performedBy": "KnowledgeWorks\\root",
       "action": "pdf-viewer-document-resolution-updated"
+    },
+    {
+      "eventId": "101008592e55437ebc3070693af66fff",
+      "timestampUtc": "2025-10-01T09:03:07Z",
+      "performedBy": "KnowledgeWorks\\root",
+      "action": "pdf-viewer-local-file-loading-updated"
     }
   ]
 }

--- a/src/LM.App.Wpf.Tests/Services/Pdf/KnowledgeworksBridgeTests.cs
+++ b/src/LM.App.Wpf.Tests/Services/Pdf/KnowledgeworksBridgeTests.cs
@@ -77,6 +77,21 @@ namespace LM.App.Wpf.Tests.Services.Pdf
             Assert.Equal("app://shared.pdf", harness.OpenedUrl);
         }
 
+        [Fact]
+        public void LoadPdfFromHostWhenTargetUrlMissing()
+        {
+            using var harness = KnowledgeworksBridgeHarness.Create();
+
+            harness.SetPdfViewerApplication();
+            harness.SetHostObject("app://virtual.pdf");
+
+            harness.InvokePdfBridgeLoad(string.Empty);
+            harness.DrainTimers();
+
+            Assert.Equal(1, harness.LoadPdfInvocationCount);
+            Assert.Equal("app://virtual.pdf", harness.OpenedUrl);
+        }
+
         private sealed class KnowledgeworksBridgeHarness : IDisposable
         {
             private readonly Engine _engine;

--- a/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
+++ b/src/LM.App.Wpf/Views/PdfViewer.xaml.cs
@@ -228,9 +228,9 @@ namespace LM.App.Wpf.Views
 
             _viewModel?.UpdateVirtualDocumentSource(virtualDocumentSource);
 
-            if (virtualDocumentSource is not null)
+            if (ShouldAppendDocumentQuery(documentSource, virtualDocumentSource))
             {
-                var safeAbsolute = virtualDocumentSource.GetComponents(UriComponents.AbsoluteUri, UriFormat.SafeUnescaped);
+                var safeAbsolute = virtualDocumentSource!.GetComponents(UriComponents.AbsoluteUri, UriFormat.SafeUnescaped);
                 var encodedPdf = Uri.EscapeDataString(safeAbsolute);
                 target = string.Concat(target, "?file=", encodedPdf);
             }
@@ -238,6 +238,26 @@ namespace LM.App.Wpf.Views
             InitializeBridge(coreWebView);
 
             coreWebView.Navigate(target);
+        }
+
+        private static bool ShouldAppendDocumentQuery(System.Uri? documentSource, System.Uri? virtualDocumentSource)
+        {
+            if (virtualDocumentSource is null)
+            {
+                return false;
+            }
+
+            if (documentSource is null)
+            {
+                return false;
+            }
+
+            if (!documentSource.IsAbsoluteUri)
+            {
+                return false;
+            }
+
+            return !string.Equals(documentSource.Scheme, System.Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase);
         }
 
         private void InitializeBridge(CoreWebView2 coreWebView)

--- a/src/LM.App.Wpf/wwwroot/pdfjs/knowledgeworks-bridge.js
+++ b/src/LM.App.Wpf/wwwroot/pdfjs/knowledgeworks-bridge.js
@@ -112,27 +112,35 @@ async function loadPdfInternal(targetUrl) {
   try {
     var app = getViewerApplication();
     if (!app) {
+      console.warn("knowledgeworks-bridge: viewer application not available");
       return;
     }
 
     await app.initializedPromise;
 
     var url = typeof targetUrl === "string" ? targetUrl.trim() : "";
-    if (!url) {
+    if (url) {
+      console.log("knowledgeworks-bridge: loading PDF from provided URL");
+    } else {
       var host = getHostObject();
-      if (!host) {
+      if (!host || typeof host.LoadPdfAsync !== "function") {
+        console.warn("knowledgeworks-bridge: host not ready to supply PDF URL");
         return;
       }
 
+      console.log("knowledgeworks-bridge: requesting PDF URL from host");
       var result = host.LoadPdfAsync();
-      url = typeof result === "string" ? result : await Promise.resolve(result);
-      if (typeof url === "string") {
-        url = url.trim();
+      var resolved = typeof result === "string" ? result : await Promise.resolve(result);
+      if (typeof resolved === "string") {
+        url = resolved.trim();
       }
-    }
 
-    if (!url) {
-      return;
+      if (!url) {
+        console.warn("knowledgeworks-bridge: host returned an empty PDF URL");
+        return;
+      }
+
+      console.log("knowledgeworks-bridge: opening host-provided PDF URL");
     }
 
     await app.open({


### PR DESCRIPTION
## Summary
- avoid adding the synthetic ?file query when navigating to local file-backed documents and rely on the bridge to hydrate the viewer
- update the knowledgeworks bridge to log host lookups and always request the document URL when no explicit target is provided
- cover the no-query scenario with a bridge unit test and log the change in the PDF viewer changelog

## Testing
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: SDK 8.0.414 cannot target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dced5ef2a8832bba86dab904eca858