### PR TITLE
Align detail sections with left panel collapsible styling

### DIFF
--- a/src/LM.App.Wpf.Tests/Library/LibraryEntryDetailTemplateTests.cs
+++ b/src/LM.App.Wpf.Tests/Library/LibraryEntryDetailTemplateTests.cs
@@ -1,0 +1,309 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.App.Wpf.ViewModels;
+using LM.App.Wpf.ViewModels.Library;
+using LM.Core.Models;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.Library
+{
+    public sealed class LibraryEntryDetailTemplateTests
+    {
+        [Fact]
+        public async Task Template_WithData_ShowsSectionContent()
+        {
+            var entry = CreatePopulatedEntry();
+            var result = new LibrarySearchResult(entry, 0.82, "highlight");
+            var host = new StubLibraryDetailViewModel(includeData: true);
+
+            await RunOnStaThreadAsync(() =>
+            {
+                EnsureApplication();
+                var root = CreateTemplateHost(result, host);
+
+                Trace.WriteLine("Locating metadata section expander for keyboard focus validation.");
+                var metadata = FindDescendant<System.Windows.Controls.Expander>(root, static expander => string.Equals(expander.Name, "MetadataSection", StringComparison.Ordinal));
+                Assert.NotNull(metadata);
+                Assert.True(metadata!.IsExpanded);
+
+                metadata.ApplyTemplate();
+                var headerToggle = metadata.Template.FindName("HeaderToggle", metadata) as System.Windows.Controls.ToggleButton;
+                Trace.WriteLine($"Header toggle located: {headerToggle is not null}; Focusable={headerToggle?.Focusable}; IsTabStop={headerToggle?.IsTabStop}.");
+                Assert.NotNull(headerToggle);
+                Assert.True(headerToggle!.IsTabStop);
+                Assert.True(headerToggle.Focusable);
+
+                metadata.IsExpanded = false;
+                metadata.UpdateLayout();
+                System.Windows.Input.Keyboard.Focus(headerToggle);
+                Trace.WriteLine($"Header toggle keyboard focus state after collapse: {headerToggle.IsKeyboardFocused}");
+                Assert.True(headerToggle.IsKeyboardFocused);
+
+                var links = FindDescendant<System.Windows.Controls.ItemsControl>(root, static control => string.Equals(control.Name, "LinksItemsControl", StringComparison.Ordinal));
+                Assert.NotNull(links);
+                Assert.True(links!.HasItems);
+
+                var attachments = FindDescendant<System.Windows.Controls.ItemsControl>(root, static control => string.Equals(control.Name, "AttachmentsItemsControl", StringComparison.Ordinal));
+                Assert.NotNull(attachments);
+                Assert.True(attachments!.HasItems);
+
+                var relations = FindDescendant<System.Windows.Controls.ItemsControl>(root, static control => string.Equals(control.Name, "RelationsItemsControl", StringComparison.Ordinal));
+                Assert.NotNull(relations);
+                Assert.True(relations!.HasItems);
+
+                var notesPlaceholder = FindDescendant<System.Windows.Controls.TextBlock>(root, static text => string.Equals(text.Name, "NotesPlaceholder", StringComparison.Ordinal));
+                Assert.NotNull(notesPlaceholder);
+                Assert.Equal(System.Windows.Visibility.Collapsed, notesPlaceholder!.Visibility);
+            }).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task Template_WithEmptyData_ShowsPlaceholders()
+        {
+            var entry = new Entry
+            {
+                Title = "Empty Entry"
+            };
+            var result = new LibrarySearchResult(entry, null, null);
+            var host = new StubLibraryDetailViewModel(includeData: false);
+
+            await RunOnStaThreadAsync(() =>
+            {
+                EnsureApplication();
+                var root = CreateTemplateHost(result, host);
+
+                Trace.WriteLine("Validating placeholder visibility for empty entry detail template.");
+                AssertVisibility(root, "SourcePlaceholder", System.Windows.Visibility.Visible);
+                AssertVisibility(root, "AbstractPlaceholder", System.Windows.Visibility.Visible);
+                AssertVisibility(root, "NotesPlaceholder", System.Windows.Visibility.Visible);
+                AssertVisibility(root, "UserNotesPlaceholder", System.Windows.Visibility.Visible);
+                AssertVisibility(root, "IdentifiersPlaceholder", System.Windows.Visibility.Visible);
+                AssertVisibility(root, "LinksPlaceholder", System.Windows.Visibility.Visible);
+                AssertVisibility(root, "AttachmentsPlaceholder", System.Windows.Visibility.Visible);
+                AssertVisibility(root, "RelationsPlaceholder", System.Windows.Visibility.Visible);
+            }).ConfigureAwait(false);
+        }
+
+        private static void AssertVisibility(System.Windows.DependencyObject root, string elementName, System.Windows.Visibility expected)
+        {
+            Trace.WriteLine($"Searching for element '{elementName}' to validate visibility state.");
+            var textBlock = FindDescendant<System.Windows.Controls.TextBlock>(root, element => string.Equals(element.Name, elementName, StringComparison.Ordinal));
+            Assert.NotNull(textBlock);
+            Assert.Equal(expected, textBlock!.Visibility);
+        }
+
+        private static Entry CreatePopulatedEntry()
+        {
+            var entry = new Entry
+            {
+                Title = "Evidence-Based Medicine",
+                DisplayName = "Evidence-Based Medicine",
+                Type = EntryType.Publication,
+                Year = 2024,
+                Source = "Journal of Clinical Practice",
+                Notes = "Notes for reviewers.",
+                UserNotes = "Personal annotation.",
+                InternalId = "KW-001",
+                Doi = "10.1000/example",
+                Pmid = "12345678",
+                Nct = "NCT00000000",
+                IsInternal = true
+            };
+
+            entry.Attachments.Add(new Attachment
+            {
+                Title = "Primary PDF",
+                RelativePath = "attachments/primary.pdf",
+                Kind = AttachmentKind.Supplement,
+                AddedBy = string.IsNullOrWhiteSpace(Environment.UserName) ? "tester" : Environment.UserName,
+                AddedUtc = DateTime.UtcNow,
+                Notes = "Full text copy.",
+                Tags = new List<string> { "pdf", "final" }
+            });
+
+            entry.Relations.Add(new Relation
+            {
+                Type = "related_to",
+                TargetEntryId = "entry-2"
+            });
+
+            return entry;
+        }
+
+        private static System.Windows.Controls.ScrollViewer CreateTemplateHost(LibrarySearchResult result, StubLibraryDetailViewModel host)
+        {
+            var uri = new Uri("/LM.App.Wpf;component/Views/Library/LibraryEntryDetailTemplate.xaml", UriKind.Relative);
+            var dictionary = (System.Windows.ResourceDictionary)System.Windows.Application.LoadComponent(uri);
+            var template = (System.Windows.DataTemplate)dictionary["LibraryEntryDetailTemplate"];
+
+            var presenter = new System.Windows.Controls.ContentPresenter
+            {
+                Content = result,
+                ContentTemplate = template
+            };
+
+            var viewer = new System.Windows.Controls.ScrollViewer
+            {
+                Content = presenter,
+                DataContext = host
+            };
+
+            InitializeElement(viewer);
+            return viewer;
+        }
+
+        private static void InitializeElement(System.Windows.FrameworkElement element)
+        {
+            if (element is null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            element.Measure(new System.Windows.Size(800, 600));
+            element.Arrange(new System.Windows.Rect(0, 0, 800, 600));
+            element.UpdateLayout();
+        }
+
+        private static void EnsureApplication()
+        {
+            if (System.Windows.Application.Current is null)
+            {
+                _ = new System.Windows.Application();
+            }
+        }
+
+        private static T? FindDescendant<T>(System.Windows.DependencyObject root, Func<T, bool>? predicate = null)
+            where T : class
+        {
+            if (root is null)
+            {
+                return null;
+            }
+
+            var queue = new Queue<System.Windows.DependencyObject>();
+            queue.Enqueue(root);
+
+            while (queue.Count > 0)
+            {
+                var next = queue.Dequeue();
+                if (next is T candidate && (predicate is null || predicate(candidate)))
+                {
+                    return candidate;
+                }
+
+                var count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(next);
+                for (var i = 0; i < count; i++)
+                {
+                    var child = System.Windows.Media.VisualTreeHelper.GetChild(next, i);
+                    if (child is not null)
+                    {
+                        queue.Enqueue(child);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static Task RunOnStaThreadAsync(Action action)
+        {
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                    completion.SetResult(true);
+                }
+                catch (Exception ex)
+                {
+                    completion.SetException(ex);
+                }
+            })
+            {
+                IsBackground = true
+            };
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+
+            return completion.Task;
+        }
+
+        private sealed class StubLibraryDetailViewModel
+        {
+            public StubLibraryDetailViewModel(bool includeData)
+            {
+                Results = new StubResults(includeData);
+                EditEntryCommand = new StubCommand();
+                OpenAttachmentCommand = new StubCommand();
+                OpenLinkCommand = new StubCommand();
+            }
+
+            public StubResults Results { get; }
+
+            public System.Windows.Input.ICommand EditEntryCommand { get; }
+
+            public System.Windows.Input.ICommand OpenAttachmentCommand { get; }
+
+            public System.Windows.Input.ICommand OpenLinkCommand { get; }
+        }
+
+        private sealed class StubResults
+        {
+            public StubResults(bool includeData)
+            {
+                LinkItems = new ObservableCollection<LibraryLinkItem>();
+
+                if (includeData)
+                {
+                    SelectedAbstract = "Abstract content.";
+                    HasSelectedAbstract = true;
+                    var link = new LibraryLinkItem("Example", "https://example.com", LinkItemKind.Url);
+                    LinkItems.Add(link);
+                    HasLinkItems = true;
+                }
+                else
+                {
+                    SelectedAbstract = null;
+                    HasSelectedAbstract = false;
+                    HasLinkItems = false;
+                }
+            }
+
+            public ObservableCollection<LibraryLinkItem> LinkItems { get; }
+
+            public string? SelectedAbstract { get; }
+
+            public bool HasSelectedAbstract { get; }
+
+            public bool HasLinkItems { get; }
+        }
+
+        private sealed class StubCommand : System.Windows.Input.ICommand
+        {
+            public event EventHandler? CanExecuteChanged
+            {
+                add { }
+                remove { }
+            }
+
+            public bool CanExecute(object? parameter) => true;
+
+            public void Execute(object? parameter)
+            {
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/Library/LibraryEntryDetailTemplate.xaml
+++ b/src/LM.App.Wpf/Views/Library/LibraryEntryDetailTemplate.xaml
@@ -5,11 +5,6 @@
     <ResourceDictionary Source="LibraryCommonResources.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
-  <Style x:Key="SectionHeaderTextStyle" TargetType="TextBlock">
-    <Setter Property="FontWeight" Value="SemiBold" />
-    <Setter Property="Margin" Value="0,16,0,4" />
-  </Style>
-
   <Style x:Key="SectionTextStyle" TargetType="TextBlock">
     <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
@@ -36,22 +31,100 @@
     <Setter Property="Margin" Value="0,4,0,0" />
   </Style>
 
-  <Style x:Key="OptionalInlineTextStyle" TargetType="TextBlock">
-    <Setter Property="Visibility" Value="Visible" />
-    <Style.Triggers>
-      <Trigger Property="Text" Value="">
-        <Setter Property="Visibility" Value="Collapsed" />
-      </Trigger>
-      <Trigger Property="Text" Value="{x:Null}">
-        <Setter Property="Visibility" Value="Collapsed" />
-      </Trigger>
-    </Style.Triggers>
-  </Style>
-
   <Style x:Key="SectionPlaceholderTextStyle" TargetType="TextBlock">
     <Setter Property="FontStyle" Value="Italic" />
     <Setter Property="Foreground" Value="Gray" />
     <Setter Property="Visibility" Value="Collapsed" />
+  </Style>
+
+  <Style x:Key="LibraryDetailExpanderToggleStyle" TargetType="ToggleButton">
+    <Setter Property="Background" Value="#F3F4F6" />
+    <Setter Property="Foreground" Value="#1F2937" />
+    <Setter Property="Padding" Value="12,10" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ToggleButton">
+          <Border x:Name="HeaderBorder"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="#E5E7EB"
+                  BorderThickness="0,0,0,1"
+                  CornerRadius="4,4,0,0"
+                  Padding="{TemplateBinding Padding}">
+            <DockPanel LastChildFill="True">
+              <TextBlock x:Name="Chevron"
+                         Width="16"
+                         Height="16"
+                         FontFamily="Segoe MDL2 Assets"
+                         FontSize="10"
+                         Foreground="#6B7280"
+                         VerticalAlignment="Center"
+                         HorizontalAlignment="Center"
+                         Text="&#xE70D;" />
+              <ContentPresenter Margin="8,0,0,0"
+                                VerticalAlignment="Center"
+                                RecognizesAccessKey="True" />
+            </DockPanel>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsChecked" Value="False">
+              <Setter TargetName="Chevron" Property="Text" Value="&#xE76C;" />
+            </Trigger>
+            <Trigger Property="IsKeyboardFocused" Value="True">
+              <Setter TargetName="HeaderBorder" Property="BorderBrush" Value="#2563EB" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="HeaderBorder" Property="Background" Value="#E5E7EB" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+              <Setter TargetName="HeaderBorder" Property="Background" Value="#D1D5DB" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <Style x:Key="LibraryDetailExpanderStyle" TargetType="Expander">
+    <Setter Property="Background" Value="White" />
+    <Setter Property="BorderBrush" Value="#E5E7EB" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="IsExpanded" Value="True" />
+    <Setter Property="Margin" Value="0,12,0,0" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="Expander">
+          <Border Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  CornerRadius="4">
+            <DockPanel>
+              <ToggleButton x:Name="HeaderToggle"
+                            DockPanel.Dock="Top"
+                            Focusable="True"
+                            IsTabStop="True"
+                            Style="{StaticResource LibraryDetailExpanderToggleStyle}"
+                            Content="{TemplateBinding Header}"
+                            IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}}" />
+              <Border x:Name="ContentHost"
+                      Background="White"
+                      CornerRadius="0,0,4,4">
+                <ContentPresenter x:Name="ExpandSite"
+                                  Margin="12"
+                                  Visibility="Collapsed"
+                                  ContentSource="Content" />
+              </Border>
+            </DockPanel>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsExpanded" Value="True">
+              <Setter TargetName="ExpandSite" Property="Visibility" Value="Visible" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
   </Style>
 
   <Style x:Key="AttachmentNotesTextStyle"
@@ -98,15 +171,6 @@
                      TextWrapping="Wrap" />
           <TextBlock Text="{Binding Entry.DisplayName}"
                      Style="{StaticResource DisplayNameTextStyle}" />
-          <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-            <TextBlock Text="{Binding Entry.Type}" />
-            <TextBlock Text="{Binding Entry.Year}"
-                       Margin="12,0,0,0"
-                       Style="{StaticResource OptionalInlineTextStyle}" />
-            <TextBlock Text="Internal"
-                       Margin="12,0,0,0"
-                       Visibility="{Binding Entry.IsInternal, Converter={StaticResource BoolToVisibilityConverter}}" />
-          </StackPanel>
         </StackPanel>
 
         <Button Grid.Column="1"
@@ -118,207 +182,276 @@
                 VerticalAlignment="Top" />
       </Grid>
 
-      <TextBlock Text="Source" Style="{StaticResource SectionHeaderTextStyle}" />
-      <TextBlock Text="{Binding Entry.Source}"
-                 Style="{StaticResource SectionTextStyle}"
-                 Visibility="{Binding HasSource, Converter={StaticResource BoolToVisibilityConverter}}" />
-      <TextBlock Text="No source recorded.">
-        <TextBlock.Style>
-          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
-            <Style.Triggers>
-              <DataTrigger Binding="{Binding HasSource}" Value="False">
-                <Setter Property="Visibility" Value="Visible" />
-              </DataTrigger>
-            </Style.Triggers>
-          </Style>
-        </TextBlock.Style>
-      </TextBlock>
+      <Expander x:Name="MetadataSection"
+                Header="Metadata"
+                Style="{StaticResource LibraryDetailExpanderStyle}"
+                Margin="0,16,0,0">
+        <StackPanel>
+          <TextBlock Margin="0,0,0,4">
+            <Run Text="Type: " FontWeight="SemiBold" />
+            <Run Text="{Binding Entry.Type}" />
+          </TextBlock>
+          <TextBlock Margin="0,0,0,4"
+                     Text="{Binding Entry.Year, StringFormat=Year: {0}}"
+                     Style="{StaticResource OptionalSectionTextStyle}" />
+          <TextBlock Margin="0,0,0,4"
+                     Text="Internal entry"
+                     Visibility="{Binding Entry.IsInternal, Converter={StaticResource BoolToVisibilityConverter}}" />
+          <TextBlock Margin="0,12,0,4" FontWeight="SemiBold" Text="Source" />
+          <TextBlock Text="{Binding Entry.Source}"
+                     Style="{StaticResource SectionTextStyle}" />
+          <TextBlock x:Name="SourcePlaceholder"
+                     Text="No source recorded."
+                     Margin="0,4,0,0">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding HasSource}" Value="False">
+                    <Setter Property="Visibility" Value="Visible" />
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+        </StackPanel>
+      </Expander>
 
-      <TextBlock Text="Abstract" Style="{StaticResource SectionHeaderTextStyle}" />
-      <TextBlock Text="{Binding DataContext.Results.SelectedAbstract, RelativeSource={RelativeSource AncestorType=ScrollViewer}}"
-                 Style="{StaticResource SectionTextStyle}"
-                 Visibility="{Binding DataContext.Results.HasSelectedAbstract, RelativeSource={RelativeSource AncestorType=ScrollViewer}, Converter={StaticResource BoolToVisibilityConverter}}" />
-      <TextBlock Text="No abstract available.">
-        <TextBlock.Style>
-          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
-            <Style.Triggers>
-              <DataTrigger Binding="{Binding DataContext.Results.HasSelectedAbstract, RelativeSource={RelativeSource AncestorType=ScrollViewer}}" Value="False">
-                <Setter Property="Visibility" Value="Visible" />
-              </DataTrigger>
-            </Style.Triggers>
-          </Style>
-        </TextBlock.Style>
-      </TextBlock>
+      <Expander x:Name="AbstractSection"
+                Header="Abstract"
+                Style="{StaticResource LibraryDetailExpanderStyle}">
+        <StackPanel>
+          <TextBlock Text="{Binding DataContext.Results.SelectedAbstract, RelativeSource={RelativeSource AncestorType=ScrollViewer}}"
+                     Style="{StaticResource SectionTextStyle}" />
+          <TextBlock x:Name="AbstractPlaceholder"
+                     Text="No abstract available."
+                     Margin="0,4,0,0">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding DataContext.Results.HasSelectedAbstract, RelativeSource={RelativeSource AncestorType=ScrollViewer}}" Value="False">
+                    <Setter Property="Visibility" Value="Visible" />
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+        </StackPanel>
+      </Expander>
 
-      <TextBlock Text="Notes" Style="{StaticResource SectionHeaderTextStyle}" />
-      <TextBlock Text="{Binding Entry.Notes}" Style="{StaticResource OptionalSectionTextStyle}" />
-      <TextBlock Text="No notes recorded.">
-        <TextBlock.Style>
-          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
-            <Style.Triggers>
-              <DataTrigger Binding="{Binding HasNotes}" Value="False">
-                <Setter Property="Visibility" Value="Visible" />
-              </DataTrigger>
-            </Style.Triggers>
-          </Style>
-        </TextBlock.Style>
-      </TextBlock>
+      <Expander x:Name="NotesSection"
+                Header="Notes"
+                Style="{StaticResource LibraryDetailExpanderStyle}">
+        <StackPanel>
+          <TextBlock Text="{Binding Entry.Notes}"
+                     Style="{StaticResource OptionalSectionTextStyle}" />
+          <TextBlock x:Name="NotesPlaceholder"
+                     Text="No notes recorded."
+                     Margin="0,4,0,0">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding HasNotes}" Value="False">
+                    <Setter Property="Visibility" Value="Visible" />
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+        </StackPanel>
+      </Expander>
 
-      <TextBlock Text="User notes" Style="{StaticResource SectionHeaderTextStyle}" />
-      <TextBlock Text="{Binding Entry.UserNotes}" Style="{StaticResource OptionalSectionTextStyle}" />
-      <TextBlock Text="No user notes provided.">
-        <TextBlock.Style>
-          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
-            <Style.Triggers>
-              <DataTrigger Binding="{Binding HasUserNotes}" Value="False">
-                <Setter Property="Visibility" Value="Visible" />
-              </DataTrigger>
-            </Style.Triggers>
-          </Style>
-        </TextBlock.Style>
-      </TextBlock>
+      <Expander x:Name="UserNotesSection"
+                Header="User notes"
+                Style="{StaticResource LibraryDetailExpanderStyle}">
+        <StackPanel>
+          <TextBlock Text="{Binding Entry.UserNotes}"
+                     Style="{StaticResource OptionalSectionTextStyle}" />
+          <TextBlock x:Name="UserNotesPlaceholder"
+                     Text="No user notes provided."
+                     Margin="0,4,0,0">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding HasUserNotes}" Value="False">
+                    <Setter Property="Visibility" Value="Visible" />
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+        </StackPanel>
+      </Expander>
 
-      <TextBlock Text="Identifiers" Style="{StaticResource SectionHeaderTextStyle}" />
-      <StackPanel>
-        <TextBlock Visibility="{Binding HasInternalId, Converter={StaticResource BoolToVisibilityConverter}}">
-          <Run Text="Internal ID: " />
-          <Run Text="{Binding Entry.InternalId}" />
-        </TextBlock>
-        <TextBlock Visibility="{Binding HasDoi, Converter={StaticResource BoolToVisibilityConverter}}">
-          <Run Text="DOI: " />
-          <Run Text="{Binding Entry.Doi}" />
-        </TextBlock>
-        <TextBlock Visibility="{Binding HasPmid, Converter={StaticResource BoolToVisibilityConverter}}">
-          <Run Text="PMID: " />
-          <Run Text="{Binding Entry.Pmid}" />
-        </TextBlock>
-        <TextBlock Visibility="{Binding HasNct, Converter={StaticResource BoolToVisibilityConverter}}">
-          <Run Text="NCT: " />
-          <Run Text="{Binding Entry.Nct}" />
-        </TextBlock>
-      </StackPanel>
-      <TextBlock Text="No identifiers recorded.">
-        <TextBlock.Style>
-          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
-            <Style.Triggers>
-              <DataTrigger Binding="{Binding HasIdentifiers}" Value="False">
-                <Setter Property="Visibility" Value="Visible" />
-              </DataTrigger>
-            </Style.Triggers>
-          </Style>
-        </TextBlock.Style>
-      </TextBlock>
+      <Expander x:Name="IdentifiersSection"
+                Header="Identifiers"
+                Style="{StaticResource LibraryDetailExpanderStyle}">
+        <StackPanel>
+          <TextBlock Visibility="{Binding HasInternalId, Converter={StaticResource BoolToVisibilityConverter}}">
+            <Run Text="Internal ID: " FontWeight="SemiBold" />
+            <Run Text="{Binding Entry.InternalId}" />
+          </TextBlock>
+          <TextBlock Visibility="{Binding HasDoi, Converter={StaticResource BoolToVisibilityConverter}}">
+            <Run Text="DOI: " FontWeight="SemiBold" />
+            <Run Text="{Binding Entry.Doi}" />
+          </TextBlock>
+          <TextBlock Visibility="{Binding HasPmid, Converter={StaticResource BoolToVisibilityConverter}}">
+            <Run Text="PMID: " FontWeight="SemiBold" />
+            <Run Text="{Binding Entry.Pmid}" />
+          </TextBlock>
+          <TextBlock Visibility="{Binding HasNct, Converter={StaticResource BoolToVisibilityConverter}}">
+            <Run Text="NCT: " FontWeight="SemiBold" />
+            <Run Text="{Binding Entry.Nct}" />
+          </TextBlock>
+          <TextBlock x:Name="IdentifiersPlaceholder"
+                     Text="No identifiers recorded."
+                     Margin="0,4,0,0">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding HasIdentifiers}" Value="False">
+                    <Setter Property="Visibility" Value="Visible" />
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+        </StackPanel>
+      </Expander>
 
