### PR TITLE
Align PDF annotation overlays with library storage layout

### DIFF
--- a/docs/library-pdf-annotations.md
+++ b/docs/library-pdf-annotations.md
@@ -19,7 +19,7 @@ warning dialog and skips launch so testers can correct the workspace data.
 ## Storage layout
 
 * Annotations are persisted to `entries/<hash>/hooks/pdf_annotations.json`.
-* Overlay payloads continue to live under `library/<hash[0..1]>/<hash>/`.
+* Overlay payloads now live alongside the PDF under `library/<first two characters>/<next two characters>/`.
 * Both the entry (`entries/<entryId>/hooks/changelog.json`) and PDF hash
   (`entries/<hash>/hooks/changelog.json`) changelog hooks receive events tagged
   with the current Windows username whenever annotations are saved.

--- a/src/LM.Infrastructure.Tests/Pdf/PdfAnnotationOverlayReaderTests.cs
+++ b/src/LM.Infrastructure.Tests/Pdf/PdfAnnotationOverlayReaderTests.cs
@@ -35,7 +35,7 @@ namespace LM.Infrastructure.Tests.Pdf
             });
 
             var reader = new PdfAnnotationOverlayReader(workspace, entryStore);
-            var overlayRelative = $"library/{hash[..2]}/{hash}/{hash}.json";
+            var overlayRelative = $"library/{hash[..2]}/{hash[2..4]}/{hash}.json";
             var overlayAbsolute = Path.Combine(temp.Path, overlayRelative.Replace('/', Path.DirectorySeparatorChar));
             Directory.CreateDirectory(Path.GetDirectoryName(overlayAbsolute)!);
             const string overlayPayload = "{\"foo\":\"bar\"}";

--- a/src/LM.Infrastructure.Tests/Pdf/PdfAnnotationPersistenceServiceTests.cs
+++ b/src/LM.Infrastructure.Tests/Pdf/PdfAnnotationPersistenceServiceTests.cs
@@ -36,7 +36,7 @@ namespace LM.Infrastructure.Tests.Pdf
 
             await service.PersistAsync(entryId, hash, overlayJson, previews, null, CancellationToken.None);
 
-            var overlayPath = Path.Combine(temp.Path, "library", normalized[..2], normalized, normalized + ".json");
+            var overlayPath = Path.Combine(temp.Path, "library", normalized[..2], normalized[2..4], normalized + ".json");
             Assert.True(File.Exists(overlayPath), $"Expected overlay at: {overlayPath}");
             Assert.Equal(overlayJson, await File.ReadAllTextAsync(overlayPath));
 
@@ -52,7 +52,7 @@ namespace LM.Infrastructure.Tests.Pdf
 
             var hook = JsonSerializer.Deserialize<PdfAnnotationsHook>(await File.ReadAllTextAsync(hookPath));
             Assert.NotNull(hook);
-            Assert.Equal($"library/{normalized[..2]}/{normalized}/{normalized}.json", hook!.OverlayPath);
+            Assert.Equal($"library/{normalized[..2]}/{normalized[2..4]}/{normalized}.json", hook!.OverlayPath);
             Assert.Equal(2, hook.Previews.Count);
             Assert.Contains(hook.Previews, p => p.AnnotationId == "ann1" && p.ImagePath == $"extraction/{normalized}/ann1.png");
             Assert.Contains(hook.Previews, p => p.AnnotationId == "ann2" && p.ImagePath == $"extraction/{normalized}/ann2.png");

--- a/src/LM.Infrastructure/Pdf/PdfAnnotationPersistenceService.cs
+++ b/src/LM.Infrastructure/Pdf/PdfAnnotationPersistenceService.cs
@@ -46,8 +46,8 @@ namespace LM.Infrastructure.Pdf
                 throw new ArgumentException("Entry identifier must be provided.", nameof(entryId));
 
             var normalizedHash = pdfHash.Trim().ToLowerInvariant();
-            if (normalizedHash.Length < 2)
-                throw new ArgumentException("PDF hash must contain at least two characters.", nameof(pdfHash));
+            if (normalizedHash.Length < 4)
+                throw new ArgumentException("PDF hash must contain at least four characters.", nameof(pdfHash));
             if (overlayJson is null)
                 throw new ArgumentNullException(nameof(overlayJson));
 
@@ -208,9 +208,10 @@ namespace LM.Infrastructure.Pdf
                 return NormalizeRelativePath(trimmed);
             }
 
-            var folder = pdfHash[..2];
+            var firstSegment = pdfHash[..2];
+            var secondSegment = pdfHash[2..4];
             var fileName = pdfHash + OverlayExtension;
-            return NormalizeRelativePath(Path.Combine("library", folder, pdfHash, fileName));
+            return NormalizeRelativePath(Path.Combine("library", firstSegment, secondSegment, fileName));
         }
 
         private static string? NormalizeAnnotationId(string? raw)


### PR DESCRIPTION
## Summary
- update the default PDF annotation overlay path to sit beside the stored PDF in the library
- adjust infrastructure tests to the new overlay location
- refresh the annotation storage documentation to describe the colocated overlay file

## Testing
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: .NET 9.0 SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4b9c1b8c832b9e0217acfdf2f95a