### PR TITLE
Fix saved search tree nullability warnings

### DIFF
--- a/src/LM.App.Wpf/Library/LibraryFilterPresetStore.cs
+++ b/src/LM.App.Wpf/Library/LibraryFilterPresetStore.cs
@@ -211,7 +211,7 @@ namespace LM.App.Wpf.Library
 
             var destination = ResolveFolder(root, targetFolderId);
             var ordered = currentParent.EnumerateChildren().ToList();
-            var removed = ordered.FindIndex(static item => item.Kind == LibraryPresetNodeKind.Preset && item.Preset is not null && ReferenceEquals(item.Preset, preset));
+            var removed = ordered.FindIndex(item => item.Kind == LibraryPresetNodeKind.Preset && item.Preset is not null && ReferenceEquals(item.Preset, preset));
             if (removed >= 0)
             {
                 ordered.RemoveAt(removed);
@@ -248,7 +248,7 @@ namespace LM.App.Wpf.Library
             }
 
             var ordered = currentParent.EnumerateChildren().ToList();
-            var removed = ordered.FindIndex(static item => item.Kind == LibraryPresetNodeKind.Folder && item.Folder is not null && ReferenceEquals(item.Folder, folder));
+            var removed = ordered.FindIndex(item => item.Kind == LibraryPresetNodeKind.Folder && item.Folder is not null && ReferenceEquals(item.Folder, folder));
             if (removed >= 0)
             {
                 ordered.RemoveAt(removed);
@@ -491,15 +491,11 @@ namespace LM.App.Wpf.Library
 
         private static void NormalizeTree(LibraryPresetFolder root)
         {
-            if (root.Folders is null)
-            {
-                root.Folders = new List<LibraryPresetFolder>();
-            }
+            var folders = root.Folders ?? new List<LibraryPresetFolder>();
+            root.Folders = folders;
 
-            if (root.Presets is null)
-            {
-                root.Presets = new List<LibraryFilterPreset>();
-            }
+            var presets = root.Presets ?? new List<LibraryFilterPreset>();
+            root.Presets = presets;
 
             if (string.IsNullOrWhiteSpace(root.Id))
             {
@@ -514,12 +510,15 @@ namespace LM.App.Wpf.Library
             var ordered = root.EnumerateChildren().ToList();
             ReassignChildren(root, ordered);
 
-            foreach (var folder in root.Folders.ToArray())
+            folders = root.Folders ?? folders;
+            presets = root.Presets ?? presets;
+
+            foreach (var folder in folders.ToArray())
             {
                 NormalizeTree(folder);
             }
 
-            foreach (var preset in root.Presets)
+            foreach (var preset in presets)
             {
                 if (string.IsNullOrWhiteSpace(preset.Id))
                 {

--- a/src/LM.App.Wpf/Library/LibraryPresetTree.cs
+++ b/src/LM.App.Wpf/Library/LibraryPresetTree.cs
@@ -30,11 +30,21 @@ namespace LM.App.Wpf.Library
 
             foreach (var folder in Folders ?? Enumerable.Empty<LibraryPresetFolder>())
             {
+                if (folder is null)
+                {
+                    continue;
+                }
+
                 combined.Add(new LibraryPresetTreeItem(LibraryPresetNodeKind.Folder, folder.SortOrder, folder, null));
             }
 
             foreach (var preset in Presets ?? Enumerable.Empty<LibraryFilterPreset>())
             {
+                if (preset is null)
+                {
+                    continue;
+                }
+
                 combined.Add(new LibraryPresetTreeItem(LibraryPresetNodeKind.Preset, preset.SortOrder, null, preset));
             }
 
@@ -54,11 +64,21 @@ namespace LM.App.Wpf.Library
 
             foreach (var folder in Folders ?? Enumerable.Empty<LibraryPresetFolder>())
             {
+                if (folder is null)
+                {
+                    continue;
+                }
+
                 clone.Folders.Add(folder.Clone());
             }
 
             foreach (var preset in Presets ?? Enumerable.Empty<LibraryFilterPreset>())
             {
+                if (preset is null)
+                {
+                    continue;
+                }
+
                 clone.Presets.Add(preset.Clone());
             }
 

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -640,8 +640,8 @@ LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel
 LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel.Preset.get -> LM.App.Wpf.Library.LibraryFilterPreset!
 LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel.SavedSearchPresetViewModel(LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel! tree, LM.App.Wpf.Library.LibraryFilterPreset! preset, int sortOrder) -> void
 LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel.SavedUtc.get -> System.DateTime
-LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel.Summary.get -> LM.App.Wpf.Common.LibraryPresetSummary
-LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel.ToSummary() -> LM.App.Wpf.Common.LibraryPresetSummary
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel.Summary.get -> LM.App.Wpf.Common.LibraryPresetSummary!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel.ToSummary() -> LM.App.Wpf.Common.LibraryPresetSummary!
 LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeChangedEventArgs
 LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeChangedEventArgs.Presets.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Common.LibraryPresetSummary!>!
 LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeChangedEventArgs.SavedSearchTreeChangedEventArgs(System.Collections.Generic.IReadOnlyList<LM.App.Wpf.Common.LibraryPresetSummary!>! presets) -> void

--- a/src/LM.App.Wpf/ViewModels/Library/LibraryFiltersViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LibraryFiltersViewModel.cs
@@ -960,7 +960,10 @@ namespace LM.App.Wpf.ViewModels.Library
 
         private void OnSavedSearchTreeChanged(object? sender, SavedSearchTreeChangedEventArgs e)
         {
-            var _ = InvokeOnDispatcherAsync(() => SavedPresets = e.Presets);
+            var _ = InvokeOnDispatcherAsync(() =>
+            {
+                SavedPresets = e.Presets;
+            });
             if (!_suppressNavigationRefresh)
             {
                 Trace.WriteLine($"[LibraryFiltersViewModel] Saved search tree changed; scheduling navigation refresh for {e.Presets.Count} preset(s).");

--- a/src/LM.App.Wpf/Views/Behaviors/SavedSearchTreeDragDropBehavior.cs
+++ b/src/LM.App.Wpf/Views/Behaviors/SavedSearchTreeDragDropBehavior.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using LM.App.Wpf.ViewModels.Library.SavedSearches;
 using Microsoft.Xaml.Behaviors;
 
@@ -139,13 +140,13 @@ namespace LM.App.Wpf.Views.Behaviors
             e.Handled = true;
         }
 
-        private static bool TryGetDragSource(System.Windows.DragEventArgs e, out SavedSearchNodeViewModel? source)
+        private static bool TryGetDragSource(System.Windows.DragEventArgs e, [NotNullWhen(true)] out SavedSearchNodeViewModel? source)
         {
             source = e.Data.GetData(typeof(SavedSearchNodeViewModel)) as SavedSearchNodeViewModel;
             return source is not null;
         }
 
-        private bool TryGetTree(out SavedSearchTreeViewModel tree)
+        private bool TryGetTree([NotNullWhen(true)] out SavedSearchTreeViewModel? tree)
         {
             tree = AssociatedObject.DataContext as SavedSearchTreeViewModel;
             return tree is not null;
@@ -157,6 +158,8 @@ namespace LM.App.Wpf.Views.Behaviors
                                            out SavedSearchFolderViewModel targetFolder,
                                            out int insertIndex)
         {
+            ArgumentNullException.ThrowIfNull(source);
+
             var item = FindTreeViewItem(sourceElement);
             switch (item?.DataContext)
             {


### PR DESCRIPTION
## Summary
- harden the saved search tree drag-and-drop behavior with nullability annotations and explicit guards
- skip null folder/preset entries when cloning or enumerating preset trees and ensure store normalization never dereferences null collections
- declare the saved search preset summary members as non-null in the public API manifest and adjust dispatcher invocation to avoid Task type mismatches

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: dotnet CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de7aeaee20832b8a1a66302f493ded