### PR TITLE
Fix PDF annotation storage to reuse entry directories

### DIFF
--- a/src/LM.Infrastructure.Tests/HookWriterTests.cs
+++ b/src/LM.Infrastructure.Tests/HookWriterTests.cs
@@ -89,7 +89,7 @@ namespace LM.Infrastructure.Tests.Hooks
 
             await writer.SavePdfAnnotationsAsync(entryId, pdfHash, hook, CancellationToken.None);
 
-            var hookPath = Path.Combine(temp.Path, "entries", pdfHash, "hooks", "pdf_annotations.json");
+            var hookPath = Path.Combine(temp.Path, "entries", entryId, "hooks", "pdf_annotations.json");
             Assert.True(File.Exists(hookPath), $"Expected pdf annotations hook at: {hookPath}");
 
             var hookJson = await File.ReadAllTextAsync(hookPath);
@@ -108,15 +108,8 @@ namespace LM.Infrastructure.Tests.Hooks
             Assert.Equal("pdf-annotations-updated", evt.Action);
             Assert.Equal(Environment.UserName, evt.PerformedBy);
 
-            var hashChangeLogPath = Path.Combine(temp.Path, "entries", pdfHash, "hooks", "changelog.json");
-            Assert.True(File.Exists(hashChangeLogPath), $"Expected hash changelog at: {hashChangeLogPath}");
-
-            var hashChangeLogJson = await File.ReadAllTextAsync(hashChangeLogPath);
-            var hashChangeLog = JsonSerializer.Deserialize<HookM.EntryChangeLogHook>(hashChangeLogJson);
-            Assert.NotNull(hashChangeLog);
-            Assert.NotNull(hashChangeLog!.Events);
-            var hashEvent = Assert.Single(hashChangeLog.Events!);
-            Assert.Equal("pdf-annotations-updated", hashEvent.Action);
+            var hashDir = Path.Combine(temp.Path, "entries", pdfHash);
+            Assert.False(Directory.Exists(hashDir), "No per-hash entry directory should be created");
         }
 
         [Fact]

--- a/src/LM.Infrastructure.Tests/Pdf/PdfAnnotationOverlayReaderTests.cs
+++ b/src/LM.Infrastructure.Tests/Pdf/PdfAnnotationOverlayReaderTests.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using LM.Core.Abstractions;
+using LM.Core.Models;
+using LM.Core.Models.Filters;
 using LM.HubSpoke.Models;
 using LM.Infrastructure.FileSystem;
 using LM.Infrastructure.Pdf;
@@ -20,15 +25,23 @@ namespace LM.Infrastructure.Tests.Pdf
             var workspace = new WorkspaceService();
             await workspace.EnsureWorkspaceAsync(temp.Path);
 
-            var reader = new PdfAnnotationOverlayReader(workspace);
+            var entryStore = new FakeEntryStore();
+            const string entryId = "overlay-entry";
             const string hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+            entryStore.Add(new Entry
+            {
+                Id = entryId,
+                MainFileHashSha256 = hash
+            });
+
+            var reader = new PdfAnnotationOverlayReader(workspace, entryStore);
             var overlayRelative = $"library/{hash[..2]}/{hash}/{hash}.json";
             var overlayAbsolute = Path.Combine(temp.Path, overlayRelative.Replace('/', Path.DirectorySeparatorChar));
             Directory.CreateDirectory(Path.GetDirectoryName(overlayAbsolute)!);
             const string overlayPayload = "{\"foo\":\"bar\"}";
             await File.WriteAllTextAsync(overlayAbsolute, overlayPayload);
 
