### PR TITLE
Add detailed PDF annotation bridge tracing

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.Bridge.cs
+++ b/src/LM.App.Wpf/ViewModels/Pdf/PdfViewerViewModel.Bridge.cs
@@ -21,6 +21,31 @@ namespace LM.App.Wpf.ViewModels.Pdf
         private bool _pendingDocumentLoadRequest;
         private string? _pendingOverlayPayload;
 
+        private static string DescribeSnapshotValue(string? value, int maxLength = 120)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return "(null/empty)";
+            }
+
+            var collapsed = value.Trim();
+            if (collapsed.Length <= maxLength)
+            {
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    "len={0}, text=\"{1}\"",
+                    collapsed.Length,
+                    collapsed);
+            }
+
+            var preview = string.Concat(collapsed.AsSpan(0, maxLength), "…");
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "len={0}, text=\"{1}\"",
+                collapsed.Length,
+                preview);
+        }
+
         public bool IsViewerReady
         {
             get => _isViewerReady;
@@ -88,8 +113,16 @@ namespace LM.App.Wpf.ViewModels.Pdf
 
         public Task<string?> CreateHighlightAsync(string payloadJson)
         {
-            Trace.WriteLine($"CreateHighlightAsync called with: {payloadJson}");
+            Trace.TraceInformation(
+                "PdfViewerViewModel.CreateHighlightAsync invoked (payload length={0})",
+                payloadJson?.Length ?? 0);
+            Trace.TraceInformation(
+                "PdfViewerViewModel.CreateHighlightAsync payload preview: {0}",
+                DescribeSnapshotValue(payloadJson));
             var annotation = EnsureAnnotationFromPayload(payloadJson);
+            Trace.TraceInformation(
+                "PdfViewerViewModel.CreateHighlightAsync resolved annotationId: {0}",
+                annotation?.Id ?? "(null)");
             return Task.FromResult(annotation?.Id);
         }
 
@@ -97,6 +130,7 @@ namespace LM.App.Wpf.ViewModels.Pdf
         {
             if (CurrentSelectionText is null && SelectionPageNumber is null)
             {
+                Trace.TraceInformation("PdfViewerViewModel.GetCurrentSelectionAsync returning null (no selection)");
                 return Task.FromResult<string?>(null);
             }
 
@@ -107,6 +141,10 @@ namespace LM.App.Wpf.ViewModels.Pdf
             };
 
             var json = JsonSerializer.Serialize(snapshot);
+            Trace.TraceInformation(
+                "PdfViewerViewModel.GetCurrentSelectionAsync returning snapshot (text={0}, pageNumber={1})",
+                DescribeSnapshotValue(CurrentSelectionText),
+                SelectionPageNumber?.ToString(CultureInfo.InvariantCulture) ?? "(null)");
             return Task.FromResult<string?>(json);
         }
 
@@ -256,6 +294,10 @@ namespace LM.App.Wpf.ViewModels.Pdf
 
         internal void UpdateSelection(string? text, int? pageNumber)
         {
+            Trace.TraceInformation(
+                "PdfViewerViewModel.UpdateSelection received (text={0}, pageNumber={1})",
+                DescribeSnapshotValue(text),
+                pageNumber?.ToString(CultureInfo.InvariantCulture) ?? "(null)");
             CurrentSelectionText = text;
             SelectionPageNumber = pageNumber;
         }
@@ -296,12 +338,21 @@ namespace LM.App.Wpf.ViewModels.Pdf
         {
             if (string.IsNullOrWhiteSpace(annotationId))
             {
+                Trace.TraceWarning("PdfViewerViewModel.HandleHighlightCreated invoked with empty annotationId");
                 return;
             }
 
+            Trace.TraceInformation(
+                "PdfViewerViewModel.HandleHighlightCreated processing annotation '{0}' for page {1}",
+                annotationId,
+                pageNumber?.ToString(CultureInfo.InvariantCulture) ?? "(null)");
             var annotation = Annotations.FirstOrDefault(a => string.Equals(a.Id, annotationId, StringComparison.OrdinalIgnoreCase));
             if (annotation is not null && pageNumber.HasValue && pageNumber.Value > 0)
             {
+                Trace.TraceInformation(
+                    "PdfViewerViewModel.HandleHighlightCreated updating annotation '{0}' to page {1}",
+                    annotationId,
+                    pageNumber.Value.ToString(CultureInfo.InvariantCulture));
                 annotation.PageNumber = pageNumber.Value;
             }
         }

