### PR TITLE
Add hierarchical saved search preset support

### DIFF
--- a/library/filter-presets.json
+++ b/library/filter-presets.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Library filter preset hierarchy",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "integer",
+      "description": "Persistent schema version."
+    },
+    "root": {
+      "$ref": "#/definitions/folder"
+    }
+  },
+  "required": ["version", "root"],
+  "definitions": {
+    "folder": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the folder."
+        },
+        "name": {
+          "type": "string",
+          "description": "Folder display name."
+        },
+        "sortOrder": {
+          "type": "integer",
+          "description": "Zero-based order within the parent."
+        },
+        "folders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/folder"
+          },
+          "default": []
+        },
+        "presets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/preset"
+          },
+          "default": []
+        }
+      },
+      "required": ["id", "name", "sortOrder", "folders", "presets"]
+    },
+    "preset": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable identifier for the saved search."
+        },
+        "name": {
+          "type": "string",
+          "description": "Display name of the saved search."
+        },
+        "sortOrder": {
+          "type": "integer",
+          "description": "Zero-based order within the parent folder."
+        },
+        "savedUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "UTC timestamp indicating when the preset was last saved."
+        },
+        "state": {
+          "$ref": "#/definitions/state"
+        }
+      },
+      "required": ["id", "name", "sortOrder", "savedUtc", "state"]
+    },
+    "state": {
+      "type": "object",
+      "properties": {
+        "useFullTextSearch": { "type": "boolean" },
+        "unifiedQuery": { "type": ["string", "null"] },
+        "fullTextQuery": { "type": ["string", "null"] },
+        "fullTextInTitle": { "type": "boolean" },
+        "fullTextInAbstract": { "type": "boolean" },
+        "fullTextInContent": { "type": "boolean" },
+        "dateFrom": { "type": ["string", "null"], "format": "date" },
+        "dateTo": { "type": ["string", "null"], "format": "date" },
+        "sortKey": { "type": ["string", "null"] },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        }
+      },
+      "required": [
+        "useFullTextSearch",
+        "fullTextInTitle",
+        "fullTextInAbstract",
+        "fullTextInContent",
+        "tags"
+      ]
+    }
+  }
+}

--- a/src/LM.App.Wpf.Tests/LibraryFilterPresetStoreTests.cs
+++ b/src/LM.App.Wpf.Tests/LibraryFilterPresetStoreTests.cs
@@ -1,5 +1,7 @@
 using System;
-using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using LM.App.Wpf.Library;
 using LM.Infrastructure.FileSystem;
@@ -31,30 +33,97 @@ public class LibraryFilterPresetStoreTests
 
         await store.SavePresetAsync(preset);
 
+        var hierarchy = await store.GetHierarchyAsync();
+        var savedPreset = Assert.Single(hierarchy.Presets);
+        Assert.False(string.IsNullOrWhiteSpace(savedPreset.Id));
+
+        var fetchedById = await store.TryGetPresetByIdAsync(savedPreset.Id!);
+        Assert.NotNull(fetchedById);
+        Assert.Equal("My Preset", fetchedById!.Name);
+
         var presets = await store.ListPresetsAsync();
         var loaded = Assert.Single(presets);
-        Assert.Equal("My Preset", loaded.Name);
-        Assert.True((DateTime.UtcNow - loaded.SavedUtc) < TimeSpan.FromMinutes(1));
-
-        Assert.Equal(preset.State.UseFullTextSearch, loaded.State.UseFullTextSearch);
+        Assert.Equal(savedPreset.Id, loaded.Id);
         Assert.Equal(preset.State.UnifiedQuery, loaded.State.UnifiedQuery);
-        Assert.Equal(preset.State.FullTextQuery, loaded.State.FullTextQuery);
-        Assert.Equal(preset.State.FullTextInTitle, loaded.State.FullTextInTitle);
-        Assert.Equal(preset.State.FullTextInAbstract, loaded.State.FullTextInAbstract);
-        Assert.Equal(preset.State.FullTextInContent, loaded.State.FullTextInContent);
 
-        var fetched = await store.TryGetPresetAsync("my preset");
-        Assert.NotNull(fetched);
-        Assert.Equal("My Preset", fetched!.Name);
-
-        await store.DeletePresetAsync("My Preset");
+        await store.DeletePresetAsync(savedPreset.Id!);
         var afterDelete = await store.ListPresetsAsync();
         Assert.Empty(afterDelete);
+    }
+
+    [Fact]
+    public async Task LegacyFlatData_MigratesIntoRootFolder()
+    {
+        using var temp = new TempDir();
+        var workspace = new WorkspaceService();
+        await workspace.EnsureWorkspaceAsync(temp.Path);
+
+        var legacy = new
+        {
+            presets = new[]
+            {
+                new
+                {
+                    Name = "Legacy",
+                    SavedUtc = DateTime.UtcNow,
+                    State = new { UnifiedQuery = "tag:legacy" }
+                }
+            }
+        };
+
+        var path = Path.Combine(temp.Path, "library", "filter-presets.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllTextAsync(path, JsonSerializer.Serialize(legacy));
+
+        var store = new LibraryFilterPresetStore(workspace);
+        var hierarchy = await store.GetHierarchyAsync();
+        var migrated = Assert.Single(hierarchy.Presets);
+        Assert.Equal("Legacy", migrated.Name);
+        Assert.False(string.IsNullOrWhiteSpace(migrated.Id));
+
+        var list = await store.ListPresetsAsync();
+        Assert.Single(list);
+        Assert.Equal("Legacy", list.Single().Name);
+    }
+
+    [Fact]
+    public async Task MovePresetBetweenFolders_UpdatesHierarchy()
+    {
+        using var temp = new TempDir();
+        var workspace = new WorkspaceService();
+        await workspace.EnsureWorkspaceAsync(temp.Path);
+
+        var store = new LibraryFilterPresetStore(workspace);
+        var presetA = new LibraryFilterPreset { Name = "Preset A" };
+        var presetB = new LibraryFilterPreset { Name = "Preset B" };
+
+        await store.SavePresetAsync(presetA);
+        await store.SavePresetAsync(presetB);
+
+        var folderId = await store.CreateFolderAsync(LibraryPresetFolder.RootId, "Folder");
+
+        var rootBeforeMove = await store.GetHierarchyAsync();
+        var ids = rootBeforeMove.Presets.Select(p => p.Id!).ToArray();
+
+        await store.MovePresetAsync(ids[0], folderId, 0);
+
+        var rootAfterMove = await store.GetHierarchyAsync();
+        Assert.Single(rootAfterMove.Presets);
+        var folder = Assert.Single(rootAfterMove.Folders);
+        Assert.Equal(folderId, folder.Id);
+        var moved = Assert.Single(folder.Presets);
+        Assert.Equal(ids[0], moved.Id);
+
+        await store.MovePresetAsync(ids[0], LibraryPresetFolder.RootId, 1);
+        var rootAfterReturn = await store.GetHierarchyAsync();
+        Assert.Equal(2, rootAfterReturn.Presets.Count);
+        Assert.Empty(rootAfterReturn.Folders.Single().Presets);
     }
 
     private sealed class TempDir : IDisposable
     {
         public string Path { get; }
+
         public TempDir()
         {
             Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "lm_preset_" + Guid.NewGuid().ToString("N"));

--- a/src/LM.App.Wpf/Common/ILibraryPresetPrompt.cs
+++ b/src/LM.App.Wpf/Common/ILibraryPresetPrompt.cs
@@ -10,7 +10,11 @@ namespace LM.App.Wpf.Common
         Task<LibraryPresetSelectionResult?> RequestSelectionAsync(LibraryPresetSelectionContext context);
     }
 
-    public sealed record LibraryPresetSaveContext(string DefaultName, IReadOnlyCollection<string> ExistingNames);
+    public sealed record LibraryPresetSaveContext(
+        string DefaultName,
+        IReadOnlyCollection<string> ExistingNames,
+        string Title = "Save Library Preset",
+        string Prompt = "Name this filter preset.");
 
     public sealed record LibraryPresetSaveResult(string Name);
 
@@ -19,7 +23,7 @@ namespace LM.App.Wpf.Common
         bool AllowLoad,
         string Title);
 
-    public sealed record LibraryPresetSelectionResult(string? SelectedPresetName, IReadOnlyList<string> DeletedPresetNames);
+    public sealed record LibraryPresetSelectionResult(string? SelectedPresetId, IReadOnlyList<string> DeletedPresetIds);
 
-    public sealed record LibraryPresetSummary(string Name, DateTime SavedUtc);
+    public sealed record LibraryPresetSummary(string Id, string Name, DateTime SavedUtc);
 }