-            var hookDirectory = Path.Combine(temp.Path, "entries", hash, "hooks");
+            var hookDirectory = Path.Combine(temp.Path, "entries", entryId, "hooks");
             Directory.CreateDirectory(hookDirectory);
             var hook = new PdfAnnotationsHook
             {
@@ -50,12 +63,74 @@ namespace LM.Infrastructure.Tests.Pdf
             var workspace = new WorkspaceService();
             await workspace.EnsureWorkspaceAsync(temp.Path);
 
-            var reader = new PdfAnnotationOverlayReader(workspace);
+            var entryStore = new FakeEntryStore();
+            var reader = new PdfAnnotationOverlayReader(workspace, entryStore);
             const string hash = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
             var result = await reader.GetOverlayJsonAsync(hash, CancellationToken.None);
 
             Assert.Null(result);
+        }
+
+        private sealed class FakeEntryStore : IEntryStore
+        {
+            private readonly Dictionary<string, Entry> _entries = new(StringComparer.OrdinalIgnoreCase);
+            private readonly Dictionary<string, Entry> _byId = new(StringComparer.OrdinalIgnoreCase);
+
+            public void Add(Entry entry)
+            {
+                if (entry is null)
+                    throw new ArgumentNullException(nameof(entry));
+
+                if (string.IsNullOrWhiteSpace(entry.Id))
+                    throw new ArgumentException("Entry id must be provided", nameof(entry));
+                if (string.IsNullOrWhiteSpace(entry.MainFileHashSha256))
+                    throw new ArgumentException("Entry hash must be provided", nameof(entry));
+
+                _byId[entry.Id] = entry;
+                _entries[entry.MainFileHashSha256] = entry;
+            }
+
+            public Task InitializeAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+            public Task SaveAsync(Entry entry, CancellationToken ct = default)
+                => throw new NotSupportedException();
+
+            public Task<Entry?> GetByIdAsync(string id, CancellationToken ct = default)
+            {
+                _byId.TryGetValue(id, out var entry);
+                return Task.FromResult<Entry?>(entry);
+            }
+
+            public async IAsyncEnumerable<Entry> EnumerateAsync([EnumeratorCancellation] CancellationToken ct = default)
+            {
+                foreach (var entry in _byId.Values)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    yield return entry;
+                    await Task.Yield();
+                }
+            }
+
+            public Task<IReadOnlyList<Entry>> SearchAsync(EntryFilter filter, CancellationToken ct = default)
+                => throw new NotSupportedException();
+
+            public Task<Entry?> FindByHashAsync(string sha256, CancellationToken ct = default)
+            {
+                if (sha256 is null)
+                {
+                    return Task.FromResult<Entry?>(null);
+                }
+
+                _entries.TryGetValue(sha256, out var entry);
+                return Task.FromResult<Entry?>(entry);
+            }
+
+            public Task<IReadOnlyList<Entry>> FindSimilarByNameYearAsync(string title, int? year, CancellationToken ct = default)
+                => throw new NotSupportedException();
+
+            public Task<Entry?> FindByIdsAsync(string? doi, string? pmid, CancellationToken ct = default)
+                => throw new NotSupportedException();
         }
 
         private sealed class TempDir : IDisposable

--- a/src/LM.Infrastructure.Tests/Pdf/PdfAnnotationPersistenceServiceTests.cs
+++ b/src/LM.Infrastructure.Tests/Pdf/PdfAnnotationPersistenceServiceTests.cs
@@ -47,7 +47,7 @@ namespace LM.Infrastructure.Tests.Pdf
                 Assert.Equal(previews[previewId], await File.ReadAllBytesAsync(previewPath));
             }
 
-            var hookPath = Path.Combine(temp.Path, "entries", normalized, "hooks", "pdf_annotations.json");
+            var hookPath = Path.Combine(temp.Path, "entries", entryId, "hooks", "pdf_annotations.json");
             Assert.True(File.Exists(hookPath));
 
             var hook = JsonSerializer.Deserialize<PdfAnnotationsHook>(await File.ReadAllTextAsync(hookPath));
@@ -64,10 +64,10 @@ namespace LM.Infrastructure.Tests.Pdf
             Assert.Equal("pdf-annotations-updated", changeEvent.Action);
             Assert.Equal(Environment.UserName, changeEvent.PerformedBy);
 
-            var hashChangeLogPath = Path.Combine(temp.Path, "entries", normalized, "hooks", "changelog.json");
-            Assert.True(File.Exists(hashChangeLogPath));
+            var hashDir = Path.Combine(temp.Path, "entries", normalized);
+            Assert.False(Directory.Exists(hashDir));
 
-            var debugOverlayPath = Path.Combine(temp.Path, "entries", normalized, "hooks", "pdf_annotations.overlay.json");
+            var debugOverlayPath = Path.Combine(temp.Path, "entries", entryId, "hooks", "pdf_annotations.overlay.json");
             Assert.True(File.Exists(debugOverlayPath));
             Assert.Equal(overlayJson, await File.ReadAllTextAsync(debugOverlayPath));
         }
@@ -93,12 +93,12 @@ namespace LM.Infrastructure.Tests.Pdf
             var overlayPath = Path.Combine(temp.Path, sidecar);
             Assert.True(File.Exists(overlayPath));
 