--- a/src/LM.App.Wpf/Views/PdfViewer.HostObject.cs
+++ b/src/LM.App.Wpf/Views/PdfViewer.HostObject.cs
@@ -43,24 +43,63 @@ namespace LM.App.Wpf.Views
 
             public Task<string?> LoadPdfAsync()
             {
-                return InvokeAsync(viewModel => viewModel.LoadPdfAsync());
+                Trace.TraceInformation("PdfViewerHostObject.LoadPdfAsync invoked");
+                return InvokeAsync(async viewModel =>
+                {
+                    Trace.TraceInformation("PdfViewerHostObject delegating LoadPdfAsync to view model");
+                    var result = await viewModel.LoadPdfAsync().ConfigureAwait(true);
+                    Trace.TraceInformation(
+                        "PdfViewerHostObject.LoadPdfAsync returning {0}",
+                        string.IsNullOrEmpty(result) ? "(null/empty)" : DescribeForLog(result));
+                    return result;
+                });
             }
 
             public Task<string?> CreateHighlightAsync(string payloadJson)
             {
-                return InvokeAsync(viewModel => viewModel.CreateHighlightAsync(payloadJson ?? string.Empty));
+                Trace.TraceInformation(
+                    "PdfViewerHostObject.CreateHighlightAsync invoked (payload length={0})",
+                    payloadJson?.Length ?? 0);
+                return InvokeAsync(async viewModel =>
+                {
+                    var payload = payloadJson ?? string.Empty;
+                    Trace.TraceInformation(
+                        "PdfViewerHostObject forwarding highlight payload: {0}",
+                        DescribeForLog(payload));
+                    var result = await viewModel.CreateHighlightAsync(payload).ConfigureAwait(true);
+                    Trace.TraceInformation(
+                        "PdfViewerHostObject.CreateHighlightAsync result: {0}",
+                        string.IsNullOrEmpty(result) ? "(null/empty)" : DescribeForLog(result));
+                    return result;
+                });
             }
 
             public Task<string?> GetCurrentSelectionAsync()
             {
-                return InvokeAsync(viewModel => viewModel.GetCurrentSelectionAsync());
+                Trace.TraceInformation("PdfViewerHostObject.GetCurrentSelectionAsync invoked");
+                return InvokeAsync(async viewModel =>
+                {
+                    var snapshot = await viewModel.GetCurrentSelectionAsync().ConfigureAwait(true);
+                    Trace.TraceInformation(
+                        "PdfViewerHostObject returning selection snapshot: {0}",
+                        string.IsNullOrEmpty(snapshot) ? "(null/empty)" : DescribeForLog(snapshot));
+                    return snapshot;
+                });
             }
 
             public Task SetOverlayAsync(string payloadJson)
             {
+                Trace.TraceInformation(
+                    "PdfViewerHostObject.SetOverlayAsync invoked (payload length={0})",
+                    payloadJson?.Length ?? 0);
                 return InvokeAsync(async viewModel =>
                 {
-                    await viewModel.SetOverlayAsync(payloadJson ?? string.Empty).ConfigureAwait(true);
+                    var payload = payloadJson ?? string.Empty;
+                    Trace.TraceInformation(
+                        "PdfViewerHostObject forwarding overlay payload: {0}",
+                        DescribeForLog(payload));
+                    await viewModel.SetOverlayAsync(payload).ConfigureAwait(true);
+                    Trace.TraceInformation("PdfViewerHostObject.SetOverlayAsync completed");
                     return (string?)null;
                 });
             }


### PR DESCRIPTION
## Summary
- add extensive console tracing in the PDF bridge script to log selection snapshots and highlight payloads
- capture detailed trace output in the WPF host, view, and view-model when processing bridge messages and creating annotations

## Testing
- dotnet --info *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd64eadcb0832b84b57e4e88b8294e