-      <TextBlock Text="Links" Style="{StaticResource SectionHeaderTextStyle}" />
-      <ItemsControl ItemsSource="{Binding DataContext.Results.LinkItems, RelativeSource={RelativeSource AncestorType=ScrollViewer}}"
-                    Visibility="{Binding DataContext.Results.HasLinkItems, RelativeSource={RelativeSource AncestorType=ScrollViewer}, Converter={StaticResource BoolToVisibilityConverter}}">
-        <ItemsControl.ItemTemplate>
-          <DataTemplate>
-            <TextBlock Style="{StaticResource SectionTextStyle}" TextWrapping="Wrap">
-              <Hyperlink Command="{Binding DataContext.OpenLinkCommand, RelativeSource={RelativeSource AncestorType=ScrollViewer}}"
-                        CommandParameter="{Binding}"
-                        ToolTip="{Binding Target}">
-                <Run Text="{Binding DisplayText}" />
-              </Hyperlink>
-            </TextBlock>
-          </DataTemplate>
-        </ItemsControl.ItemTemplate>
-      </ItemsControl>
-      <TextBlock Text="No links added.">
-        <TextBlock.Style>
-          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
-            <Style.Triggers>
-              <DataTrigger Binding="{Binding DataContext.Results.HasLinkItems, RelativeSource={RelativeSource AncestorType=ScrollViewer}}" Value="False">
-                <Setter Property="Visibility" Value="Visible" />
-              </DataTrigger>
-            </Style.Triggers>
-          </Style>
-        </TextBlock.Style>
-      </TextBlock>
+      <Expander x:Name="LinksSection"
+                Header="Links"
+                Style="{StaticResource LibraryDetailExpanderStyle}">
+        <StackPanel>
+          <ItemsControl x:Name="LinksItemsControl"
+                        ItemsSource="{Binding DataContext.Results.LinkItems, RelativeSource={RelativeSource AncestorType=ScrollViewer}}"
+                        Visibility="{Binding DataContext.Results.HasLinkItems, RelativeSource={RelativeSource AncestorType=ScrollViewer}, Converter={StaticResource BoolToVisibilityConverter}}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <TextBlock Style="{StaticResource SectionTextStyle}" TextWrapping="Wrap">
+                  <Hyperlink Command="{Binding DataContext.OpenLinkCommand, RelativeSource={RelativeSource AncestorType=ScrollViewer}}"
+                            CommandParameter="{Binding}"
+                            ToolTip="{Binding Target}">
+                    <Run Text="{Binding DisplayText}" />
+                  </Hyperlink>
+                </TextBlock>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+          <TextBlock x:Name="LinksPlaceholder"
+                     Text="No links added."
+                     Margin="0,4,0,0">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding DataContext.Results.HasLinkItems, RelativeSource={RelativeSource AncestorType=ScrollViewer}}" Value="False">
+                    <Setter Property="Visibility" Value="Visible" />
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+        </StackPanel>
+      </Expander>
 