--- a/src/LM.App.Wpf/Library/LibraryFilterPresetStore.cs
+++ b/src/LM.App.Wpf/Library/LibraryFilterPresetStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -15,7 +16,9 @@ namespace LM.App.Wpf.Library
     /// </summary>
     public sealed class LibraryFilterPresetStore
     {
+        private const int CurrentVersion = 2;
         private readonly IWorkSpaceService _workspace;
+
         private static readonly JsonSerializerOptions JsonOptions = new()
         {
             WriteIndented = true,
@@ -28,67 +31,243 @@ namespace LM.App.Wpf.Library
             _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
         }
 
-        public async Task SavePresetAsync(LibraryFilterPreset preset, CancellationToken ct = default)
+        public Task SavePresetAsync(LibraryFilterPreset preset, CancellationToken ct = default)
+        {
+            return SavePresetAsync(preset, LibraryPresetFolder.RootId, ct);
+        }
+
+        public async Task SavePresetAsync(LibraryFilterPreset preset, string? targetFolderId, CancellationToken ct = default)
         {
             if (preset is null)
+            {
                 throw new ArgumentNullException(nameof(preset));
+            }
 
             var file = await LoadAsync(ct).ConfigureAwait(false);
+            var root = EnsureRoot(file);
+            var destination = ResolveFolder(root, targetFolderId);
 
-            var existingIndex = file.Presets.FindIndex(p => string.Equals(p.Name, preset.Name, StringComparison.OrdinalIgnoreCase));
+            if (string.IsNullOrWhiteSpace(preset.Id))
+            {
+                preset.Id = Guid.NewGuid().ToString("N");
+            }
+
             preset.SavedUtc = DateTime.UtcNow;
 
-            if (existingIndex >= 0)
+            var (existingParent, existingPreset) = TryFindPreset(root, preset.Id);
+            if (existingPreset is null && !string.IsNullOrWhiteSpace(preset.Name))
             {
-                file.Presets[existingIndex] = preset;
-            }
-            else
-            {
-                file.Presets.Add(preset);
+                (existingParent, existingPreset) = TryFindPresetByName(root, preset.Name);
             }
 
-            file.Presets.Sort(static (a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+            if (existingPreset is not null)
+            {
+                existingParent!.Presets.Remove(existingPreset);
+                Trace.WriteLine($"[LibraryFilterPresetStore] Updating preset '{preset.Name}' ({preset.Id}).");
+            }
+
+            InsertPreset(destination, preset, existingPreset?.SortOrder ?? destination.EnumerateChildren().Count());
+            NormalizeTree(root);
+
+            file.Version = CurrentVersion;
             await SaveAsync(file, ct).ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryFilterPresetStore] Persisted preset '{preset.Name}' to folder '{destination.Id}'.");
         }
 
         public async Task<IReadOnlyList<LibraryFilterPreset>> ListPresetsAsync(CancellationToken ct = default)
         {
             var file = await LoadAsync(ct).ConfigureAwait(false);
-            return file.Presets
-                .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
-                .Select(p => p.Clone())
-                .ToArray();
+            var results = new List<LibraryFilterPreset>();
+            Flatten(file.Root, results);
+            Trace.WriteLine($"[LibraryFilterPresetStore] Listed {results.Count} preset(s).");
+            return results.Select(static preset => preset.Clone()).ToArray();
         }
 
-        public async Task<LibraryFilterPreset?> TryGetPresetAsync(string name, CancellationToken ct = default)
+        public async Task<LibraryPresetFolder> GetHierarchyAsync(CancellationToken ct = default)
         {
-            if (string.IsNullOrWhiteSpace(name))
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            Trace.WriteLine("[LibraryFilterPresetStore] Loaded hierarchy snapshot.");
+            return file.Root.Clone();
+        }
+
+        public async Task<LibraryFilterPreset?> TryGetPresetByIdAsync(string presetId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(presetId))
+            {
                 return null;
+            }
 
             var file = await LoadAsync(ct).ConfigureAwait(false);
-            var preset = file.Presets.FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+            var (_, preset) = TryFindPreset(file.Root, presetId);
             return preset?.Clone();
         }
 
-        public async Task DeletePresetAsync(string name, CancellationToken ct = default)
+        public async Task<LibraryFilterPreset?> TryGetPresetAsync(string key, CancellationToken ct = default)
         {
-            if (string.IsNullOrWhiteSpace(name))
-                return;
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return null;
+            }
 
             var file = await LoadAsync(ct).ConfigureAwait(false);
-            file.Presets.RemoveAll(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+            var (_, presetById) = TryFindPreset(file.Root, key);
+            if (presetById is not null)
+            {
+                return presetById.Clone();
+            }
+
+            var (_, preset) = TryFindPresetByName(file.Root, key);
+            return preset?.Clone();
+        }
+
+        public async Task DeletePresetAsync(string key, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return;
+            }
+
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            var (parent, preset) = TryFindPreset(file.Root, key);
+            if (preset is null)
+            {
+                (parent, preset) = TryFindPresetByName(file.Root, key);
+            }
+
+            if (preset is null || parent is null)
+            {
+                Trace.WriteLine($"[LibraryFilterPresetStore] No preset found for key '{key}'.");
+                return;
+            }
+
+            parent.Presets.Remove(preset);
+            NormalizeTree(file.Root);
             await SaveAsync(file, ct).ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryFilterPresetStore] Deleted preset '{preset.Name}' ({preset.Id}).");
+        }
+
+        public async Task<string> CreateFolderAsync(string parentFolderId, string name, CancellationToken ct = default)
+        {
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            var root = EnsureRoot(file);
+            var parent = ResolveFolder(root, parentFolderId);
+
+            var folder = new LibraryPresetFolder
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Name = name?.Trim() ?? string.Empty
+            };
+
+            InsertFolder(parent, folder, parent.EnumerateChildren().Count());
+            NormalizeTree(root);
+            file.Version = CurrentVersion;
+            await SaveAsync(file, ct).ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryFilterPresetStore] Created folder '{folder.Name}' ({folder.Id}) under '{parent.Id}'.");
+            return folder.Id;
+        }
+
+        public async Task DeleteFolderAsync(string folderId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(folderId) || string.Equals(folderId, LibraryPresetFolder.RootId, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            var (parent, folder) = TryFindFolder(file.Root, folderId);
+            if (folder is null || parent is null)
+            {
+                Trace.WriteLine($"[LibraryFilterPresetStore] Folder '{folderId}' not found for deletion.");
+                return;
+            }
+
+            parent.Folders.Remove(folder);
+            NormalizeTree(file.Root);
+            await SaveAsync(file, ct).ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryFilterPresetStore] Deleted folder '{folder.Name}' ({folder.Id}).");
+        }
+
+        public async Task MovePresetAsync(string presetId, string targetFolderId, int insertIndex, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(presetId))
+            {
+                return;
+            }
+
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            var root = EnsureRoot(file);
+            var (currentParent, preset) = TryFindPreset(root, presetId);
+            if (preset is null || currentParent is null)
+            {
+                Trace.WriteLine($"[LibraryFilterPresetStore] Cannot move preset '{presetId}'; not found.");
+                return;
+            }
+
+            var destination = ResolveFolder(root, targetFolderId);
+            var ordered = currentParent.EnumerateChildren().ToList();
+            var removed = ordered.FindIndex(static item => item.Kind == LibraryPresetNodeKind.Preset && item.Preset is not null && ReferenceEquals(item.Preset, preset));
+            if (removed >= 0)
+            {
+                ordered.RemoveAt(removed);
+                ReassignChildren(currentParent, ordered);
+            }
+
+            InsertPreset(destination, preset, insertIndex);
+            NormalizeTree(root);
+            await SaveAsync(file, ct).ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryFilterPresetStore] Moved preset '{preset.Name}' to folder '{destination.Id}' at index {insertIndex}.");
+        }
+
+        public async Task MoveFolderAsync(string folderId, string targetFolderId, int insertIndex, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(folderId) || string.Equals(folderId, LibraryPresetFolder.RootId, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            var root = EnsureRoot(file);
+            var (currentParent, folder) = TryFindFolder(root, folderId);
+            if (folder is null || currentParent is null)
+            {
+                Trace.WriteLine($"[LibraryFilterPresetStore] Cannot move folder '{folderId}'; not found.");
+                return;
+            }
+
+            var destination = ResolveFolder(root, targetFolderId);
+            if (ReferenceEquals(destination, folder) || IsDescendant(folder, destination))
+            {
+                Trace.WriteLine($"[LibraryFilterPresetStore] Ignoring move of folder '{folder.Id}' into itself or descendant.");
+                return;
+            }
+
+            var ordered = currentParent.EnumerateChildren().ToList();
+            var removed = ordered.FindIndex(static item => item.Kind == LibraryPresetNodeKind.Folder && item.Folder is not null && ReferenceEquals(item.Folder, folder));
+            if (removed >= 0)
+            {
+                ordered.RemoveAt(removed);
+                ReassignChildren(currentParent, ordered);
+            }
+
+            InsertFolder(destination, folder, insertIndex);
+            NormalizeTree(root);
+            await SaveAsync(file, ct).ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryFilterPresetStore] Moved folder '{folder.Name}' to '{destination.Id}' at index {insertIndex}.");
         }
 
         private async Task<LibraryPresetFile> LoadAsync(CancellationToken ct)
         {
             var path = GetFilePath();
             if (!File.Exists(path))
-                return new LibraryPresetFile();
+            {
+                Trace.WriteLine("[LibraryFilterPresetStore] No preset file found; creating new store.");
+                return CreateDefaultFile();
+            }
 
             await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
-            var file = await JsonSerializer.DeserializeAsync<LibraryPresetFile>(stream, JsonOptions, ct).ConfigureAwait(false);
-            return file ?? new LibraryPresetFile();
+            var file = await JsonSerializer.DeserializeAsync<LibraryPresetFile>(stream, JsonOptions, ct).ConfigureAwait(false) ?? CreateDefaultFile();
+            MigrateIfNeeded(file);
+            return file;
         }
 
         private async Task SaveAsync(LibraryPresetFile file, CancellationToken ct)
@@ -100,6 +279,7 @@ namespace LM.App.Wpf.Library
                 Directory.CreateDirectory(directory);
             }
 
+            file.Version = CurrentVersion;
             var json = JsonSerializer.Serialize(file, JsonOptions);
             await File.WriteAllTextAsync(path, json, ct).ConfigureAwait(false);
         }
@@ -110,22 +290,306 @@ namespace LM.App.Wpf.Library
             return Path.Combine(root, "library", "filter-presets.json");
         }
 
