### PR TITLE
Fix saved search drag-drop namespaces

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchFolderViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchFolderViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using LM.App.Wpf.Library;
 
 namespace LM.App.Wpf.ViewModels.Library.SavedSearches
 {

--- a/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchNodeViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchNodeViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using CommunityToolkit.Mvvm.ComponentModel;
+using LM.App.Wpf.Library;
 
 namespace LM.App.Wpf.ViewModels.Library.SavedSearches
 {

--- a/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchPresetViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchPresetViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using LM.App.Wpf.Common;
 using LM.App.Wpf.Library;
 
 namespace LM.App.Wpf.ViewModels.Library.SavedSearches

--- a/src/LM.App.Wpf/Views/Behaviors/SavedSearchTreeDragDropBehavior.cs
+++ b/src/LM.App.Wpf/Views/Behaviors/SavedSearchTreeDragDropBehavior.cs
@@ -1,16 +1,12 @@
 using System;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
-using System.Windows.Media;
 using LM.App.Wpf.ViewModels.Library.SavedSearches;
 using Microsoft.Xaml.Behaviors;
 
 namespace LM.App.Wpf.Views.Behaviors
 {
-    public sealed class SavedSearchTreeDragDropBehavior : Behavior<TreeView>
+    public sealed class SavedSearchTreeDragDropBehavior : Behavior<System.Windows.Controls.TreeView>
     {
-        private Point? _dragStart;
+        private System.Windows.Point? _dragStart;
         private SavedSearchNodeViewModel? _dragSource;
 
         protected override void OnAttached()
@@ -33,9 +29,9 @@ namespace LM.App.Wpf.Views.Behaviors
             AssociatedObject.Drop -= OnDrop;
         }
 
-        private void OnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        private void OnPreviewMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            var item = FindTreeViewItem(e.OriginalSource as DependencyObject);
+            var item = FindTreeViewItem(e.OriginalSource as System.Windows.DependencyObject);
             if (item?.DataContext is SavedSearchNodeViewModel node)
             {
                 _dragStart = e.GetPosition(AssociatedObject);
@@ -48,54 +44,54 @@ namespace LM.App.Wpf.Views.Behaviors
             }
         }
 
-        private void OnPreviewMouseMove(object sender, MouseEventArgs e)
+        private void OnPreviewMouseMove(object sender, System.Windows.Input.MouseEventArgs e)
         {
-            if (_dragStart is null || _dragSource is null || e.LeftButton != MouseButtonState.Pressed)
+            if (_dragStart is null || _dragSource is null || e.LeftButton != System.Windows.Input.MouseButtonState.Pressed)
             {
                 return;
             }
 
             var currentPosition = e.GetPosition(AssociatedObject);
-            if (Math.Abs(currentPosition.X - _dragStart.Value.X) < SystemParameters.MinimumHorizontalDragDistance &&
-                Math.Abs(currentPosition.Y - _dragStart.Value.Y) < SystemParameters.MinimumVerticalDragDistance)
+            if (Math.Abs(currentPosition.X - _dragStart.Value.X) < System.Windows.SystemParameters.MinimumHorizontalDragDistance &&
+                Math.Abs(currentPosition.Y - _dragStart.Value.Y) < System.Windows.SystemParameters.MinimumVerticalDragDistance)
             {
                 return;
             }
 
-            var data = new DataObject(typeof(SavedSearchNodeViewModel), _dragSource);
-            DragDrop.DoDragDrop(AssociatedObject, data, DragDropEffects.Move);
+            var data = new System.Windows.DataObject(typeof(SavedSearchNodeViewModel), _dragSource);
+            System.Windows.DragDrop.DoDragDrop(AssociatedObject, data, System.Windows.DragDropEffects.Move);
             _dragStart = null;
             _dragSource = null;
         }
 
-        private void OnDragOver(object sender, DragEventArgs e)
+        private void OnDragOver(object sender, System.Windows.DragEventArgs e)
         {
             if (!TryGetDragSource(e, out var source) || !TryGetTree(out var tree))
             {
-                e.Effects = DragDropEffects.None;
+                e.Effects = System.Windows.DragDropEffects.None;
                 e.Handled = true;
                 return;
             }
 
-            if (!TryGetDropInfo(e.OriginalSource as DependencyObject, tree, source, out var targetFolder, out var insertIndex))
+            if (!TryGetDropInfo(e.OriginalSource as System.Windows.DependencyObject, tree, source, out var targetFolder, out var insertIndex))
             {
-                e.Effects = DragDropEffects.None;
+                e.Effects = System.Windows.DragDropEffects.None;
                 e.Handled = true;
                 return;
             }
 
             if (source is SavedSearchFolderViewModel folder && IsAncestor(folder, targetFolder))
             {
-                e.Effects = DragDropEffects.None;
+                e.Effects = System.Windows.DragDropEffects.None;
                 e.Handled = true;
                 return;
             }
 
-            e.Effects = DragDropEffects.Move;
+            e.Effects = System.Windows.DragDropEffects.Move;
             e.Handled = true;
         }
 
-        private async void OnDrop(object sender, DragEventArgs e)
+        private async void OnDrop(object sender, System.Windows.DragEventArgs e)
         {
             if (!TryGetDragSource(e, out var source) || !TryGetTree(out var tree))
             {
@@ -103,7 +99,7 @@ namespace LM.App.Wpf.Views.Behaviors
                 return;
             }
 
-            if (!TryGetDropInfo(e.OriginalSource as DependencyObject, tree, source, out var targetFolder, out var insertIndex))
+            if (!TryGetDropInfo(e.OriginalSource as System.Windows.DependencyObject, tree, source, out var targetFolder, out var insertIndex))
             {
                 e.Handled = true;
                 return;
@@ -139,7 +135,7 @@ namespace LM.App.Wpf.Views.Behaviors
             e.Handled = true;
         }
 
-        private static bool TryGetDragSource(DragEventArgs e, out SavedSearchNodeViewModel? source)
+        private static bool TryGetDragSource(System.Windows.DragEventArgs e, out SavedSearchNodeViewModel? source)
         {
             source = e.Data.GetData(typeof(SavedSearchNodeViewModel)) as SavedSearchNodeViewModel;
             return source is not null;
@@ -151,7 +147,7 @@ namespace LM.App.Wpf.Views.Behaviors
             return tree is not null;
         }
 
-        private static bool TryGetDropInfo(DependencyObject? sourceElement,
+        private static bool TryGetDropInfo(System.Windows.DependencyObject? sourceElement,
                                            SavedSearchTreeViewModel tree,
                                            out SavedSearchFolderViewModel targetFolder,
                                            out int insertIndex)
@@ -190,14 +186,14 @@ namespace LM.App.Wpf.Views.Behaviors
             return false;
         }
 
-        private static TreeViewItem? FindTreeViewItem(DependencyObject? current)
+        private static System.Windows.Controls.TreeViewItem? FindTreeViewItem(System.Windows.DependencyObject? current)
         {
-            while (current is not null && current is not TreeViewItem)
+            while (current is not null && current is not System.Windows.Controls.TreeViewItem)
             {
-                current = VisualTreeHelper.GetParent(current);
+                current = System.Windows.Media.VisualTreeHelper.GetParent(current);
             }
 
-            return current as TreeViewItem;
+            return current as System.Windows.Controls.TreeViewItem;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add the LM.App.Wpf.Library namespace imports to the saved search view models so their base types resolve
- fully qualify System.Windows types in the saved search tree drag/drop behavior to eliminate WinForms ambiguities

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de71c426f0832ba23b0de92bdc7e30