### PR TITLE
Align PDF overlay storage with source document metadata

### DIFF
--- a/docs/library-pdf-annotations.md
+++ b/docs/library-pdf-annotations.md
@@ -19,7 +19,8 @@ warning dialog and skips launch so testers can correct the workspace data.
 ## Storage layout
 
 * Annotations are persisted to `entries/<hash>/hooks/pdf_annotations.json`.
-* Overlay payloads now live alongside the PDF under `library/<first two characters>/<next two characters>/`.
+* Overlay payloads now live alongside the PDF (for example, `library/.../document.overlay.json`).
+* A debug snapshot of the raw overlay is stored under `debug/<pdf-hash>.debug.json` for troubleshooting.
 * Both the entry (`entries/<entryId>/hooks/changelog.json`) and PDF hash
   (`entries/<hash>/hooks/changelog.json`) changelog hooks receive events tagged
   with the current Windows username whenever annotations are saved.

--- a/src/LM.App.Wpf.Tests/Pdf/PdfViewerViewModelTests.cs
+++ b/src/LM.App.Wpf.Tests/Pdf/PdfViewerViewModelTests.cs
@@ -9,6 +9,7 @@ using LM.App.Wpf.Services;
 using LM.App.Wpf.ViewModels.Pdf;
 using LM.Core.Abstractions;
 using LM.Infrastructure.Hooks;
+using LM.Core.Models.Pdf;
 using Xunit;
 
 namespace LM.App.Wpf.Tests.Pdf
@@ -83,7 +84,15 @@ namespace LM.App.Wpf.Tests.Pdf
 
         private sealed class TestPersistenceService : IPdfAnnotationPersistenceService
         {
-            public Task PersistAsync(string entryId, string pdfHash, string overlayJson, IReadOnlyDictionary<string, byte[]> previewImages, string? overlaySidecarRelativePath, CancellationToken cancellationToken)
+            public Task PersistAsync(
+                string entryId,
+                string pdfHash,
+                string overlayJson,
+                IReadOnlyDictionary<string, byte[]> previewImages,
+                string? overlaySidecarRelativePath,
+                string? pdfRelativePath,
+                IReadOnlyList<PdfAnnotationBridgeMetadata> annotations,
+                CancellationToken cancellationToken)
                 => Task.CompletedTask;
         }
 

--- a/src/LM.Core/Abstractions/IPdfAnnotationPersistenceService.cs
+++ b/src/LM.Core/Abstractions/IPdfAnnotationPersistenceService.cs
@@ -17,6 +17,8 @@ namespace LM.Core.Abstractions
         /// <param name="overlayJson">Serialized annotation overlay metadata.</param>
         /// <param name="previewImages">PNG preview images keyed by annotation identifier.</param>
         /// <param name="overlaySidecarRelativePath">Optional workspace-relative path for the overlay sidecar JSON. When omitted, a default path is chosen.</param>
+        /// <param name="pdfRelativePath">Workspace-relative path to the PDF file backing the annotations.</param>
+        /// <param name="annotations">Annotation metadata captured from the viewer bridge.</param>
         /// <param name="cancellationToken">Token used to observe cancellation.</param>
         Task PersistAsync(
             string entryId,
@@ -24,6 +26,8 @@ namespace LM.Core.Abstractions
             string overlayJson,
             IReadOnlyDictionary<string, byte[]> previewImages,
             string? overlaySidecarRelativePath,
+            string? pdfRelativePath,
+            IReadOnlyList<Models.Pdf.PdfAnnotationBridgeMetadata> annotations,
             CancellationToken cancellationToken);
     }
 }