-      <TextBlock Text="Attachments" Style="{StaticResource SectionHeaderTextStyle}" />
-      <ItemsControl ItemsSource="{Binding Entry.Attachments}"
-                    Visibility="{Binding HasAttachments, Converter={StaticResource BoolToVisibilityConverter}}">
-        <ItemsControl.ItemTemplate>
-          <DataTemplate>
-            <Border BorderBrush="#FFE0E0E0"
-                    BorderThickness="1"
-                    Padding="8"
-                    Margin="0,0,0,8">
-              <Grid>
-                <Grid.ColumnDefinitions>
-                  <ColumnDefinition Width="*" />
-                  <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
+      <Expander x:Name="AttachmentsSection"
+                Header="Attachments"
+                Style="{StaticResource LibraryDetailExpanderStyle}">
+        <StackPanel>
+          <ItemsControl x:Name="AttachmentsItemsControl"
+                        ItemsSource="{Binding Entry.Attachments}"
+                        Visibility="{Binding HasAttachments, Converter={StaticResource BoolToVisibilityConverter}}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <Border BorderBrush="#FFE0E0E0"
+                        BorderThickness="1"
+                        Padding="8"
+                        Margin="0,0,0,8">
+                  <Grid>
+                    <Grid.ColumnDefinitions>
+                      <ColumnDefinition Width="*" />
+                      <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
 
