### PR TITLE
Simplify library search header interactions

### DIFF
--- a/src/LM.App.Wpf.Tests/Library/LibraryViewInteractionsTests.cs
+++ b/src/LM.App.Wpf.Tests/Library/LibraryViewInteractionsTests.cs
@@ -1,0 +1,199 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LM.App.Wpf.Views;
+using LM.App.Wpf.Views.Library.Controls;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.Library
+{
+    public sealed class LibraryViewInteractionsTests
+    {
+        [Fact]
+        public async Task UnifiedQueryBoxEnter_InvokesSearchCommand()
+        {
+            var vm = new StubLibraryViewModel();
+
+            await RunOnStaThreadAsync(() =>
+            {
+                EnsureApplication();
+                var view = new LibraryView
+                {
+                    DataContext = vm
+                };
+
+                InitializeView(view);
+
+                var queryBox = FindDescendant<LibrarySearchQueryBox>(view, box => string.Equals(box.Name, "UnifiedQueryBox", StringComparison.Ordinal));
+                Assert.NotNull(queryBox);
+
+                var binding = queryBox!.InputBindings
+                    .OfType<System.Windows.Input.KeyBinding>()
+                    .FirstOrDefault(static b => b.Key == System.Windows.Input.Key.Enter);
+
+                Assert.NotNull(binding);
+                Assert.NotNull(binding!.Command);
+
+                binding.Command!.Execute(null);
+
+                Assert.Equal(1, vm.SearchInvocationCount);
+            }).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task FullTextToggle_ExecutesSearchCommandOnStateChange()
+        {
+            var vm = new StubLibraryViewModel();
+
+            await RunOnStaThreadAsync(() =>
+            {
+                EnsureApplication();
+                var view = new LibraryView
+                {
+                    DataContext = vm
+                };
+
+                InitializeView(view);
+
+                var toggle = FindDescendant<System.Windows.Controls.Primitives.ToggleButton>(view, control => string.Equals(control.Name, "FullTextToggle", StringComparison.Ordinal));
+                Assert.NotNull(toggle);
+
+                toggle!.IsChecked = true;
+                Assert.True(vm.Filters.UseFullTextSearch);
+                Assert.Equal(1, vm.SearchInvocationCount);
+
+                toggle.IsChecked = false;
+                Assert.False(vm.Filters.UseFullTextSearch);
+                Assert.Equal(2, vm.SearchInvocationCount);
+            }).ConfigureAwait(false);
+        }
+
+        private static void InitializeView(LibraryView view)
+        {
+            if (view is null)
+            {
+                throw new ArgumentNullException(nameof(view));
+            }
+
+            view.Measure(new System.Windows.Size(800, 600));
+            view.Arrange(new System.Windows.Rect(0, 0, 800, 600));
+            view.UpdateLayout();
+        }
+
+        private static void EnsureApplication()
+        {
+            if (System.Windows.Application.Current is null)
+            {
+                _ = new System.Windows.Application();
+            }
+        }
+
+        private static T? FindDescendant<T>(System.Windows.DependencyObject root, Func<T, bool>? predicate = null)
+            where T : class
+        {
+            if (root is null)
+            {
+                return null;
+            }
+
+            var queue = new Queue<System.Windows.DependencyObject>();
+            queue.Enqueue(root);
+
+            while (queue.Count > 0)
+            {
+                var next = queue.Dequeue();
+                if (next is T candidate && (predicate is null || predicate(candidate)))
+                {
+                    return candidate;
+                }
+
+                var count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(next);
+                for (var i = 0; i < count; i++)
+                {
+                    var child = System.Windows.Media.VisualTreeHelper.GetChild(next, i);
+                    if (child is not null)
+                    {
+                        queue.Enqueue(child);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static Task RunOnStaThreadAsync(Action action)
+        {
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                    completion.SetResult(true);
+                }
+                catch (Exception ex)
+                {
+                    completion.SetException(ex);
+                }
+            })
+            {
+                IsBackground = true
+            };
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+
+            return completion.Task;
+        }
+
+        private sealed class StubLibraryViewModel
+        {
+            private readonly AsyncRelayCommand _command;
+
+            public StubLibraryViewModel()
+            {
+                Filters = new StubFilters();
+                _command = new AsyncRelayCommand(async () =>
+                {
+                    SearchInvocationCount++;
+                    await Task.CompletedTask;
+                });
+            }
+
+            public StubFilters Filters { get; }
+
+            public IAsyncRelayCommand SearchCommand => _command;
+
+            public int SearchInvocationCount { get; private set; }
+        }
+
+        private sealed class StubFilters : ObservableObject
+        {
+            private string? _unifiedQuery = string.Empty;
+            private bool _useFullTextSearch;
+
+            public string? UnifiedQuery
+            {
+                get => _unifiedQuery;
+                set => SetProperty(ref _unifiedQuery, value);
+            }
+
+            public bool UseFullTextSearch
+            {
+                get => _useFullTextSearch;
+                set => SetProperty(ref _useFullTextSearch, value);
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/Library/LibraryThemeResources.xaml
+++ b/src/LM.App.Wpf/Views/Library/LibraryThemeResources.xaml
@@ -133,8 +133,9 @@
     <Setter Property="BorderBrush" Value="{StaticResource LibraryPanelBorderBrush}" />
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Foreground" Value="{StaticResource LibraryPrimaryForegroundBrush}" />
-    <Setter Property="Padding" Value="14,10" />
+    <Setter Property="Padding" Value="12,6" />
     <Setter Property="FontSize" Value="14" />
+    <Setter Property="MinHeight" Value="32" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="Template">
       <Setter.Value>

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -5,9 +5,11 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviors="clr-namespace:LM.App.Wpf.Views.Behaviors"
+             xmlns:controls="clr-namespace:LM.App.Wpf.Views.Library.Controls"
              xmlns:converters="clr-namespace:LM.App.Wpf.Views.Converters"
              xmlns:viewModels="clr-namespace:LM.App.Wpf.ViewModels.Library"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             xmlns:core="clr-namespace:Microsoft.Xaml.Behaviors.Core;assembly=Microsoft.Xaml.Behaviors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              d:DesignHeight="600" d:DesignWidth="900">
@@ -48,58 +50,51 @@
 
                 <!-- Compact Search header -->
                 <Border Grid.Row="0"
-                Grid.Column="0"
-                Grid.ColumnSpan="5"
-                Background="#FAFAFA"
-                BorderBrush="#E5E7EB"
-                BorderThickness="0,0,0,1"
-                Padding="8,6">
-                    <StackPanel DataContext="{Binding Filters}">
-                        <DockPanel>
-                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
-                                <Button Content="Save search"
-                        Command="{Binding SavePresetCommand}"
-                        Margin="0,0,4,0"
-                        Padding="6,3"
-                        Height="26"/>
-                                <Button Content="Clear"
-                        Command="{Binding ClearCommand}"
-                        Padding="6,3"
-                        Height="26"/>
-                            </StackPanel>
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" MaxWidth="500"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <TextBox Grid.Column="0"
-                         Text="{Binding UnifiedQuery, UpdateSourceTrigger=PropertyChanged}"
-                         Height="26"
-                         VerticalContentAlignment="Center"
-                         Padding="4,0"
-                         BorderBrush="#D1D5DB"
-                         BorderThickness="1">
-                                    <TextBox.InputBindings>
-                                        <KeyBinding Key="Enter"
-                                                    Command="{Binding DataContext.SearchCommand, ElementName=LibraryViewControl}"/>
-                                    </TextBox.InputBindings>
-                                </TextBox>
-                                <ComboBox Grid.Column="1"
-                          Margin="4,0,0,0"
-                          MinWidth="100"
-                          Height="26"
-                          ItemsSource="{Binding SortOptions}"
-                          SelectedItem="{Binding SelectedSort}"
-                          DisplayMemberPath="DisplayName"/>
-                                <CheckBox Grid.Column="2"
-                          Content="Full text"
-                          Margin="8,0,0,0"
-                          VerticalAlignment="Center"
-                          IsChecked="{Binding UseFullTextSearch}"/>
-                            </Grid>
-                        </DockPanel>
-                    </StackPanel>
+                        Grid.Column="0"
+                        Grid.ColumnSpan="5"
+                        Background="#FAFAFA"
+                        BorderBrush="#E5E7EB"
+                        BorderThickness="0,0,0,1"
+                        Padding="8,6">
+                    <Grid DataContext="{Binding Filters}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <controls:LibrarySearchQueryBox x:Name="UnifiedQueryBox"
+                                                        Grid.Column="0"
+                                                        Margin="0,0,12,0"
+                                                        MaxWidth="600"
+                                                        VerticalAlignment="Center"
+                                                        Text="{Binding UnifiedQuery, UpdateSourceTrigger=PropertyChanged}">
+                            <controls:LibrarySearchQueryBox.InputBindings>
+                                <KeyBinding Key="Enter"
+                                            Command="{Binding DataContext.SearchCommand, ElementName=LibraryViewControl}"/>
+                            </controls:LibrarySearchQueryBox.InputBindings>
+                        </controls:LibrarySearchQueryBox>
+                        <StackPanel Grid.Column="1"
+                                    Orientation="Horizontal"
+                                    VerticalAlignment="Center">
+                            <ToggleButton x:Name="FullTextToggle"
+                                          Width="52"
+                                          Height="26"
+                                          Margin="0,0,8,0"
+                                          IsChecked="{Binding UseFullTextSearch}"
+                                          Style="{StaticResource LibraryPillToggleStyle}">
+                                <i:Interaction.Triggers>
+                                    <i:EventTrigger EventName="Checked">
+                                        <core:InvokeCommandAction Command="{Binding DataContext.SearchCommand, ElementName=LibraryViewControl}"/>
+                                    </i:EventTrigger>
+                                    <i:EventTrigger EventName="Unchecked">
+                                        <core:InvokeCommandAction Command="{Binding DataContext.SearchCommand, ElementName=LibraryViewControl}"/>
+                                    </i:EventTrigger>
+                                </i:Interaction.Triggers>
+                            </ToggleButton>
+                            <TextBlock Text="Full text"
+                                       VerticalAlignment="Center"
+                                       Foreground="#4B5563"/>
+                        </StackPanel>
+                    </Grid>
                 </Border>
 
                 <!-- Left Panel - Collections/Tags (Zotero-style) -->


### PR DESCRIPTION
## Summary
- replace the library header textbox with the themed LibrarySearchQueryBox bound to Filters.UnifiedQuery
- remove legacy preset buttons and sort combo while wiring the full text toggle to re-run SearchCommand immediately
- adjust query box styling for the compact header and add tests covering Enter key execution and full-text service routing

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de61382ddc832b86ca815e4777bf11