+        private static LibraryPresetFile CreateDefaultFile()
+        {
+            return new LibraryPresetFile
+            {
+                Version = CurrentVersion,
+                Root = new LibraryPresetFolder
+                {
+                    Id = LibraryPresetFolder.RootId,
+                    Name = string.Empty
+                }
+            };
+        }
+
+        private static void MigrateIfNeeded(LibraryPresetFile file)
+        {
+            if (file.Root is null)
+            {
+                file.Root = new LibraryPresetFolder
+                {
+                    Id = LibraryPresetFolder.RootId,
+                    Name = string.Empty
+                };
+            }
+
+            if (file.Version >= 2)
+            {
+                NormalizeTree(file.Root);
+                return;
+            }
+
+            if (file.LegacyPresets is not null && file.LegacyPresets.Count > 0)
+            {
+                var index = 0;
+                foreach (var preset in file.LegacyPresets)
+                {
+                    if (string.IsNullOrWhiteSpace(preset.Id))
+                    {
+                        preset.Id = Guid.NewGuid().ToString("N");
+                    }
+
+                    preset.SortOrder = index++;
+                    file.Root.Presets.Add(preset);
+                }
+            }
+
+            file.LegacyPresets = null;
+            NormalizeTree(file.Root);
+        }
+
+        private static LibraryPresetFolder EnsureRoot(LibraryPresetFile file)
+        {
+            if (file.Root is null)
+            {
+                file.Root = new LibraryPresetFolder
+                {
+                    Id = LibraryPresetFolder.RootId,
+                    Name = string.Empty
+                };
+            }
+
+            if (!string.Equals(file.Root.Id, LibraryPresetFolder.RootId, StringComparison.Ordinal))
+            {
+                file.Root.Id = LibraryPresetFolder.RootId;
+            }
+
+            return file.Root;
+        }
+
+        private static LibraryPresetFolder ResolveFolder(LibraryPresetFolder root, string? folderId)
+        {
+            if (string.IsNullOrWhiteSpace(folderId) || string.Equals(folderId, LibraryPresetFolder.RootId, StringComparison.Ordinal))
+            {
+                return root;
+            }
+
+            var (_, folder) = TryFindFolder(root, folderId);
+            return folder ?? root;
+        }
+
+        private static (LibraryPresetFolder? Parent, LibraryFilterPreset? Preset) TryFindPreset(LibraryPresetFolder root, string presetId)
+        {
+            foreach (var item in root.EnumerateChildren())
+            {
+                switch (item.Kind)
+                {
+                    case LibraryPresetNodeKind.Preset when item.Preset is not null && string.Equals(item.Preset.Id, presetId, StringComparison.Ordinal):
+                        return (root, item.Preset);
+                    case LibraryPresetNodeKind.Folder when item.Folder is not null:
+                    {
+                        var found = TryFindPreset(item.Folder, presetId);
+                        if (found.Preset is not null)
+                        {
+                            return found;
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            return (null, null);
+        }
+
+        private static (LibraryPresetFolder? Parent, LibraryFilterPreset? Preset) TryFindPresetByName(LibraryPresetFolder root, string name)
+        {
+            foreach (var item in root.EnumerateChildren())
+            {
+                switch (item.Kind)
+                {
+                    case LibraryPresetNodeKind.Preset when item.Preset is not null && string.Equals(item.Preset.Name, name, StringComparison.OrdinalIgnoreCase):
+                        return (root, item.Preset);
+                    case LibraryPresetNodeKind.Folder when item.Folder is not null:
+                    {
+                        var found = TryFindPresetByName(item.Folder, name);
+                        if (found.Preset is not null)
+                        {
+                            return found;
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            return (null, null);
+        }
+
+        private static (LibraryPresetFolder? Parent, LibraryPresetFolder? Folder) TryFindFolder(LibraryPresetFolder root, string folderId)
+        {
+            foreach (var item in root.EnumerateChildren())
+            {
+                if (item.Kind == LibraryPresetNodeKind.Folder && item.Folder is not null)
+                {
+                    if (string.Equals(item.Folder.Id, folderId, StringComparison.Ordinal))
+                    {
+                        return (root, item.Folder);
+                    }
+
+                    var nested = TryFindFolder(item.Folder, folderId);
+                    if (nested.Folder is not null)
+                    {
+                        return nested;
+                    }
+                }
+            }
+
+            return (null, null);
+        }
+
+        private static void InsertPreset(LibraryPresetFolder destination, LibraryFilterPreset preset, int insertIndex)
+        {
+            var ordered = destination.EnumerateChildren().ToList();
+            insertIndex = Math.Clamp(insertIndex, 0, ordered.Count);
+            ordered.Insert(insertIndex, new LibraryPresetTreeItem(LibraryPresetNodeKind.Preset, insertIndex, null, preset));
+            ReassignChildren(destination, ordered);
+        }
+
+        private static void InsertFolder(LibraryPresetFolder destination, LibraryPresetFolder folder, int insertIndex)
+        {
+            var ordered = destination.EnumerateChildren().ToList();
+            insertIndex = Math.Clamp(insertIndex, 0, ordered.Count);
+            ordered.Insert(insertIndex, new LibraryPresetTreeItem(LibraryPresetNodeKind.Folder, insertIndex, folder, null));
+            ReassignChildren(destination, ordered);
+        }
+
+        private static void ReassignChildren(LibraryPresetFolder folder, List<LibraryPresetTreeItem> ordered)
+        {
+            for (var i = 0; i < ordered.Count; i++)
+            {
+                switch (ordered[i].Kind)
+                {
+                    case LibraryPresetNodeKind.Folder when ordered[i].Folder is not null:
+                        ordered[i].Folder.SortOrder = i;
+                        break;
+                    case LibraryPresetNodeKind.Preset when ordered[i].Preset is not null:
+                        ordered[i].Preset.SortOrder = i;
+                        break;
+                }
+            }
+
+            folder.Folders = ordered
+                .Where(static item => item.Kind == LibraryPresetNodeKind.Folder && item.Folder is not null)
+                .Select(static item => item.Folder!)
+                .OrderBy(static f => f.SortOrder)
+                .ToList();
+
+            folder.Presets = ordered
+                .Where(static item => item.Kind == LibraryPresetNodeKind.Preset && item.Preset is not null)
+                .Select(static item => item.Preset!)
+                .OrderBy(static p => p.SortOrder)
+                .ToList();
+        }
+
+        private static void NormalizeTree(LibraryPresetFolder root)
+        {
+            if (root.Folders is null)
+            {
+                root.Folders = new List<LibraryPresetFolder>();
+            }
+
+            if (root.Presets is null)
+            {
+                root.Presets = new List<LibraryFilterPreset>();
+            }
+
+            if (string.IsNullOrWhiteSpace(root.Id))
+            {
+                root.Id = Guid.NewGuid().ToString("N");
+            }
+
+            if (string.Equals(root.Id, LibraryPresetFolder.RootId, StringComparison.Ordinal))
+            {
+                root.Id = LibraryPresetFolder.RootId;
+            }
+
+            var ordered = root.EnumerateChildren().ToList();
+            ReassignChildren(root, ordered);
+
+            foreach (var folder in root.Folders.ToArray())
+            {
+                NormalizeTree(folder);
+            }
+
+            foreach (var preset in root.Presets)
+            {
+                if (string.IsNullOrWhiteSpace(preset.Id))
+                {
+                    preset.Id = Guid.NewGuid().ToString("N");
+                }
+            }
+        }
+
+        private static bool IsDescendant(LibraryPresetFolder potentialAncestor, LibraryPresetFolder candidate)
+        {
+            if (ReferenceEquals(potentialAncestor, candidate))
+            {
+                return true;
+            }
+
+            foreach (var folder in potentialAncestor.Folders)
+            {
+                if (ReferenceEquals(folder, candidate))
+                {
+                    return true;
+                }
+
+                if (IsDescendant(folder, candidate))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void Flatten(LibraryPresetFolder folder, List<LibraryFilterPreset> results)
+        {
+            foreach (var item in folder.EnumerateChildren())
+            {
+                switch (item.Kind)
+                {
+                    case LibraryPresetNodeKind.Preset when item.Preset is not null:
+                        results.Add(item.Preset);
+                        break;
+                    case LibraryPresetNodeKind.Folder when item.Folder is not null:
+                        Flatten(item.Folder, results);
+                        break;
+                }
+            }
+        }
+
         private sealed class LibraryPresetFile
         {
-            public List<LibraryFilterPreset> Presets { get; set; } = new();
+            public int Version { get; set; }
+
+            public LibraryPresetFolder? Root { get; set; }
+
+            [JsonPropertyName("presets")]
+            public List<LibraryFilterPreset>? LegacyPresets { get; set; }
         }
     }
 
     public sealed class LibraryFilterPreset
     {
+        public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
         public string Name { get; set; } = string.Empty;
+
+        public int SortOrder { get; set; }
+
         public DateTime SavedUtc { get; set; } = DateTime.UtcNow;
+
         public LibraryFilterState State { get; set; } = new();
 
         internal LibraryFilterPreset Clone()
             => new()
             {
+                Id = Id,
                 Name = Name,
+                SortOrder = SortOrder,
                 SavedUtc = SavedUtc,
                 State = State.Clone()
             };
@@ -139,8 +603,8 @@ namespace LM.App.Wpf.Library
         public bool FullTextInTitle { get; set; } = true;
         public bool FullTextInAbstract { get; set; } = true;
         public bool FullTextInContent { get; set; } = true;
-        public System.DateTime? DateFrom { get; set; }
-        public System.DateTime? DateTo { get; set; }
+        public DateTime? DateFrom { get; set; }
+        public DateTime? DateTo { get; set; }
         public string? SortKey { get; set; }
         public string[] Tags { get; set; } = Array.Empty<string>();
 

--- a/src/LM.App.Wpf/Library/LibraryPresetTree.cs
+++ b/src/LM.App.Wpf/Library/LibraryPresetTree.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LM.App.Wpf.Library
+{
+    public enum LibraryPresetNodeKind
+    {
+        Folder,
+        Preset
+    }
+
+    public sealed class LibraryPresetFolder
+    {
+        public const string RootId = "root";
+
+        public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+        public string Name { get; set; } = string.Empty;
+
+        public int SortOrder { get; set; }
+
+        public List<LibraryPresetFolder> Folders { get; set; } = new();
+
+        public List<LibraryFilterPreset> Presets { get; set; } = new();
+
+        public IEnumerable<LibraryPresetTreeItem> EnumerateChildren()
+        {
+            var combined = new List<LibraryPresetTreeItem>();
+
+            foreach (var folder in Folders ?? Enumerable.Empty<LibraryPresetFolder>())
+            {
+                combined.Add(new LibraryPresetTreeItem(LibraryPresetNodeKind.Folder, folder.SortOrder, folder, null));
+            }
+
+            foreach (var preset in Presets ?? Enumerable.Empty<LibraryFilterPreset>())
+            {
+                combined.Add(new LibraryPresetTreeItem(LibraryPresetNodeKind.Preset, preset.SortOrder, null, preset));
+            }
+
+            return combined
+                .OrderBy(static item => item.SortOrder)
+                .ToArray();
+        }
+
+        public LibraryPresetFolder Clone()
+        {
+            var clone = new LibraryPresetFolder
+            {
+                Id = Id,
+                Name = Name,
+                SortOrder = SortOrder
+            };
+
+            foreach (var folder in Folders ?? Enumerable.Empty<LibraryPresetFolder>())
+            {
+                clone.Folders.Add(folder.Clone());
+            }
+
+            foreach (var preset in Presets ?? Enumerable.Empty<LibraryFilterPreset>())
+            {
+                clone.Presets.Add(preset.Clone());
+            }
+
+            return clone;
+        }
+
+        internal void NormalizeOrder()
+        {
+            var ordered = EnumerateChildren().ToArray();
+            for (var i = 0; i < ordered.Length; i++)
+            {
+                switch (ordered[i].Kind)
+                {
+                    case LibraryPresetNodeKind.Folder when ordered[i].Folder is not null:
+                        ordered[i].Folder.SortOrder = i;
+                        break;
+                    case LibraryPresetNodeKind.Preset when ordered[i].Preset is not null:
+                        ordered[i].Preset.SortOrder = i;
+                        break;
+                }
+            }
+        }
+    }
+
+    public readonly struct LibraryPresetTreeItem
+    {
+        public LibraryPresetTreeItem(LibraryPresetNodeKind kind, int sortOrder, LibraryPresetFolder? folder, LibraryFilterPreset? preset)
+        {
+            Kind = kind;
+            SortOrder = sortOrder;
+            Folder = folder;
+            Preset = preset;
+        }
+
+        public LibraryPresetNodeKind Kind { get; }
+
+        public int SortOrder { get; }
+
+        public LibraryPresetFolder? Folder { get; }
+
+        public LibraryFilterPreset? Preset { get; }
+    }
+}

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -133,7 +133,11 @@ LM.App.Wpf.Common.LibraryPresetSaveContext.DefaultName.get -> string!
 LM.App.Wpf.Common.LibraryPresetSaveContext.DefaultName.init -> void
 LM.App.Wpf.Common.LibraryPresetSaveContext.ExistingNames.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 LM.App.Wpf.Common.LibraryPresetSaveContext.ExistingNames.init -> void
-LM.App.Wpf.Common.LibraryPresetSaveContext.LibraryPresetSaveContext(string! DefaultName, System.Collections.Generic.IReadOnlyCollection<string!>! ExistingNames) -> void
+LM.App.Wpf.Common.LibraryPresetSaveContext.LibraryPresetSaveContext(string! DefaultName, System.Collections.Generic.IReadOnlyCollection<string!>! ExistingNames, string! Title, string! Prompt) -> void
+LM.App.Wpf.Common.LibraryPresetSaveContext.Prompt.get -> string!
+LM.App.Wpf.Common.LibraryPresetSaveContext.Prompt.init -> void
+LM.App.Wpf.Common.LibraryPresetSaveContext.Title.get -> string!
+LM.App.Wpf.Common.LibraryPresetSaveContext.Title.init -> void
 LM.App.Wpf.Common.LibraryPresetSaveResult
 LM.App.Wpf.Common.LibraryPresetSaveResult.LibraryPresetSaveResult(string! Name) -> void
 LM.App.Wpf.Common.LibraryPresetSaveResult.Name.get -> string!
@@ -147,13 +151,15 @@ LM.App.Wpf.Common.LibraryPresetSelectionContext.Presets.init -> void
 LM.App.Wpf.Common.LibraryPresetSelectionContext.Title.get -> string!
 LM.App.Wpf.Common.LibraryPresetSelectionContext.Title.init -> void
 LM.App.Wpf.Common.LibraryPresetSelectionResult
-LM.App.Wpf.Common.LibraryPresetSelectionResult.DeletedPresetNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
-LM.App.Wpf.Common.LibraryPresetSelectionResult.DeletedPresetNames.init -> void
-LM.App.Wpf.Common.LibraryPresetSelectionResult.LibraryPresetSelectionResult(string? SelectedPresetName, System.Collections.Generic.IReadOnlyList<string!>! DeletedPresetNames) -> void
-LM.App.Wpf.Common.LibraryPresetSelectionResult.SelectedPresetName.get -> string?
-LM.App.Wpf.Common.LibraryPresetSelectionResult.SelectedPresetName.init -> void
+LM.App.Wpf.Common.LibraryPresetSelectionResult.DeletedPresetIds.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.Common.LibraryPresetSelectionResult.DeletedPresetIds.init -> void
+LM.App.Wpf.Common.LibraryPresetSelectionResult.LibraryPresetSelectionResult(string? SelectedPresetId, System.Collections.Generic.IReadOnlyList<string!>! DeletedPresetIds) -> void
+LM.App.Wpf.Common.LibraryPresetSelectionResult.SelectedPresetId.get -> string?
+LM.App.Wpf.Common.LibraryPresetSelectionResult.SelectedPresetId.init -> void
 LM.App.Wpf.Common.LibraryPresetSummary
-LM.App.Wpf.Common.LibraryPresetSummary.LibraryPresetSummary(string! Name, System.DateTime SavedUtc) -> void
+LM.App.Wpf.Common.LibraryPresetSummary.Id.get -> string!
+LM.App.Wpf.Common.LibraryPresetSummary.Id.init -> void
+LM.App.Wpf.Common.LibraryPresetSummary.LibraryPresetSummary(string! Id, string! Name, System.DateTime SavedUtc) -> void
 LM.App.Wpf.Common.LibraryPresetSummary.Name.get -> string!
 LM.App.Wpf.Common.LibraryPresetSummary.Name.init -> void
 LM.App.Wpf.Common.LibraryPresetSummary.SavedUtc.get -> System.DateTime
@@ -237,18 +243,50 @@ LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.WebViewBridge.set -> void
 LM.App.Wpf.ViewModels.Pdf.PdfViewerViewModel.DeleteAnnotationCommand.get -> System.Windows.Input.ICommand!
 LM.App.Wpf.Library.LibraryFilterPreset
 LM.App.Wpf.Library.LibraryFilterPreset.LibraryFilterPreset() -> void
+LM.App.Wpf.Library.LibraryFilterPreset.Id.get -> string!
+LM.App.Wpf.Library.LibraryFilterPreset.Id.set -> void
 LM.App.Wpf.Library.LibraryFilterPreset.Name.get -> string!
 LM.App.Wpf.Library.LibraryFilterPreset.Name.set -> void
 LM.App.Wpf.Library.LibraryFilterPreset.SavedUtc.get -> System.DateTime
 LM.App.Wpf.Library.LibraryFilterPreset.SavedUtc.set -> void
+LM.App.Wpf.Library.LibraryFilterPreset.SortOrder.get -> int
+LM.App.Wpf.Library.LibraryFilterPreset.SortOrder.set -> void
 LM.App.Wpf.Library.LibraryFilterPreset.State.get -> LM.App.Wpf.Library.LibraryFilterState!
 LM.App.Wpf.Library.LibraryFilterPreset.State.set -> void
 LM.App.Wpf.Library.LibraryFilterPresetStore
 LM.App.Wpf.Library.LibraryFilterPresetStore.DeletePresetAsync(string! name, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.LibraryFilterPresetStore.CreateFolderAsync(string! parentFolderId, string! name, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.App.Wpf.Library.LibraryFilterPresetStore.DeleteFolderAsync(string! folderId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.LibraryFilterPresetStore.GetHierarchyAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.LibraryPresetFolder!>!
+LM.App.Wpf.Library.LibraryFilterPresetStore.MoveFolderAsync(string! folderId, string! targetFolderId, int insertIndex, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.LibraryFilterPresetStore.MovePresetAsync(string! presetId, string! targetFolderId, int insertIndex, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.App.Wpf.Library.LibraryFilterPresetStore.LibraryFilterPresetStore(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
 LM.App.Wpf.Library.LibraryFilterPresetStore.ListPresetsAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Library.LibraryFilterPreset!>!>!
 LM.App.Wpf.Library.LibraryFilterPresetStore.SavePresetAsync(LM.App.Wpf.Library.LibraryFilterPreset! preset, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.LibraryFilterPresetStore.SavePresetAsync(LM.App.Wpf.Library.LibraryFilterPreset! preset, string? targetFolderId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.App.Wpf.Library.LibraryFilterPresetStore.TryGetPresetAsync(string! name, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.LibraryFilterPreset?>!
+LM.App.Wpf.Library.LibraryFilterPresetStore.TryGetPresetByIdAsync(string! presetId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.LibraryFilterPreset?>!
+LM.App.Wpf.Library.LibraryPresetFolder
+LM.App.Wpf.Library.LibraryPresetFolder.Clone() -> LM.App.Wpf.Library.LibraryPresetFolder!
+LM.App.Wpf.Library.LibraryPresetFolder.EnumerateChildren() -> System.Collections.Generic.IEnumerable<LM.App.Wpf.Library.LibraryPresetTreeItem>
+LM.App.Wpf.Library.LibraryPresetFolder.Folders.get -> System.Collections.Generic.List<LM.App.Wpf.Library.LibraryPresetFolder!>!
+LM.App.Wpf.Library.LibraryPresetFolder.Folders.set -> void
+LM.App.Wpf.Library.LibraryPresetFolder.Id.get -> string!
+LM.App.Wpf.Library.LibraryPresetFolder.Id.set -> void
+LM.App.Wpf.Library.LibraryPresetFolder.LibraryPresetFolder() -> void
+LM.App.Wpf.Library.LibraryPresetFolder.Name.get -> string!
+LM.App.Wpf.Library.LibraryPresetFolder.Name.set -> void
+LM.App.Wpf.Library.LibraryPresetFolder.Presets.get -> System.Collections.Generic.List<LM.App.Wpf.Library.LibraryFilterPreset!>!
+LM.App.Wpf.Library.LibraryPresetFolder.Presets.set -> void
+LM.App.Wpf.Library.LibraryPresetFolder.SortOrder.get -> int
+LM.App.Wpf.Library.LibraryPresetFolder.SortOrder.set -> void
+LM.App.Wpf.Library.LibraryPresetNodeKind
+LM.App.Wpf.Library.LibraryPresetTreeItem
+LM.App.Wpf.Library.LibraryPresetTreeItem.Folder.get -> LM.App.Wpf.Library.LibraryPresetFolder?
+LM.App.Wpf.Library.LibraryPresetTreeItem.Kind.get -> LM.App.Wpf.Library.LibraryPresetNodeKind
+LM.App.Wpf.Library.LibraryPresetTreeItem.LibraryPresetTreeItem(LM.App.Wpf.Library.LibraryPresetNodeKind kind, int sortOrder, LM.App.Wpf.Library.LibraryPresetFolder? folder, LM.App.Wpf.Library.LibraryFilterPreset? preset) -> void
+LM.App.Wpf.Library.LibraryPresetTreeItem.Preset.get -> LM.App.Wpf.Library.LibraryFilterPreset?
+LM.App.Wpf.Library.LibraryPresetTreeItem.SortOrder.get -> int
 LM.App.Wpf.Library.ILibraryEntryEditor
 LM.App.Wpf.Library.ILibraryEntryEditor.EditEntryAsync(LM.Core.Models.Entry! entry) -> System.Threading.Tasks.Task<System.Boolean>!
 LM.App.Wpf.Library.LibraryFilterState
@@ -306,11 +344,11 @@ LM.App.Wpf.ViewModels.AddViewModel.StagingListViewModel.get -> LM.App.Wpf.ViewMo
 LM.App.Wpf.ViewModels.AddViewModel.WatchedFolders.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.WatchedFolder!>!
 LM.App.Wpf.ViewModels.AddViewModel.WatchedFoldersViewModel.get -> LM.App.Wpf.ViewModels.WatchedFoldersViewModel!
 LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel
-LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel.DeletedPresetNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel.DeletedPresetIds.get -> System.Collections.Generic.IReadOnlyList<string!>!
 LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel.Initialize(LM.App.Wpf.Common.LibraryPresetSelectionContext! context) -> void
 LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel.LibraryPresetPickerDialogViewModel() -> void
 LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel.Presets.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.Common.LibraryPresetSummary!>!
-LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel.SelectedPresetName.get -> string?
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetPickerDialogViewModel.SelectedPresetId.get -> string?
 LM.App.Wpf.ViewModels.Dialogs.LitSearchRunEntryItemViewModel
 LM.App.Wpf.ViewModels.Dialogs.LitSearchRunEntryItemViewModel.EntryId.get -> string!
 LM.App.Wpf.ViewModels.Dialogs.LitSearchRunEntryItemViewModel.HookAbsolutePath.get -> string!
@@ -342,6 +380,9 @@ LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel.Initialize(LM.App
 LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel.LibraryPresetSaveDialogViewModel() -> void
 LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel.ResultName.get -> string!
 LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel.Title.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel.Title.set -> void
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel.Prompt.get -> string!
+LM.App.Wpf.ViewModels.Dialogs.LibraryPresetSaveDialogViewModel.Prompt.set -> void
 LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel
 LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel.Initialize(LM.App.Wpf.Common.SearchSavePromptContext! context) -> void
 LM.App.Wpf.ViewModels.Dialogs.SearchSaveDialogViewModel.ResultName.get -> string!
@@ -576,6 +617,43 @@ LM.App.Wpf.Library.AttachmentMetadataSelection.Title.get -> string!
 LM.App.Wpf.Library.AttachmentMetadataSelection.Title.init -> void
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.LibraryFiltersViewModel(LM.App.Wpf.Library.LibraryFilterPresetStore! presetStore, LM.App.Wpf.Common.ILibraryPresetPrompt! presetPrompt, LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchDragDropRequest
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchDragDropRequest.InsertIndex.get -> int
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchDragDropRequest.InsertIndex.init -> void
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchDragDropRequest.Source.get -> LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchNodeViewModel?
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchDragDropRequest.Source.init -> void
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchDragDropRequest.TargetFolder.get -> LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchFolderViewModel?
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchDragDropRequest.TargetFolder.init -> void
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchFolderViewModel
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchFolderViewModel.Children.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchNodeViewModel!>!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchFolderViewModel.SavedSearchFolderViewModel(LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel! tree, string! id, string! name, int sortOrder) -> void
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchNodeViewModel
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchNodeViewModel.Id.get -> string!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchNodeViewModel.Kind.get -> LM.App.Wpf.Library.LibraryPresetNodeKind
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchNodeViewModel.Name.get -> string
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchNodeViewModel.Name.set -> void
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchNodeViewModel.Parent.get -> LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchFolderViewModel?
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchNodeViewModel.SortOrder.get -> int
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchNodeViewModel.SortOrder.set -> void
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchNodeViewModel.Tree.get -> LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel.Preset.get -> LM.App.Wpf.Library.LibraryFilterPreset!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel.SavedSearchPresetViewModel(LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel! tree, LM.App.Wpf.Library.LibraryFilterPreset! preset, int sortOrder) -> void
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel.SavedUtc.get -> System.DateTime
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel.Summary.get -> LM.App.Wpf.Common.LibraryPresetSummary
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel.ToSummary() -> LM.App.Wpf.Common.LibraryPresetSummary
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeChangedEventArgs
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeChangedEventArgs.Presets.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Common.LibraryPresetSummary!>!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeChangedEventArgs.SavedSearchTreeChangedEventArgs(System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Common.LibraryPresetSummary!>! presets) -> void
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.CreateFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchFolderViewModel?>!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.DeleteFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchFolderViewModel>!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.DeletePresetCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel>!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.MoveCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchDragDropRequest>!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.RefreshAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.Root.get -> LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchFolderViewModel!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.SavedSearchTreeViewModel(LM.App.Wpf.Library.LibraryFilterPresetStore! store, LM.App.Wpf.Common.ILibraryPresetPrompt! prompt) -> void
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.TreeChanged -> System.EventHandler<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeChangedEventArgs!>?
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.ClearCommand.get -> CommunityToolkit.Mvvm.Input.IRelayCommand!
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.ApplyPresetAsync(LM.App.Wpf.Common.LibraryPresetSummary! summary, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel.ApplyState(LM.App.Wpf.Library.LibraryFilterState! state) -> void
@@ -831,6 +909,8 @@ LM.App.Wpf.Views.Behaviors.FileDropRequest.DropTarget.init -> void
 LM.App.Wpf.Views.Behaviors.FileDropRequest.FileDropRequest(System.Collections.Generic.IReadOnlyList<string!>! Paths, object? DropTarget, System.Windows.DragEventArgs! Args) -> void
 LM.App.Wpf.Views.Behaviors.FileDropRequest.Paths.get -> System.Collections.Generic.IReadOnlyList<string!>!
 LM.App.Wpf.Views.Behaviors.FileDropRequest.Paths.init -> void
+LM.App.Wpf.Views.Behaviors.SavedSearchTreeDragDropBehavior
+LM.App.Wpf.Views.Behaviors.SavedSearchTreeDragDropBehavior.SavedSearchTreeDragDropBehavior() -> void
 LM.App.Wpf.Views.AddView.AddView() -> void
 LM.App.Wpf.Views.AddView.InitializeComponent() -> void
 LM.App.Wpf.Views.LibraryPresetPickerDialog

--- a/src/LM.App.Wpf/ViewModels/Dialogs/LibraryPresetPickerDialogViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Dialogs/LibraryPresetPickerDialogViewModel.cs
@@ -24,9 +24,9 @@ namespace LM.App.Wpf.ViewModels.Dialogs
         [ObservableProperty]
         private bool allowLoad;
 
-        public IReadOnlyList<string> DeletedPresetNames => _deleted;
+        public IReadOnlyList<string> DeletedPresetIds => _deleted;
 
-        public string? SelectedPresetName { get; private set; }
+        public string? SelectedPresetId { get; private set; }
 
         public void Initialize(LibraryPresetSelectionContext context)
         {
@@ -36,7 +36,7 @@ namespace LM.App.Wpf.ViewModels.Dialogs
             Title = context.Title;
             AllowLoad = context.AllowLoad;
             _deleted.Clear();
-            SelectedPresetName = null;
+            SelectedPresetId = null;
 
             Presets.Clear();
             foreach (var preset in context.Presets.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase))
@@ -65,7 +65,10 @@ namespace LM.App.Wpf.ViewModels.Dialogs
             if (confirm != System.Windows.MessageBoxResult.Yes)
                 return;
 
-            _deleted.Add(SelectedPreset.Name);
+            if (!string.IsNullOrWhiteSpace(SelectedPreset.Id))
+            {
+                _deleted.Add(SelectedPreset.Id);
+            }
             var index = Presets.IndexOf(SelectedPreset);
             Presets.Remove(SelectedPreset);
 
@@ -80,7 +83,7 @@ namespace LM.App.Wpf.ViewModels.Dialogs
             if (!AllowLoad || SelectedPreset is null)
                 return;
 
-            SelectedPresetName = SelectedPreset.Name;
+            SelectedPresetId = SelectedPreset.Id;
             RequestClose(true);
         }
 

--- a/src/LM.App.Wpf/ViewModels/Library/LibraryFiltersViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LibraryFiltersViewModel.cs
@@ -13,6 +13,7 @@ using CommunityToolkit.Mvvm.Input;
 using LM.App.Wpf.Common;
 using LM.App.Wpf.Library;
 using LM.App.Wpf.Library.Search;
+using LM.App.Wpf.ViewModels.Library.SavedSearches;
 using LM.Core.Abstractions;
 using LM.Core.Models;
 using LM.Core.Models.Search;
@@ -34,6 +35,7 @@ namespace LM.App.Wpf.ViewModels.Library
         private bool _initialized;
         private bool _suppressLeftPanelSync;
         private bool _suppressRightPanelSync;
+        private bool _suppressNavigationRefresh;
         private double _lastLeftPanelWidth = DefaultLeftPanelWidth;
         private double _lastRightPanelWidth = DefaultRightPanelWidth;
         private static readonly System.StringComparer TagComparer = System.StringComparer.OrdinalIgnoreCase;
@@ -92,6 +94,8 @@ namespace LM.App.Wpf.ViewModels.Library
 
         public bool HasSavedPresets => SavedPresets.Count > 0;
 
+        public SavedSearchTreeViewModel SavedSearches { get; }
+
         public IReadOnlyList<string> KeywordTokens { get; } = LibrarySearchFieldMap.GetDisplayTokens();
 
         public string KeywordTooltip { get; } = BuildKeywordTooltip();
@@ -109,6 +113,9 @@ namespace LM.App.Wpf.ViewModels.Library
             _presetPrompt = presetPrompt ?? throw new ArgumentNullException(nameof(presetPrompt));
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+
+            SavedSearches = new SavedSearchTreeViewModel(_presetStore, _presetPrompt);
+            SavedSearches.TreeChanged += OnSavedSearchTreeChanged;
 
             RemoveTagCommand = new RelayCommand<string?>(RemoveTag, CanRemoveTag);
             SelectedTags.CollectionChanged += OnSelectedTagsCollectionChanged;
@@ -351,7 +358,6 @@ namespace LM.App.Wpf.ViewModels.Library
             try
             {
                 await RefreshSavedPresetsAsync(ct).ConfigureAwait(false);
-                await RefreshNavigationAsync(ct).ConfigureAwait(false);
                 _initialized = true;
             }
             catch (Exception ex) when (!ct.IsCancellationRequested)
@@ -503,9 +509,8 @@ namespace LM.App.Wpf.ViewModels.Library
                     State = CaptureState()
                 };
 
-                await _presetStore.SavePresetAsync(preset).ConfigureAwait(false);
+                await _presetStore.SavePresetAsync(preset, LibraryPresetFolder.RootId).ConfigureAwait(false);
                 await RefreshSavedPresetsAsync().ConfigureAwait(false);
-                await RefreshNavigationAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -533,7 +538,7 @@ namespace LM.App.Wpf.ViewModels.Library
                     return;
                 }
 
-                var summaries = presets.Select(p => new LibraryPresetSummary(p.Name, p.SavedUtc)).ToArray();
+                var summaries = presets.Select(p => new LibraryPresetSummary(p.Id, p.Name, p.SavedUtc)).ToArray();
                 var result = await _presetPrompt.RequestSelectionAsync(
                     new LibraryPresetSelectionContext(summaries, AllowLoad: true, "Load Saved Search")).ConfigureAwait(false);
                 if (result is null)
@@ -541,14 +546,17 @@ namespace LM.App.Wpf.ViewModels.Library
                     return;
                 }
 
-                await DeletePresetsAsync(result.DeletedPresetNames).ConfigureAwait(false);
-                if (string.IsNullOrWhiteSpace(result.SelectedPresetName))
+                await DeletePresetsAsync(result.DeletedPresetIds).ConfigureAwait(false);
+                if (string.IsNullOrWhiteSpace(result.SelectedPresetId))
                 {
                     return;
                 }
 
-                var summary = new LibraryPresetSummary(result.SelectedPresetName!, DateTime.UtcNow);
-                await ApplyPresetAsync(summary).ConfigureAwait(false);
+                var summary = summaries.FirstOrDefault(s => string.Equals(s.Id, result.SelectedPresetId, StringComparison.Ordinal));
+                if (summary is not null)
+                {
+                    await ApplyPresetAsync(summary).ConfigureAwait(false);
+                }
             }
             catch (Exception ex)
             {
@@ -576,7 +584,7 @@ namespace LM.App.Wpf.ViewModels.Library
                     return;
                 }
 
-                var summaries = presets.Select(p => new LibraryPresetSummary(p.Name, p.SavedUtc)).ToArray();
+                var summaries = presets.Select(p => new LibraryPresetSummary(p.Id, p.Name, p.SavedUtc)).ToArray();
                 var result = await _presetPrompt.RequestSelectionAsync(
                     new LibraryPresetSelectionContext(summaries, AllowLoad: false, "Manage Saved Searches")).ConfigureAwait(false);
                 if (result is null)
@@ -584,7 +592,7 @@ namespace LM.App.Wpf.ViewModels.Library
                     return;
                 }
 
-                await DeletePresetsAsync(result.DeletedPresetNames).ConfigureAwait(false);
+                await DeletePresetsAsync(result.DeletedPresetIds).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -609,7 +617,8 @@ namespace LM.App.Wpf.ViewModels.Library
 
             try
             {
-                var preset = await _presetStore.TryGetPresetAsync(summary.Name, ct).ConfigureAwait(false);
+                var preset = await _presetStore.TryGetPresetByIdAsync(summary.Id, ct).ConfigureAwait(false)
+                             ?? await _presetStore.TryGetPresetAsync(summary.Name, ct).ConfigureAwait(false);
                 if (preset is null)
                 {
                     await RefreshSavedPresetsAsync(ct).ConfigureAwait(false);
@@ -798,25 +807,24 @@ namespace LM.App.Wpf.ViewModels.Library
             return File.Exists(combined) ? combined : null;
         }
 
-        private async Task DeletePresetsAsync(IReadOnlyList<string> names, CancellationToken ct = default)
+        private async Task DeletePresetsAsync(IReadOnlyList<string> ids, CancellationToken ct = default)
         {
-            if (names is null || names.Count == 0)
+            if (ids is null || ids.Count == 0)
             {
                 return;
             }
 
-            foreach (var name in names)
+            foreach (var id in ids)
             {
-                if (string.IsNullOrWhiteSpace(name))
+                if (string.IsNullOrWhiteSpace(id))
                 {
                     continue;
                 }
 
-                await _presetStore.DeletePresetAsync(name, ct).ConfigureAwait(false);
+                await _presetStore.DeletePresetAsync(id, ct).ConfigureAwait(false);
             }
 
             await RefreshSavedPresetsAsync(ct).ConfigureAwait(false);
-            await RefreshNavigationAsync(ct).ConfigureAwait(false);
         }
 
         private string BuildDefaultPresetName(IReadOnlyList<LibraryFilterPreset> existing)
@@ -849,17 +857,28 @@ namespace LM.App.Wpf.ViewModels.Library
             await _presetLock.WaitAsync(ct).ConfigureAwait(false);
             try
             {
-                var presets = await _presetStore.ListPresetsAsync(ct).ConfigureAwait(false);
-                var summaries = presets
-                    .Select(p => new LibraryPresetSummary(p.Name, p.SavedUtc))
-                    .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
-                    .ToArray();
-
-                await InvokeOnDispatcherAsync(() => SavedPresets = summaries).ConfigureAwait(false);
+                _suppressNavigationRefresh = true;
+                await SavedSearches.RefreshAsync(ct).ConfigureAwait(false);
             }
             finally
             {
+                _suppressNavigationRefresh = false;
                 _presetLock.Release();
+            }
+
+            if (!ct.IsCancellationRequested)
+            {
+                await RefreshNavigationAsync(ct).ConfigureAwait(false);
+            }
+        }
+
+        private void OnSavedSearchTreeChanged(object? sender, SavedSearchTreeChangedEventArgs e)
+        {
+            var _ = InvokeOnDispatcherAsync(() => SavedPresets = e.Presets);
+            if (!_suppressNavigationRefresh)
+            {
+                Trace.WriteLine($"[LibraryFiltersViewModel] Saved search tree changed; scheduling navigation refresh for {e.Presets.Count} preset(s).");
+                _ = RefreshNavigationAsync();
             }
         }
 

--- a/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchFolderViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchFolderViewModel.cs
@@ -1,0 +1,17 @@
+using System.Collections.ObjectModel;
+
+namespace LM.App.Wpf.ViewModels.Library.SavedSearches
+{
+    public sealed partial class SavedSearchFolderViewModel : SavedSearchNodeViewModel
+    {
+        public SavedSearchFolderViewModel(SavedSearchTreeViewModel tree,
+                                          string id,
+                                          string name,
+                                          int sortOrder)
+            : base(tree, id, name, LibraryPresetNodeKind.Folder, sortOrder)
+        {
+        }
+
+        public ObservableCollection<SavedSearchNodeViewModel> Children { get; } = new();
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchNodeViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchNodeViewModel.cs
@@ -1,0 +1,35 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace LM.App.Wpf.ViewModels.Library.SavedSearches
+{
+    public abstract partial class SavedSearchNodeViewModel : ObservableObject
+    {
+        protected SavedSearchNodeViewModel(SavedSearchTreeViewModel tree,
+                                           string id,
+                                           string name,
+                                           LibraryPresetNodeKind kind,
+                                           int sortOrder)
+        {
+            Tree = tree ?? throw new ArgumentNullException(nameof(tree));
+            Id = string.IsNullOrWhiteSpace(id) ? throw new ArgumentException("Id cannot be null", nameof(id)) : id;
+            this.name = name ?? string.Empty;
+            Kind = kind;
+            this.sortOrder = sortOrder;
+        }
+
+        public SavedSearchTreeViewModel Tree { get; }
+
+        public string Id { get; }
+
+        public LibraryPresetNodeKind Kind { get; }
+
+        public SavedSearchFolderViewModel? Parent { get; internal set; }
+
+        [ObservableProperty]
+        private string name = string.Empty;
+
+        [ObservableProperty]
+        private int sortOrder;
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchPresetViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchPresetViewModel.cs
@@ -1,0 +1,24 @@
+using System;
+using LM.App.Wpf.Library;
+
+namespace LM.App.Wpf.ViewModels.Library.SavedSearches
+{
+    public sealed partial class SavedSearchPresetViewModel : SavedSearchNodeViewModel
+    {
+        public SavedSearchPresetViewModel(SavedSearchTreeViewModel tree,
+                                          LibraryFilterPreset preset,
+                                          int sortOrder)
+            : base(tree, preset.Id, preset.Name, LibraryPresetNodeKind.Preset, sortOrder)
+        {
+            Preset = preset ?? throw new ArgumentNullException(nameof(preset));
+        }
+
+        public LibraryFilterPreset Preset { get; }
+
+        public DateTime SavedUtc => Preset.SavedUtc;
+
+        public LibraryPresetSummary ToSummary() => new(Preset.Id, Preset.Name, Preset.SavedUtc);
+
+        public LibraryPresetSummary Summary => ToSummary();
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchTreeViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchTreeViewModel.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LM.App.Wpf.Common;
+using LM.App.Wpf.Library;
+
+namespace LM.App.Wpf.ViewModels.Library.SavedSearches
+{
+    public sealed partial class SavedSearchTreeViewModel : ObservableObject
+    {
+        private readonly LibraryFilterPresetStore _store;
+        private readonly ILibraryPresetPrompt _prompt;
+        private readonly SemaphoreSlim _refreshLock = new(1, 1);
+
+        public SavedSearchTreeViewModel(LibraryFilterPresetStore store, ILibraryPresetPrompt prompt)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            _prompt = prompt ?? throw new ArgumentNullException(nameof(prompt));
+
+            Root = new SavedSearchFolderViewModel(this, LibraryPresetFolder.RootId, "Saved Searches", 0);
+
+            CreateFolderCommand = new AsyncRelayCommand<SavedSearchFolderViewModel?>(CreateFolderAsync);
+            DeleteFolderCommand = new AsyncRelayCommand<SavedSearchFolderViewModel>(DeleteFolderAsync, CanDeleteFolder);
+            DeletePresetCommand = new AsyncRelayCommand<SavedSearchPresetViewModel>(DeletePresetAsync, preset => preset is not null);
+            MoveCommand = new AsyncRelayCommand<SavedSearchDragDropRequest>(MoveAsync, request => request?.Source is not null);
+        }
+
+        public SavedSearchFolderViewModel Root { get; }
+
+        public IAsyncRelayCommand<SavedSearchFolderViewModel?> CreateFolderCommand { get; }
+
+        public IAsyncRelayCommand<SavedSearchFolderViewModel> DeleteFolderCommand { get; }
+
+        public IAsyncRelayCommand<SavedSearchPresetViewModel> DeletePresetCommand { get; }
+
+        public IAsyncRelayCommand<SavedSearchDragDropRequest> MoveCommand { get; }
+
+        public event EventHandler<SavedSearchTreeChangedEventArgs>? TreeChanged;
+
+        public async Task RefreshAsync(CancellationToken ct = default)
+        {
+            await _refreshLock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                var hierarchy = await _store.GetHierarchyAsync(ct).ConfigureAwait(false);
+                var summaries = new List<LibraryPresetSummary>();
+
+                await InvokeOnDispatcherAsync(() =>
+                {
+                    Root.Children.Clear();
+                    foreach (var node in BuildNodes(hierarchy, Root, summaries))
+                    {
+                        Root.Children.Add(node);
+                    }
+                }).ConfigureAwait(false);
+
+                OnTreeChanged(summaries);
+                Trace.WriteLine($"[SavedSearchTreeViewModel] Refreshed hierarchy with {summaries.Count} preset(s).");
+            }
+            finally
+            {
+                _refreshLock.Release();
+            }
+        }
+
+        private async Task CreateFolderAsync(SavedSearchFolderViewModel? parent)
+        {
+            var target = parent ?? Root;
+            var existing = await InvokeOnDispatcherAsync(() => target.Children
+                .OfType<SavedSearchFolderViewModel>()
+                .Select(folder => folder.Name)
+                .ToArray()).ConfigureAwait(false);
+
+            var context = new LibraryPresetSaveContext(
+                "New folder",
+                existing,
+                "Create Folder",
+                "Name this folder.");
+
+            var result = await _prompt.RequestSaveAsync(context).ConfigureAwait(false);
+            if (result is null || string.IsNullOrWhiteSpace(result.Name))
+            {
+                return;
+            }
+
+            await _store.CreateFolderAsync(target.Id, result.Name.Trim(), CancellationToken.None).ConfigureAwait(false);
+            Trace.WriteLine($"[SavedSearchTreeViewModel] Created folder '{result.Name}' under '{target.Id}'.");
+            await RefreshAsync().ConfigureAwait(false);
+        }
+
+        private bool CanDeleteFolder(SavedSearchFolderViewModel? folder)
+        {
+            return folder is not null && !string.Equals(folder.Id, LibraryPresetFolder.RootId, StringComparison.Ordinal);
+        }
+
+        private async Task DeleteFolderAsync(SavedSearchFolderViewModel folder)
+        {
+            if (!CanDeleteFolder(folder))
+            {
+                return;
+            }
+
+            var result = System.Windows.MessageBox.Show(
+                $"Delete folder '{folder.Name}' and all saved searches within it?",
+                "Delete Folder",
+                System.Windows.MessageBoxButton.YesNo,
+                System.Windows.MessageBoxImage.Warning);
+
+            if (result != System.Windows.MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            await _store.DeleteFolderAsync(folder.Id, CancellationToken.None).ConfigureAwait(false);
+            Trace.WriteLine($"[SavedSearchTreeViewModel] Deleted folder '{folder.Id}'.");
+            await RefreshAsync().ConfigureAwait(false);
+        }
+
+        private async Task DeletePresetAsync(SavedSearchPresetViewModel preset)
+        {
+            if (preset is null)
+            {
+                return;
+            }
+
+            var result = System.Windows.MessageBox.Show(
+                $"Delete saved search '{preset.Name}'?",
+                "Delete Saved Search",
+                System.Windows.MessageBoxButton.YesNo,
+                System.Windows.MessageBoxImage.Question);
+
+            if (result != System.Windows.MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            await _store.DeletePresetAsync(preset.Id, CancellationToken.None).ConfigureAwait(false);
+            Trace.WriteLine($"[SavedSearchTreeViewModel] Deleted preset '{preset.Id}'.");
+            await RefreshAsync().ConfigureAwait(false);
+        }
+
+        private async Task MoveAsync(SavedSearchDragDropRequest? request)
+        {
+            if (request is null || request.Source is null || request.TargetFolder is null)
+            {
+                return;
+            }
+
+            if (request.Source is SavedSearchFolderViewModel folder)
+            {
+                await _store.MoveFolderAsync(folder.Id, request.TargetFolder.Id, request.InsertIndex, CancellationToken.None).ConfigureAwait(false);
+                Trace.WriteLine($"[SavedSearchTreeViewModel] Requested move of folder '{folder.Id}' to '{request.TargetFolder.Id}' at {request.InsertIndex}.");
+            }
+            else if (request.Source is SavedSearchPresetViewModel preset)
+            {
+                await _store.MovePresetAsync(preset.Id, request.TargetFolder.Id, request.InsertIndex, CancellationToken.None).ConfigureAwait(false);
+                Trace.WriteLine($"[SavedSearchTreeViewModel] Requested move of preset '{preset.Id}' to '{request.TargetFolder.Id}' at {request.InsertIndex}.");
+            }
+
+            await RefreshAsync().ConfigureAwait(false);
+        }
+
+        private IEnumerable<SavedSearchNodeViewModel> BuildNodes(LibraryPresetFolder source,
+                                                                  SavedSearchFolderViewModel parent,
+                                                                  List<LibraryPresetSummary> summaries)
+        {
+            var nodes = new List<SavedSearchNodeViewModel>();
+
+            foreach (var item in source.EnumerateChildren())
+            {
+                switch (item.Kind)
+                {
+                    case LibraryPresetNodeKind.Folder when item.Folder is not null:
+                    {
+                        var folderVm = new SavedSearchFolderViewModel(this, item.Folder.Id, item.Folder.Name, item.Folder.SortOrder)
+                        {
+                            Parent = parent
+                        };
+
+                        foreach (var child in BuildNodes(item.Folder, folderVm, summaries))
+                        {
+                            folderVm.Children.Add(child);
+                        }
+
+                        nodes.Add(folderVm);
+                        break;
+                    }
+
+                    case LibraryPresetNodeKind.Preset when item.Preset is not null:
+                    {
+                        var presetVm = new SavedSearchPresetViewModel(this, item.Preset, item.Preset.SortOrder)
+                        {
+                            Parent = parent
+                        };
+
+                        summaries.Add(presetVm.ToSummary());
+                        nodes.Add(presetVm);
+                        break;
+                    }
+                }
+            }
+
+            return nodes
+                .OrderBy(static node => node.SortOrder)
+                .ToList();
+        }
+
+        private void OnTreeChanged(IReadOnlyList<LibraryPresetSummary> summaries)
+        {
+            TreeChanged?.Invoke(this, new SavedSearchTreeChangedEventArgs(summaries.ToArray()));
+        }
+
+        private static Task InvokeOnDispatcherAsync(Action action)
+        {
+            if (action is null)
+                throw new ArgumentNullException(nameof(action));
+
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher is null || dispatcher.CheckAccess())
+            {
+                action();
+                return Task.CompletedTask;
+            }
+
+            return dispatcher.InvokeAsync(action).Task;
+        }
+
+        private static Task<TResult> InvokeOnDispatcherAsync<TResult>(Func<TResult> action)
+        {
+            if (action is null)
+                throw new ArgumentNullException(nameof(action));
+
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher is null || dispatcher.CheckAccess())
+            {
+                return Task.FromResult(action());
+            }
+
+            return dispatcher.InvokeAsync(action).Task;
+        }
+    }
+
+    public sealed class SavedSearchTreeChangedEventArgs : EventArgs
+    {
+        public SavedSearchTreeChangedEventArgs(IReadOnlyList<LibraryPresetSummary> presets)
+        {
+            Presets = presets ?? Array.Empty<LibraryPresetSummary>();
+        }
+
+        public IReadOnlyList<LibraryPresetSummary> Presets { get; }
+    }
+
+    public sealed class SavedSearchDragDropRequest
+    {
+        public SavedSearchNodeViewModel? Source { get; init; }
+
+        public SavedSearchFolderViewModel? TargetFolder { get; init; }
+
+        public int InsertIndex { get; init; }
+    }
+}

--- a/src/LM.App.Wpf/Views/Behaviors/SavedSearchTreeDragDropBehavior.cs
+++ b/src/LM.App.Wpf/Views/Behaviors/SavedSearchTreeDragDropBehavior.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using LM.App.Wpf.ViewModels.Library.SavedSearches;
+using Microsoft.Xaml.Behaviors;
+
+namespace LM.App.Wpf.Views.Behaviors
+{
+    public sealed class SavedSearchTreeDragDropBehavior : Behavior<TreeView>
+    {
+        private Point? _dragStart;
+        private SavedSearchNodeViewModel? _dragSource;
+
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+            AssociatedObject.PreviewMouseLeftButtonDown += OnPreviewMouseLeftButtonDown;
+            AssociatedObject.PreviewMouseMove += OnPreviewMouseMove;
+            AssociatedObject.DragOver += OnDragOver;
+            AssociatedObject.Drop += OnDrop;
+        }
+
+        protected override void OnDetaching()
+        {
+            base.OnDetaching();
+
+            AssociatedObject.PreviewMouseLeftButtonDown -= OnPreviewMouseLeftButtonDown;
+            AssociatedObject.PreviewMouseMove -= OnPreviewMouseMove;
+            AssociatedObject.DragOver -= OnDragOver;
+            AssociatedObject.Drop -= OnDrop;
+        }
+
+        private void OnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            var item = FindTreeViewItem(e.OriginalSource as DependencyObject);
+            if (item?.DataContext is SavedSearchNodeViewModel node)
+            {
+                _dragStart = e.GetPosition(AssociatedObject);
+                _dragSource = node;
+            }
+            else
+            {
+                _dragStart = null;
+                _dragSource = null;
+            }
+        }
+
+        private void OnPreviewMouseMove(object sender, MouseEventArgs e)
+        {
+            if (_dragStart is null || _dragSource is null || e.LeftButton != MouseButtonState.Pressed)
+            {
+                return;
+            }
+
+            var currentPosition = e.GetPosition(AssociatedObject);
+            if (Math.Abs(currentPosition.X - _dragStart.Value.X) < SystemParameters.MinimumHorizontalDragDistance &&
+                Math.Abs(currentPosition.Y - _dragStart.Value.Y) < SystemParameters.MinimumVerticalDragDistance)
+            {
+                return;
+            }
+
+            var data = new DataObject(typeof(SavedSearchNodeViewModel), _dragSource);
+            DragDrop.DoDragDrop(AssociatedObject, data, DragDropEffects.Move);
+            _dragStart = null;
+            _dragSource = null;
+        }
+
+        private void OnDragOver(object sender, DragEventArgs e)
+        {
+            if (!TryGetDragSource(e, out var source) || !TryGetTree(out var tree))
+            {
+                e.Effects = DragDropEffects.None;
+                e.Handled = true;
+                return;
+            }
+
+            if (!TryGetDropInfo(e.OriginalSource as DependencyObject, tree, source, out var targetFolder, out var insertIndex))
+            {
+                e.Effects = DragDropEffects.None;
+                e.Handled = true;
+                return;
+            }
+
+            if (source is SavedSearchFolderViewModel folder && IsAncestor(folder, targetFolder))
+            {
+                e.Effects = DragDropEffects.None;
+                e.Handled = true;
+                return;
+            }
+
+            e.Effects = DragDropEffects.Move;
+            e.Handled = true;
+        }
+
+        private async void OnDrop(object sender, DragEventArgs e)
+        {
+            if (!TryGetDragSource(e, out var source) || !TryGetTree(out var tree))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (!TryGetDropInfo(e.OriginalSource as DependencyObject, tree, source, out var targetFolder, out var insertIndex))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (source is SavedSearchFolderViewModel folder && IsAncestor(folder, targetFolder))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            if (source.Parent == targetFolder)
+            {
+                var currentIndex = targetFolder.Children.IndexOf(source);
+                if (currentIndex < insertIndex)
+                {
+                    insertIndex--;
+                }
+            }
+
+            var request = new SavedSearchDragDropRequest
+            {
+                Source = source,
+                TargetFolder = targetFolder,
+                InsertIndex = Math.Max(0, insertIndex)
+            };
+
+            if (tree.MoveCommand.CanExecute(request))
+            {
+                await tree.MoveCommand.ExecuteAsync(request);
+            }
+
+            e.Handled = true;
+        }
+
+        private static bool TryGetDragSource(DragEventArgs e, out SavedSearchNodeViewModel? source)
+        {
+            source = e.Data.GetData(typeof(SavedSearchNodeViewModel)) as SavedSearchNodeViewModel;
+            return source is not null;
+        }
+
+        private bool TryGetTree(out SavedSearchTreeViewModel tree)
+        {
+            tree = AssociatedObject.DataContext as SavedSearchTreeViewModel;
+            return tree is not null;
+        }
+
+        private static bool TryGetDropInfo(DependencyObject? sourceElement,
+                                           SavedSearchTreeViewModel tree,
+                                           out SavedSearchFolderViewModel targetFolder,
+                                           out int insertIndex)
+        {
+            var item = FindTreeViewItem(sourceElement);
+            switch (item?.DataContext)
+            {
+                case SavedSearchFolderViewModel folder:
+                    targetFolder = folder;
+                    insertIndex = folder.Children.Count;
+                    return true;
+                case SavedSearchPresetViewModel preset:
+                    targetFolder = preset.Parent ?? tree.Root;
+                    insertIndex = targetFolder.Children.IndexOf(preset);
+                    return true;
+                default:
+                    targetFolder = tree.Root;
+                    insertIndex = tree.Root.Children.Count;
+                    return true;
+            }
+        }
+
+        private static bool IsAncestor(SavedSearchFolderViewModel ancestor, SavedSearchFolderViewModel candidate)
+        {
+            var current = candidate;
+            while (current is not null)
+            {
+                if (ReferenceEquals(current, ancestor))
+                {
+                    return true;
+                }
+
+                current = current.Parent;
+            }
+
+            return false;
+        }
+
+        private static TreeViewItem? FindTreeViewItem(DependencyObject? current)
+        {
+            while (current is not null && current is not TreeViewItem)
+            {
+                current = VisualTreeHelper.GetParent(current);
+            }
+
+            return current as TreeViewItem;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Views/LibraryPresetPrompt.cs
+++ b/src/LM.App.Wpf/Views/LibraryPresetPrompt.cs
@@ -53,12 +53,12 @@ namespace LM.App.Wpf.Views
 
                 dialog.ShowDialog();
 
-                if (viewModel.DeletedPresetNames.Count == 0 && string.IsNullOrEmpty(viewModel.SelectedPresetName))
+                if (viewModel.DeletedPresetIds.Count == 0 && string.IsNullOrEmpty(viewModel.SelectedPresetId))
                     return null;
 
                 return new LibraryPresetSelectionResult(
-                    viewModel.SelectedPresetName,
-                    viewModel.DeletedPresetNames.ToList());
+                    viewModel.SelectedPresetId,
+                    viewModel.DeletedPresetIds.ToList());
             });
         }
 

--- a/src/LM.App.Wpf/Views/LibraryPresetSaveDialog.xaml
+++ b/src/LM.App.Wpf/Views/LibraryPresetSaveDialog.xaml
@@ -24,7 +24,7 @@
 
     <TextBlock Grid.Row="0"
                Grid.ColumnSpan="2"
-               Text="Name this filter preset." />
+               Text="{Binding Prompt}" />
 
     <TextBlock Grid.Row="2"
                Grid.Column="0"

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -8,6 +8,7 @@
              xmlns:controls="clr-namespace:LM.App.Wpf.Views.Library.Controls"
              xmlns:converters="clr-namespace:LM.App.Wpf.Views.Converters"
              xmlns:viewModels="clr-namespace:LM.App.Wpf.ViewModels.Library"
+             xmlns:saved="clr-namespace:LM.App.Wpf.ViewModels.Library.SavedSearches"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:core="clr-namespace:Microsoft.Xaml.Behaviors.Core;assembly=Microsoft.Xaml.Behaviors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -121,6 +122,18 @@
                           BorderThickness="0,0,0,1"
                           Padding="6,4">
                                         <DockPanel>
+                                            <StackPanel DockPanel.Dock="Right"
+                                                        Orientation="Horizontal"
+                                                        HorizontalAlignment="Right">
+                                                <Button Content="Save search"
+                                                        Padding="8,4"
+                                                        Command="{Binding SavePresetCommand}"/>
+                                                <Button Content="New folder"
+                                                        Padding="8,4"
+                                                        Margin="4,0,0,0"
+                                                        Command="{Binding SavedSearches.CreateFolderCommand}"
+                                                        CommandParameter="{Binding SavedSearches.Root}"/>
+                                            </StackPanel>
                                             <ToggleButton DockPanel.Dock="Left"
                                     Name="SavedSearchToggle"
                                     IsChecked="True"
@@ -158,37 +171,61 @@
                                  Margin="4,0,0,0"/>
                                         </DockPanel>
                                     </Border>
-                                    <ItemsControl ItemsSource="{Binding SavedPresets}"
-                                Margin="0"
-                                Visibility="{Binding IsChecked, ElementName=SavedSearchToggle, Converter={StaticResource BoolToVisibilityConverter}}">
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <Button Content="{Binding Name}"
-                                Command="{Binding DataContext.Filters.LoadPresetCommand, ElementName=LibraryViewControl}"
-                                CommandParameter="{Binding}"
-                                HorizontalContentAlignment="Left"
-                                HorizontalAlignment="Stretch"
-                                Background="Transparent"
-                                BorderThickness="0"
-                                Padding="8,4">
-                                                    <Button.Template>
-                                                        <ControlTemplate TargetType="Button">
-                                                            <Border Background="{TemplateBinding Background}"
-                                      Padding="{TemplateBinding Padding}">
-                                                                <TextBlock Text="{TemplateBinding Content}" 
-                                           TextTrimming="CharacterEllipsis"/>
-                                                            </Border>
-                                                            <ControlTemplate.Triggers>
-                                                                <Trigger Property="IsMouseOver" Value="True">
-                                                                    <Setter Property="Background" Value="#F3F4F6"/>
-                                                                </Trigger>
-                                                            </ControlTemplate.Triggers>
-                                                        </ControlTemplate>
-                                                    </Button.Template>
-                                                </Button>
+                                    <TreeView Margin="0"
+                                              DataContext="{Binding SavedSearches}"
+                                              ItemsSource="{Binding Root.Children}"
+                                              Background="Transparent"
+                                              BorderThickness="0"
+                                              HorizontalContentAlignment="Stretch"
+                                              Visibility="{Binding IsChecked, ElementName=SavedSearchToggle, Converter={StaticResource BoolToVisibilityConverter}}">
+                                        <i:Interaction.Behaviors>
+                                            <behaviors:SavedSearchTreeDragDropBehavior />
+                                        </i:Interaction.Behaviors>
+                                        <TreeView.Resources>
+                                            <HierarchicalDataTemplate DataType="{x:Type saved:SavedSearchFolderViewModel}"
+                                                                      ItemsSource="{Binding Children}">
+                                                <TextBlock Text="{Binding Name}" Margin="4,2"/>
+                                                <HierarchicalDataTemplate.ItemContainerStyle>
+                                                    <Style TargetType="TreeViewItem">
+                                                        <Setter Property="IsExpanded" Value="True" />
+                                                        <Setter Property="ContextMenu">
+                                                            <Setter.Value>
+                                                                <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                                                    <MenuItem Header="New folder"
+                                                                              Command="{Binding Tree.CreateFolderCommand}"
+                                                                              CommandParameter="{Binding}" />
+                                                                    <MenuItem Header="Delete folder"
+                                                                              Command="{Binding Tree.DeleteFolderCommand}"
+                                                                              CommandParameter="{Binding}" />
+                                                                </ContextMenu>
+                                                            </Setter.Value>
+                                                        </Setter>
+                                                    </Style>
+                                                </HierarchicalDataTemplate.ItemContainerStyle>
+                                            </HierarchicalDataTemplate>
+                                            <DataTemplate DataType="{x:Type saved:SavedSearchPresetViewModel}">
+                                                <TextBlock Text="{Binding Name}"
+                                                           Margin="4,2"
+                                                           TextTrimming="CharacterEllipsis">
+                                                    <TextBlock.InputBindings>
+                                                        <MouseBinding MouseAction="LeftDoubleClick"
+                                                                      Command="{Binding DataContext.Filters.ApplyPresetCommand, ElementName=LibraryViewControl}"
+                                                                      CommandParameter="{Binding Summary}" />
+                                                    </TextBlock.InputBindings>
+                                                    <TextBlock.ContextMenu>
+                                                        <ContextMenu DataContext="{Binding}">
+                                                            <MenuItem Header="Load"
+                                                                      Command="{Binding DataContext.Filters.ApplyPresetCommand, ElementName=LibraryViewControl}"
+                                                                      CommandParameter="{Binding Summary}" />
+                                                            <MenuItem Header="Delete"
+                                                                      Command="{Binding Tree.DeletePresetCommand}"
+                                                                      CommandParameter="{Binding}" />
+                                                        </ContextMenu>
+                                                    </TextBlock.ContextMenu>
+                                                </TextBlock>
                                             </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
+                                        </TreeView.Resources>
+                                    </TreeView>
                                 </StackPanel>
                             </Border>
 


### PR DESCRIPTION
## Summary
- add hierarchical storage for library filter presets including migration from legacy flat data
- expose saved search tree view models with folder CRUD, drag/drop, and prompt updates
- replace the saved-search list UI with a TreeView wired to the hierarchy and persistence hooks

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68de65c36bb4832ba8af098d619666f6