-                <StackPanel Grid.Column="0">
-                  <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
-                  <TextBlock Text="{Binding RelativePath}" Style="{StaticResource OptionalSectionTextStyle}" />
-                  <TextBlock Margin="0,4,0,0">
-                    <Run Text="Type: " />
-                    <Run Text="{Binding Kind}" />
-                  </TextBlock>
-                  <TextBlock Text="{Binding AddedBy, StringFormat=Added by {0}}"
-                             Margin="0,2,0,0"
-                             Style="{StaticResource OptionalSectionTextStyle}" />
-                  <TextBlock Text="{Binding AddedUtc, StringFormat=Added on {0:yyyy-MM-dd HH:mm}}"
-                             Margin="0,2,0,0" />
-                  <TextBlock Text="{Binding Notes}" Style="{StaticResource AttachmentNotesTextStyle}" />
-                  <TextBlock Style="{StaticResource AttachmentTagsTextStyle}">
-                    <Run Text="Tags: " />
-                    <Run Text="{Binding Tags, Converter={StaticResource StringJoinConverter}}" />
-                  </TextBlock>
-                </StackPanel>
+                    <StackPanel Grid.Column="0">
+                      <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                      <TextBlock Text="{Binding RelativePath}" Style="{StaticResource OptionalSectionTextStyle}" />
+                      <TextBlock Margin="0,4,0,0">
+                        <Run Text="Type: " />
+                        <Run Text="{Binding Kind}" />
+                      </TextBlock>
+                      <TextBlock Text="{Binding AddedBy, StringFormat=Added by {0}}"
+                                 Margin="0,2,0,0"
+                                 Style="{StaticResource OptionalSectionTextStyle}" />
+                      <TextBlock Text="{Binding AddedUtc, StringFormat=Added on {0:yyyy-MM-dd HH:mm}}"
+                                 Margin="0,2,0,0" />
+                      <TextBlock Text="{Binding Notes}" Style="{StaticResource AttachmentNotesTextStyle}" />
+                      <TextBlock Style="{StaticResource AttachmentTagsTextStyle}">
+                        <Run Text="Tags: " />
+                        <Run Text="{Binding Tags, Converter={StaticResource StringJoinConverter}}" />
+                      </TextBlock>
+                    </StackPanel>
 
