### PR TITLE
Fix litsearch organizer tree wiring

### DIFF
--- a/src/LM.App.Wpf.Tests/Library/LibraryViewInteractionsTests.cs
+++ b/src/LM.App.Wpf.Tests/Library/LibraryViewInteractionsTests.cs
@@ -42,7 +42,7 @@ namespace LM.App.Wpf.Tests.Library
                 binding.Command!.Execute(null);
 
                 Assert.Equal(1, vm.SearchInvocationCount);
-            }).ConfigureAwait(false);
+            });
         }
 
         private static void InitializeView(LibraryView view)

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -1026,6 +1026,8 @@ LM.App.Wpf.Library.LitSearch.LitSearchOrganizerStore.LitSearchOrganizerStore(LM.
 LM.App.Wpf.Library.LitSearch.LitSearchOrganizerStore.MoveEntryAsync(string! entryId, string! targetFolderId, int insertIndex, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.App.Wpf.Library.LitSearch.LitSearchOrganizerStore.MoveFolderAsync(string! folderId, string! targetFolderId, int insertIndex, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.App.Wpf.Library.LitSearch.LitSearchOrganizerStore.SyncEntriesAsync(System.Collections.Generic.IEnumerable<string!>! entryIds, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.LitSearch.LitSearchOrganizerFolder!>!
+LM.App.Wpf.Library.LitSearch.LitSearchOrganizerSchema
+LM.App.Wpf.Library.LitSearch.LitSearchOrganizerSchema.CurrentVersion -> int
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchEntryViewModel
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchEntryViewModel.LitSearchEntryViewModel(LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchTreeViewModel! tree, string! id, string! title, string? query) -> void
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchEntryViewModel.Parent.get -> LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchFolderViewModel?
@@ -1049,6 +1051,7 @@ LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchNodeViewModel.LitSearchNodeView
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchNodeViewModel.Name.get -> string!
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchNodeViewModel.NavigationNode.get -> LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel?
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchNodeViewModel.NavigationNode.set -> void
+LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchNodeViewModel.SetNavigationNode(LM.App.Wpf.ViewModels.Library.LibraryNavigationNodeViewModel? navigationNode) -> void
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchNodeViewModel.Tree.get -> LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchTreeViewModel!
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchRunViewModel
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchRunViewModel.Label.get -> string!

--- a/src/LM.App.Wpf/ViewModels/Library/LitSearch/LitSearchNodeViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LitSearch/LitSearchNodeViewModel.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using LM.App.Wpf.ViewModels.Library;
 
@@ -19,5 +20,11 @@ namespace LM.App.Wpf.ViewModels.Library.LitSearch
         public abstract bool IsDraggable { get; }
 
         public LibraryNavigationNodeViewModel? NavigationNode { get; protected set; }
+
+        internal void SetNavigationNode(LibraryNavigationNodeViewModel? navigationNode)
+        {
+            NavigationNode = navigationNode;
+            Trace.WriteLine($"[LitSearchNodeViewModel] Navigation node assigned for '{Id}' -> '{navigationNode?.Name ?? "<null>"}'.");
+        }
     }
 }

--- a/src/LM.App.Wpf/ViewModels/Library/LitSearch/LitSearchTreeViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LitSearch/LitSearchTreeViewModel.cs
@@ -194,20 +194,22 @@ namespace LM.App.Wpf.ViewModels.Library.LitSearch
                 Parent = parent
             };
 
-            entryVm.NavigationNode = new LibraryNavigationNodeViewModel(snapshot.Title, LibraryNavigationNodeKind.LitSearchEntry)
+            var entryNode = new LibraryNavigationNodeViewModel(snapshot.Title, LibraryNavigationNodeKind.LitSearchEntry)
             {
                 Payload = new LibraryLitSearchEntryPayload(snapshot.EntryId, snapshot.HookPath, snapshot.Title, snapshot.Query)
             };
 
+            entryVm.SetNavigationNode(entryNode);
+
             foreach (var run in snapshot.Runs)
             {
-                var runVm = new LitSearchRunViewModel(this, run.RunId, run.Label, entryVm)
+                var runVm = new LitSearchRunViewModel(this, run.RunId, run.Label, entryVm);
+                var runNode = new LibraryNavigationNodeViewModel(run.Label, LibraryNavigationNodeKind.LitSearchRun)
                 {
-                    NavigationNode = new LibraryNavigationNodeViewModel(run.Label, LibraryNavigationNodeKind.LitSearchRun)
-                    {
-                        Payload = new LibraryLitSearchRunPayload(snapshot.EntryId, run.RunId, run.CheckedEntriesPath, run.Label)
-                    }
+                    Payload = new LibraryLitSearchRunPayload(snapshot.EntryId, run.RunId, run.CheckedEntriesPath, run.Label)
                 };
+
+                runVm.SetNavigationNode(runNode);
 
                 entryVm.Runs.Add(runVm);
             }


### PR DESCRIPTION
## Summary
- centralize the LitSearch organizer schema version so helper types can default correctly
- tighten child reordering logic to satisfy nullable analysis and add tracing-based navigation wiring helpers
- adjust tree construction and tests to use the new navigation helper and appease analyzers

## Testing
- Unable to run `dotnet build` (dotnet SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de84a3fc60832ba2338e958a019d5a