### PR TITLE
Enable Enter key to trigger library search

### DIFF
--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -79,7 +79,12 @@
                          VerticalContentAlignment="Center"
                          Padding="4,0"
                          BorderBrush="#D1D5DB"
-                         BorderThickness="1"/>
+                         BorderThickness="1">
+                                    <TextBox.InputBindings>
+                                        <KeyBinding Key="Enter"
+                                                    Command="{Binding DataContext.SearchCommand, ElementName=LibraryViewControl}"/>
+                                    </TextBox.InputBindings>
+                                </TextBox>
                                 <ComboBox Grid.Column="1"
                           Margin="4,0,0,0"
                           MinWidth="100"


### PR DESCRIPTION
## Summary
- allow the library search textbox to invoke SearchCommand when the Enter key is pressed so users can trigger searches from the keyboard

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: dotnet is not installed in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68de55e35bac832b9aed114110b4cfb5