-                <Button Grid.Column="1"
-                        Content="Open"
-                        Command="{Binding DataContext.OpenAttachmentCommand, RelativeSource={RelativeSource AncestorType=ScrollViewer}}"
-                        CommandParameter="{Binding}"
-                        Padding="12,4"
-                        Margin="12,0,0,0"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Top" />
-              </Grid>
-            </Border>
-          </DataTemplate>
-        </ItemsControl.ItemTemplate>
-      </ItemsControl>
-      <TextBlock Text="No attachments found.">
-        <TextBlock.Style>
-          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
-            <Style.Triggers>
-              <DataTrigger Binding="{Binding HasAttachments}" Value="False">
-                <Setter Property="Visibility" Value="Visible" />
-              </DataTrigger>
-            </Style.Triggers>
-          </Style>
-        </TextBlock.Style>
-      </TextBlock>
+                    <Button Grid.Column="1"
+                            Content="Open"
+                            Command="{Binding DataContext.OpenAttachmentCommand, RelativeSource={RelativeSource AncestorType=ScrollViewer}}"
+                            CommandParameter="{Binding}"
+                            Padding="12,4"
+                            Margin="12,0,0,0"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top" />
+                  </Grid>
+                </Border>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+          <TextBlock x:Name="AttachmentsPlaceholder"
+                     Text="No attachments found."
+                     Margin="0,4,0,0">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding HasAttachments}" Value="False">
+                    <Setter Property="Visibility" Value="Visible" />
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+        </StackPanel>
+      </Expander>
 