-            var hookPath = Path.Combine(temp.Path, "entries", normalized, "hooks", "pdf_annotations.json");
+            var hookPath = Path.Combine(temp.Path, "entries", entryId, "hooks", "pdf_annotations.json");
             var hook = JsonSerializer.Deserialize<PdfAnnotationsHook>(await File.ReadAllTextAsync(hookPath));
             Assert.NotNull(hook);
             Assert.Equal(sidecar.Replace("\\", "/"), hook!.OverlayPath);
 
-            var debugOverlayPath = Path.Combine(temp.Path, "entries", normalized, "hooks", "pdf_annotations.overlay.json");
+            var debugOverlayPath = Path.Combine(temp.Path, "entries", entryId, "hooks", "pdf_annotations.overlay.json");
             Assert.True(File.Exists(debugOverlayPath));
             Assert.Equal(overlayJson, await File.ReadAllTextAsync(debugOverlayPath));
         }
@@ -136,7 +136,7 @@ namespace LM.Infrastructure.Tests.Pdf
                 null,
                 CancellationToken.None);
 
-            var hookPath = Path.Combine(temp.Path, "entries", normalized, "hooks", "pdf_annotations.json");
+            var hookPath = Path.Combine(temp.Path, "entries", entryId, "hooks", "pdf_annotations.json");
             var hook = JsonSerializer.Deserialize<PdfAnnotationsHook>(await File.ReadAllTextAsync(hookPath));
             Assert.NotNull(hook);
             var preview = Assert.Single(hook!.Previews);

--- a/src/LM.Infrastructure/Hooks/HookWriter.cs
+++ b/src/LM.Infrastructure/Hooks/HookWriter.cs
@@ -76,9 +76,11 @@ namespace LM.Infrastructure.Hooks
             if (hook is null)
                 throw new ArgumentNullException(nameof(hook));
 
-            var normalizedHash = pdfHash.Trim().ToLowerInvariant();
+            var normalizedEntryId = entryId.Trim();
+            if (normalizedEntryId.Length == 0)
+                throw new ArgumentException("Entry id must be non-empty.", nameof(entryId));
 
-            var relDir = Path.Combine("entries", normalizedHash, "hooks");
+            var relDir = Path.Combine("entries", normalizedEntryId, "hooks");
             var absDir = _workspace.GetAbsolutePath(relDir);
             Directory.CreateDirectory(absDir);
 
@@ -98,8 +100,7 @@ namespace LM.Infrastructure.Hooks
                 Events = new List<HookM.EntryChangeLogEvent> { changeEvent }
             };
 
-            await AppendChangeLogAsync(entryId, changeLog, ct).ConfigureAwait(false);
-            await AppendChangeLogAsync(normalizedHash, changeLog, ct).ConfigureAwait(false);
+            await AppendChangeLogAsync(normalizedEntryId, changeLog, ct).ConfigureAwait(false);
         }
 
         public async Task AppendChangeLogAsync(string entryId, HookM.EntryChangeLogHook hook, CancellationToken ct)

--- a/src/LM.Infrastructure/PublicAPI.Unshipped.txt
+++ b/src/LM.Infrastructure/PublicAPI.Unshipped.txt
@@ -72,7 +72,7 @@ LM.Infrastructure.Pdf.PdfAnnotationPreviewStorage
 LM.Infrastructure.Pdf.PdfAnnotationPreviewStorage.PdfAnnotationPreviewStorage(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
 LM.Infrastructure.Pdf.PdfAnnotationPreviewStorage.SaveAsync(string! pdfHash, string! annotationId, byte[]! pngBytes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
 LM.Infrastructure.Pdf.PdfAnnotationOverlayReader
-LM.Infrastructure.Pdf.PdfAnnotationOverlayReader.PdfAnnotationOverlayReader(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.Infrastructure.Pdf.PdfAnnotationOverlayReader.PdfAnnotationOverlayReader(LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IEntryStore! entryStore) -> void
 LM.Infrastructure.Pdf.PdfAnnotationOverlayReader.GetOverlayJsonAsync(string! pdfHash, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
 LM.Infrastructure.Search.PubMedSearchProvider
 LM.Infrastructure.Search.PubMedSearchProvider.PubMedSearchProvider() -> void


### PR DESCRIPTION
## Summary
- store PDF annotation hooks under the owning entry instead of creating hash-based entry folders
- update the annotation persistence service and overlay reader to resolve existing entry metadata when saving or loading overlays
- adjust related tests and public API declarations to reflect the new entry-based storage locations

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: installed SDK only supports up to .NET 8)*
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: installed SDK only supports up to .NET 8)*

------
https://chatgpt.com/codex/tasks/task_e_68dd45a349b4832b97172ea340fc335b