--- a/src/LM.Core/Models/Pdf/PdfAnnotationBridgeMetadata.cs
+++ b/src/LM.Core/Models/Pdf/PdfAnnotationBridgeMetadata.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace LM.Core.Models.Pdf
+{
+    /// <summary>
+    /// Snapshot of annotation metadata captured from the PDF bridge layer.
+    /// </summary>
+    public sealed class PdfAnnotationBridgeMetadata
+    {
+        public PdfAnnotationBridgeMetadata(string annotationId, string? text, string? note)
+        {
+            if (string.IsNullOrWhiteSpace(annotationId))
+            {
+                throw new ArgumentException("Annotation identifier must be provided.", nameof(annotationId));
+            }
+
+            AnnotationId = annotationId.Trim();
+            Text = NormalizeOptional(text);
+            Note = NormalizeOptional(note);
+        }
+
+        /// <summary>
+        /// Gets the unique annotation identifier provided by the viewer bridge.
+        /// </summary>
+        public string AnnotationId { get; }
+
+        /// <summary>
+        /// Gets the sanitized text snippet associated with the annotation, if any.
+        /// </summary>
+        public string? Text { get; }
+
+        /// <summary>
+        /// Gets the sanitized free-form note captured for the annotation, if any.
+        /// </summary>
+        public string? Note { get; }
+
+        private static string? NormalizeOptional(string? value)
+            => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+}

--- a/src/LM.Core/PublicAPI.Unshipped.txt
+++ b/src/LM.Core/PublicAPI.Unshipped.txt
@@ -25,7 +25,12 @@ LM.Core.Abstractions.IFileStorageRepository.SaveNewAsync(string! sourcePath, str
 LM.Core.Abstractions.IHasher
 LM.Core.Abstractions.IHasher.ComputeSha256Async(string! filePath, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
 LM.Core.Abstractions.IPdfAnnotationPersistenceService
-LM.Core.Abstractions.IPdfAnnotationPersistenceService.PersistAsync(string! entryId, string! pdfHash, string! overlayJson, System.Collections.Generic.IReadOnlyDictionary<string!, byte[]!>! previewImages, string? overlaySidecarRelativePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+LM.Core.Abstractions.IPdfAnnotationPersistenceService.PersistAsync(string! entryId, string! pdfHash, string! overlayJson, System.Collections.Generic.IReadOnlyDictionary<string!, byte[]!>! previewImages, string? overlaySidecarRelativePath, string? pdfRelativePath, System.Collections.Generic.IReadOnlyList<LM.Core.Models.Pdf.PdfAnnotationBridgeMetadata!>! annotations, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+LM.Core.Models.Pdf.PdfAnnotationBridgeMetadata
+LM.Core.Models.Pdf.PdfAnnotationBridgeMetadata.AnnotationId.get -> string!
+LM.Core.Models.Pdf.PdfAnnotationBridgeMetadata.Note.get -> string?
+LM.Core.Models.Pdf.PdfAnnotationBridgeMetadata.PdfAnnotationBridgeMetadata(string! annotationId, string? text, string? note) -> void
+LM.Core.Models.Pdf.PdfAnnotationBridgeMetadata.Text.get -> string?
 LM.Core.Abstractions.IPdfAnnotationPreviewStorage
 LM.Core.Abstractions.IPdfAnnotationPreviewStorage.SaveAsync(string! pdfHash, string! annotationId, byte[]! pngBytes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
 LM.Core.Abstractions.IPdfAnnotationOverlayReader

--- a/src/LM.HubAndSpoke/Models/PdfAnnotationsHook.cs
+++ b/src/LM.HubAndSpoke/Models/PdfAnnotationsHook.cs
@@ -12,8 +12,23 @@ namespace LM.HubSpoke.Models
         [JsonPropertyName("overlayPath")]
         public string OverlayPath { get; init; } = string.Empty;
 
+        [JsonPropertyName("annotations")]
+        public List<PdfAnnotationMetadata> Annotations { get; init; } = new();
+
         [JsonPropertyName("previews")]
         public List<PdfAnnotationPreview> Previews { get; init; } = new();
+    }
+
+    public sealed class PdfAnnotationMetadata
+    {
+        [JsonPropertyName("annotationId")]
+        public string AnnotationId { get; init; } = string.Empty;
+
+        [JsonPropertyName("text")]
+        public string? Text { get; init; }
+
+        [JsonPropertyName("note")]
+        public string? Note { get; init; }
     }
 
     public sealed class PdfAnnotationPreview

--- a/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
+++ b/src/LM.HubAndSpoke/PublicAPI.Unshipped.txt
@@ -304,6 +304,8 @@ LM.HubSpoke.Models.PdfAnnotationPreview.ImagePath.get -> string!
 LM.HubSpoke.Models.PdfAnnotationPreview.ImagePath.init -> void
 LM.HubSpoke.Models.PdfAnnotationPreview.PdfAnnotationPreview() -> void
 LM.HubSpoke.Models.PdfAnnotationsHook
+LM.HubSpoke.Models.PdfAnnotationsHook.Annotations.get -> System.Collections.Generic.List<LM.HubSpoke.Models.PdfAnnotationMetadata!>!
+LM.HubSpoke.Models.PdfAnnotationsHook.Annotations.init -> void
 LM.HubSpoke.Models.PdfAnnotationsHook.OverlayPath.get -> string!
 LM.HubSpoke.Models.PdfAnnotationsHook.OverlayPath.init -> void
 LM.HubSpoke.Models.PdfAnnotationsHook.Previews.get -> System.Collections.Generic.List<LM.HubSpoke.Models.PdfAnnotationPreview!>!
@@ -311,6 +313,14 @@ LM.HubSpoke.Models.PdfAnnotationsHook.Previews.init -> void
 LM.HubSpoke.Models.PdfAnnotationsHook.SchemaVersion.get -> string!
 LM.HubSpoke.Models.PdfAnnotationsHook.SchemaVersion.init -> void
 LM.HubSpoke.Models.PdfAnnotationsHook.PdfAnnotationsHook() -> void
+LM.HubSpoke.Models.PdfAnnotationMetadata
+LM.HubSpoke.Models.PdfAnnotationMetadata.AnnotationId.get -> string!
+LM.HubSpoke.Models.PdfAnnotationMetadata.AnnotationId.init -> void
+LM.HubSpoke.Models.PdfAnnotationMetadata.Note.get -> string?
+LM.HubSpoke.Models.PdfAnnotationMetadata.Note.init -> void
+LM.HubSpoke.Models.PdfAnnotationMetadata.PdfAnnotationMetadata() -> void
+LM.HubSpoke.Models.PdfAnnotationMetadata.Text.get -> string?
+LM.HubSpoke.Models.PdfAnnotationMetadata.Text.init -> void
 LM.HubSpoke.Models.EntryHooks
 LM.HubSpoke.Models.EntryHooks.Article.get -> string?
 LM.HubSpoke.Models.EntryHooks.Article.init -> void

--- a/src/LM.Infrastructure.Tests/HookWriterTests.cs
+++ b/src/LM.Infrastructure.Tests/HookWriterTests.cs
@@ -81,6 +81,10 @@ namespace LM.Infrastructure.Tests.Hooks
             var hook = new HookM.PdfAnnotationsHook
             {
                 OverlayPath = "library/ab/abcdef/abcdef.json",
+                Annotations = new List<HookM.PdfAnnotationMetadata>
+                {
+                    new() { AnnotationId = "ann-1", Text = "Snippet", Note = "Note" }
+                },
                 Previews = new List<HookM.PdfAnnotationPreview>
                 {
                     new() { AnnotationId = "ann-1", ImagePath = "extraction/abcdef/ann-1.png" }
@@ -95,6 +99,12 @@ namespace LM.Infrastructure.Tests.Hooks
             var hookJson = await File.ReadAllTextAsync(hookPath);
             using var hookDoc = JsonDocument.Parse(hookJson);
             Assert.Equal(hook.OverlayPath, hookDoc.RootElement.GetProperty("overlayPath").GetString());
+            var annotationsElement = hookDoc.RootElement.GetProperty("annotations");
+            Assert.Equal(1, annotationsElement.GetArrayLength());
+            var annotationElement = annotationsElement[0];
+            Assert.Equal("ann-1", annotationElement.GetProperty("annotationId").GetString());
+            Assert.Equal("Snippet", annotationElement.GetProperty("text").GetString());
+            Assert.Equal("Note", annotationElement.GetProperty("note").GetString());
 
             var changeLogPath = Path.Combine(temp.Path, "entries", entryId, "hooks", "changelog.json");
             Assert.True(File.Exists(changeLogPath), $"Expected changelog at: {changeLogPath}");

--- a/src/LM.Infrastructure/Pdf/PdfAnnotationPersistenceService.cs
+++ b/src/LM.Infrastructure/Pdf/PdfAnnotationPersistenceService.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using LM.Core.Abstractions;
+using LM.Core.Models.Pdf;
 using LM.HubSpoke.Models;
 using LM.Infrastructure.Hooks;
 
@@ -18,7 +19,7 @@ namespace LM.Infrastructure.Pdf
     {
         private const string OverlayExtension = ".json";
         private const string PreviewExtension = ".png";
-        private const string DebugOverlayFileName = "pdf_annotations.overlay.json";
+        private const string DebugDirectoryName = "debug";
 
         private readonly IWorkSpaceService _workspace;
         private readonly HookWriter _hookWriter;
@@ -35,6 +36,8 @@ namespace LM.Infrastructure.Pdf
             string overlayJson,
             IReadOnlyDictionary<string, byte[]> previewImages,
             string? overlaySidecarRelativePath,
+            string? pdfRelativePath,
+            IReadOnlyList<PdfAnnotationBridgeMetadata> annotations,
             CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(entryId))
@@ -52,10 +55,11 @@ namespace LM.Infrastructure.Pdf
                 throw new ArgumentNullException(nameof(overlayJson));
 
             var safePreviewImages = previewImages ?? new Dictionary<string, byte[]>(capacity: 0);
+            var annotationSnapshot = annotations ?? Array.Empty<PdfAnnotationBridgeMetadata>();
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var overlayRelativePath = ResolveOverlayRelativePath(normalizedHash, overlaySidecarRelativePath);
+            var overlayRelativePath = ResolveOverlayRelativePath(normalizedHash, overlaySidecarRelativePath, pdfRelativePath);
             var overlayAbsolutePath = _workspace.GetAbsolutePath(overlayRelativePath);
             EnsureDirectoryForFile(overlayAbsolutePath);
 
@@ -99,12 +103,13 @@ namespace LM.Infrastructure.Pdf
             var hook = new PdfAnnotationsHook
             {
                 OverlayPath = NormalizeRelativePath(overlayRelativePath),
-                Previews = previews
+                Previews = previews,
+                Annotations = BuildAnnotationMetadata(annotationSnapshot)
             };
 
             await _hookWriter.SavePdfAnnotationsAsync(normalizedEntryId, normalizedHash, hook, cancellationToken).ConfigureAwait(false);
 
-            await WriteDebugOverlayCopyAsync(normalizedEntryId, overlayJson, cancellationToken).ConfigureAwait(false);
+            await WriteDebugOverlaySnapshotAsync(normalizedHash, overlayJson, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<Dictionary<string, string>> LoadExistingPreviewsAsync(string entryId, CancellationToken cancellationToken)
@@ -170,16 +175,16 @@ namespace LM.Infrastructure.Pdf
             return result;
         }
 
-        private async Task WriteDebugOverlayCopyAsync(string entryId, string overlayJson, CancellationToken cancellationToken)
+        private async Task WriteDebugOverlaySnapshotAsync(string pdfHash, string overlayJson, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrWhiteSpace(overlayJson))
+            if (string.IsNullOrWhiteSpace(overlayJson) || string.IsNullOrWhiteSpace(pdfHash))
             {
                 return;
             }
 
             try
             {
-                var debugRelative = Path.Combine("entries", entryId, "hooks", DebugOverlayFileName);
+                var debugRelative = Path.Combine(DebugDirectoryName, pdfHash + ".debug.json");
                 var debugAbsolute = _workspace.GetAbsolutePath(debugRelative);
                 EnsureDirectoryForFile(debugAbsolute);
 
@@ -195,7 +200,7 @@ namespace LM.Infrastructure.Pdf
             }
         }
 
-        private static string ResolveOverlayRelativePath(string pdfHash, string? sidecar)
+        private static string ResolveOverlayRelativePath(string pdfHash, string? sidecar, string? pdfRelativePath)
         {
             if (!string.IsNullOrWhiteSpace(sidecar))
             {
@@ -208,10 +213,54 @@ namespace LM.Infrastructure.Pdf
                 return NormalizeRelativePath(trimmed);
             }
 
+            if (!string.IsNullOrWhiteSpace(pdfRelativePath))
+            {
+                var sanitized = NormalizeRelativePath(pdfRelativePath.Trim());
+                var directory = Path.GetDirectoryName(sanitized);
+                var fileName = Path.GetFileNameWithoutExtension(sanitized);
+
+                if (!string.IsNullOrWhiteSpace(fileName))
+                {
+                    var overlayFileName = fileName + ".overlay.json";
+                    var combined = string.IsNullOrWhiteSpace(directory)
+                        ? overlayFileName
+                        : Path.Combine(directory, overlayFileName);
+                    return NormalizeRelativePath(combined);
+                }
+            }
+
             var firstSegment = pdfHash[..2];
             var secondSegment = pdfHash[2..4];
-            var fileName = pdfHash + OverlayExtension;
+            var fileName = pdfHash + ".overlay" + OverlayExtension;
             return NormalizeRelativePath(Path.Combine("library", firstSegment, secondSegment, fileName));
+        }
+
+        private static List<PdfAnnotationMetadata> BuildAnnotationMetadata(IReadOnlyList<PdfAnnotationBridgeMetadata> annotations)
+        {
+            if (annotations is null || annotations.Count == 0)
+            {
+                return new List<PdfAnnotationMetadata>();
+            }
+
+            var map = new Dictionary<string, PdfAnnotationMetadata>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var annotation in annotations)
+            {
+                if (annotation is null || string.IsNullOrWhiteSpace(annotation.AnnotationId))
+                {
+                    continue;
+                }
+
+                var normalizedId = annotation.AnnotationId.Trim();
+                map[normalizedId] = new PdfAnnotationMetadata
+                {
+                    AnnotationId = normalizedId,
+                    Text = annotation.Text,
+                    Note = annotation.Note
+                };
+            }
+
+            return new List<PdfAnnotationMetadata>(map.Values);
         }
 
         private static string? NormalizeAnnotationId(string? raw)

--- a/src/LM.Infrastructure/PublicAPI.Unshipped.txt
+++ b/src/LM.Infrastructure/PublicAPI.Unshipped.txt
@@ -67,7 +67,7 @@ LM.Infrastructure.PubMed.PubMedClient.PubMedClient() -> void
 LM.Infrastructure.PubMed.PubMedClient.TryGetByDoiAsync(string! doi, bool includeCitedBy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<LM.Core.Models.PublicationRecord?>!
 LM.Infrastructure.Pdf.PdfAnnotationPersistenceService
 LM.Infrastructure.Pdf.PdfAnnotationPersistenceService.PdfAnnotationPersistenceService(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
-LM.Infrastructure.Pdf.PdfAnnotationPersistenceService.PersistAsync(string! entryId, string! pdfHash, string! overlayJson, System.Collections.Generic.IReadOnlyDictionary<string!, byte[]!>! previewImages, string? overlaySidecarRelativePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+LM.Infrastructure.Pdf.PdfAnnotationPersistenceService.PersistAsync(string! entryId, string! pdfHash, string! overlayJson, System.Collections.Generic.IReadOnlyDictionary<string!, byte[]!>! previewImages, string? overlaySidecarRelativePath, string? pdfRelativePath, System.Collections.Generic.IReadOnlyList<LM.Core.Models.Pdf.PdfAnnotationBridgeMetadata!>! annotations, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 LM.Infrastructure.Pdf.PdfAnnotationPreviewStorage
 LM.Infrastructure.Pdf.PdfAnnotationPreviewStorage.PdfAnnotationPreviewStorage(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
 LM.Infrastructure.Pdf.PdfAnnotationPreviewStorage.SaveAsync(string! pdfHash, string! annotationId, byte[]! pngBytes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!


### PR DESCRIPTION
## Summary
- store overlay sidecars alongside their source PDFs and include annotation text/notes in the hook payloads
- capture annotation metadata and PDF relative paths from the viewer bridge when scheduling persistence
- write debug overlays under the workspace debug directory and refresh related documentation and tests

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: repository targets net9.0 but SDK 8.0.414 is available in the environment)*
- dotnet test KnowledgeWorks_20250820_082416.sln -c Debug *(fails: repository targets net9.0 but SDK 8.0.414 is available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5184fc60832b885099c751fa642d