-      <TextBlock Text="Relations" Style="{StaticResource SectionHeaderTextStyle}" />
-      <ItemsControl ItemsSource="{Binding Entry.Relations}"
-                    Visibility="{Binding HasRelations, Converter={StaticResource BoolToVisibilityConverter}}">
-        <ItemsControl.ItemTemplate>
-          <DataTemplate>
-            <TextBlock>
-              <Run Text="{Binding Type}" FontWeight="SemiBold" />
-              <Run Text=" → " />
-              <Run Text="{Binding TargetEntryId}" />
-            </TextBlock>
-          </DataTemplate>
-        </ItemsControl.ItemTemplate>
-      </ItemsControl>
-      <TextBlock Text="No relations associated.">
-        <TextBlock.Style>
-          <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
-            <Style.Triggers>
-              <DataTrigger Binding="{Binding HasRelations}" Value="False">
-                <Setter Property="Visibility" Value="Visible" />
-              </DataTrigger>
-            </Style.Triggers>
-          </Style>
-        </TextBlock.Style>
-      </TextBlock>
+      <Expander x:Name="RelationsSection"
+                Header="Relations"
+                Style="{StaticResource LibraryDetailExpanderStyle}">
+        <StackPanel>
+          <ItemsControl x:Name="RelationsItemsControl"
+                        ItemsSource="{Binding Entry.Relations}"
+                        Visibility="{Binding HasRelations, Converter={StaticResource BoolToVisibilityConverter}}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <TextBlock>
+                  <Run Text="{Binding Type}" FontWeight="SemiBold" />
+                  <Run Text=" → " />
+                  <Run Text="{Binding TargetEntryId}" />
+                </TextBlock>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+          <TextBlock x:Name="RelationsPlaceholder"
+                     Text="No relations associated."
+                     Margin="0,4,0,0">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock" BasedOn="{StaticResource SectionPlaceholderTextStyle}">
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding HasRelations}" Value="False">
+                    <Setter Property="Visibility" Value="Visible" />
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+        </StackPanel>
+      </Expander>
     </StackPanel>
   </DataTemplate>
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
- restyle the library entry detail expanders to mirror the left panel header treatment, including shared colors, chevron glyphs, and rounded borders
- wrap expander content in a rounded host so collapsed/expanded states retain the panel card silhouette
- extend the UI template tests with trace logging and keyboard focus assertions for the expander header toggle and placeholder coverage

## Testing
- `dotnet test KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de65d49d14832b89b1228882ed9c15