### PR TITLE
Add workspace collections store and integrate library collections UI

### DIFF
--- a/src/LM.App.Wpf.Tests/Library/LibraryCollectionStoreTests.cs
+++ b/src/LM.App.Wpf.Tests/Library/LibraryCollectionStoreTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.App.Wpf.Library.Collections;
+using LM.Core.Abstractions;
+using Xunit;
+
+namespace LM.App.Wpf.Tests.Library
+{
+    public sealed class LibraryCollectionStoreTests
+    {
+        [Fact]
+        public async Task CreateFolderAsync_PersistsCollectionWithMetadata()
+        {
+            using var workspace = new TempWorkspace();
+            var store = new LibraryCollectionStore(workspace);
+
+            var folderId = await store.CreateFolderAsync(LibraryCollectionFolder.RootId, "Reading List", "tester", CancellationToken.None);
+
+            var hierarchy = await store.GetHierarchyAsync(CancellationToken.None);
+            var folder = hierarchy.Folders.Single(f => string.Equals(f.Id, folderId, StringComparison.Ordinal));
+
+            Assert.Equal("Reading List", folder.Name);
+            Assert.Equal("tester", folder.Metadata.CreatedBy);
+            Assert.Equal("tester", folder.Metadata.ModifiedBy);
+
+            var filePath = Path.Combine(workspace.GetWorkspaceRoot(), "library", "collections.json");
+            Assert.True(File.Exists(filePath));
+        }
+
+        [Fact]
+        public async Task AddEntriesAsync_AppendsEntriesWithCreator()
+        {
+            using var workspace = new TempWorkspace();
+            var store = new LibraryCollectionStore(workspace);
+
+            var folderId = await store.CreateFolderAsync(LibraryCollectionFolder.RootId, "Queue", "tester", CancellationToken.None);
+
+            await store.AddEntriesAsync(folderId, new[] { "entry-1", "entry-2", "entry-1" }, "tester", CancellationToken.None);
+
+            var hierarchy = await store.GetHierarchyAsync(CancellationToken.None);
+            var folder = hierarchy.Folders.Single(f => string.Equals(f.Id, folderId, StringComparison.Ordinal));
+
+            Assert.Equal(2, folder.Entries.Count);
+            Assert.All(folder.Entries, entry => Assert.Equal("tester", entry.AddedBy));
+        }
+
+        [Fact]
+        public async Task RemoveEntriesAsync_RemovesExistingEntries()
+        {
+            using var workspace = new TempWorkspace();
+            var store = new LibraryCollectionStore(workspace);
+
+            var folderId = await store.CreateFolderAsync(LibraryCollectionFolder.RootId, "Archive", "tester", CancellationToken.None);
+            await store.AddEntriesAsync(folderId, new[] { "entry-1", "entry-2" }, "tester", CancellationToken.None);
+
+            await store.RemoveEntriesAsync(folderId, new[] { "entry-1" }, "tester", CancellationToken.None);
+
+            var hierarchy = await store.GetHierarchyAsync(CancellationToken.None);
+            var folder = hierarchy.Folders.Single(f => string.Equals(f.Id, folderId, StringComparison.Ordinal));
+
+            Assert.Single(folder.Entries);
+            Assert.Equal("entry-2", folder.Entries[0].EntryId);
+        }
+
+        private sealed class TempWorkspace : IWorkSpaceService, IDisposable
+        {
+            public TempWorkspace()
+            {
+                RootPath = Path.Combine(Path.GetTempPath(), "kw-collection-tests", Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(Path.Combine(RootPath, "library"));
+            }
+
+            public string RootPath { get; }
+
+            public string? WorkspacePath => RootPath;
+
+            public Task EnsureWorkspaceAsync(string absoluteWorkspacePath, CancellationToken ct = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public string GetWorkspaceRoot() => RootPath;
+
+            public string GetLocalDbPath() => Path.Combine(RootPath, "metadata.db");
+
+            public string GetAbsolutePath(string relativePath) => Path.Combine(RootPath, relativePath ?? string.Empty);
+
+            public void Dispose()
+            {
+                try
+                {
+                    if (Directory.Exists(RootPath))
+                    {
+                        Directory.Delete(RootPath, recursive: true);
+                    }
+                }
+                catch
+                {
+                    // ignore cleanup failures for tests
+                }
+            }
+        }
+    }
+}

--- a/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
+++ b/src/LM.App.Wpf/Composition/Modules/LibraryModule.cs
@@ -6,6 +6,8 @@ using LM.App.Wpf.ViewModels;
 using LM.App.Wpf.ViewModels.Dialogs;
 using LM.App.Wpf.ViewModels.Library;
 using LM.App.Wpf.ViewModels.Library.LitSearch;
+using LM.App.Wpf.ViewModels.Library.Collections;
+using LM.App.Wpf.Library.Collections;
 using LM.App.Wpf.Library.LitSearch;
 using LM.Core.Abstractions;
 using LM.Core.Abstractions.Configuration;
@@ -27,6 +29,7 @@ namespace LM.App.Wpf.Composition.Modules
             services.AddSingleton<IClipboardService, ClipboardService>();
             services.AddSingleton<IFileExplorerService, FileExplorerService>();
             services.AddSingleton<LibraryFilterPresetStore>();
+            services.AddSingleton<LibraryCollectionStore>();
             services.AddSingleton<LitSearchOrganizerStore>();
             services.AddSingleton<ILibraryPresetPrompt, LibraryPresetPrompt>();
             services.AddTransient<LibraryPresetSaveDialogViewModel>();
@@ -62,6 +65,11 @@ namespace LM.App.Wpf.Composition.Modules
                 sp.GetRequiredService<IHasher>(),
                 sp.GetRequiredService<Services.Pdf.IPdfViewerLauncher>()));
 
+            services.AddSingleton(sp => new LibraryCollectionsViewModel(
+                sp.GetRequiredService<LibraryCollectionStore>(),
+                sp.GetRequiredService<LibraryResultsViewModel>(),
+                sp.GetRequiredService<HookOrchestrator>()));
+
             services.AddSingleton(sp => new LibraryViewModel(
                 sp.GetRequiredService<IEntryStore>(),
                 sp.GetRequiredService<IFullTextSearchService>(),
@@ -72,7 +80,8 @@ namespace LM.App.Wpf.Composition.Modules
                 sp.GetRequiredService<IClipboardService>(),
                 sp.GetRequiredService<IFileExplorerService>(),
                 sp.GetRequiredService<ILibraryDocumentService>(),
-                sp.GetRequiredService<LitSearchTreeViewModel>()));
+                sp.GetRequiredService<LitSearchTreeViewModel>(),
+                sp.GetRequiredService<LibraryCollectionsViewModel>()));
         }
     }
 }

--- a/src/LM.App.Wpf/Library/Collections/LibraryCollectionModels.cs
+++ b/src/LM.App.Wpf/Library/Collections/LibraryCollectionModels.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace LM.App.Wpf.Library.Collections
+{
+    public sealed class LibraryCollectionFile
+    {
+        [JsonPropertyName("version")]
+        public int Version { get; set; }
+
+        [JsonPropertyName("root")]
+        public LibraryCollectionFolder? Root { get; set; }
+    }
+
+    public sealed class LibraryCollectionFolder
+    {
+        public const string RootId = "collections-root";
+
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("metadata")]
+        public LibraryCollectionMetadata Metadata { get; set; } = new();
+
+        [JsonPropertyName("folders")]
+        public List<LibraryCollectionFolder> Folders { get; set; } = new();
+
+        [JsonPropertyName("entries")]
+        public List<LibraryCollectionEntry> Entries { get; set; } = new();
+
+        public LibraryCollectionFolder Clone()
+        {
+            return new LibraryCollectionFolder
+            {
+                Id = Id,
+                Name = Name,
+                Metadata = Metadata.Clone(),
+                Folders = Folders.Select(static folder => folder.Clone()).ToList(),
+                Entries = Entries.Select(static entry => entry.Clone()).ToList()
+            };
+        }
+
+        public IEnumerable<LibraryCollectionFolder> EnumerateDescendants()
+        {
+            foreach (var child in Folders)
+            {
+                yield return child;
+
+                foreach (var grandChild in child.EnumerateDescendants())
+                {
+                    yield return grandChild;
+                }
+            }
+        }
+    }
+
+    public sealed class LibraryCollectionMetadata
+    {
+        [JsonPropertyName("createdBy")]
+        public string CreatedBy { get; set; } = string.Empty;
+
+        [JsonPropertyName("createdUtc")]
+        public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+
+        [JsonPropertyName("modifiedBy")]
+        public string ModifiedBy { get; set; } = string.Empty;
+
+        [JsonPropertyName("modifiedUtc")]
+        public DateTime ModifiedUtc { get; set; } = DateTime.UtcNow;
+
+        public LibraryCollectionMetadata Clone()
+        {
+            return new LibraryCollectionMetadata
+            {
+                CreatedBy = CreatedBy,
+                CreatedUtc = CreatedUtc,
+                ModifiedBy = ModifiedBy,
+                ModifiedUtc = ModifiedUtc
+            };
+        }
+    }
+
+    public sealed class LibraryCollectionEntry
+    {
+        [JsonPropertyName("entryId")]
+        public string EntryId { get; set; } = string.Empty;
+
+        [JsonPropertyName("addedBy")]
+        public string AddedBy { get; set; } = string.Empty;
+
+        [JsonPropertyName("addedUtc")]
+        public DateTime AddedUtc { get; set; } = DateTime.UtcNow;
+
+        public LibraryCollectionEntry Clone()
+        {
+            return new LibraryCollectionEntry
+            {
+                EntryId = EntryId,
+                AddedBy = AddedBy,
+                AddedUtc = AddedUtc
+            };
+        }
+    }
+
+    internal static class LibraryCollectionFolderExtensions
+    {
+        public static LibraryCollectionFolder CloneRoot(this LibraryCollectionFolder root)
+        {
+            if (root is null)
+            {
+                throw new ArgumentNullException(nameof(root));
+            }
+
+            return root.Clone();
+        }
+
+        public static bool TryFindFolder(this LibraryCollectionFolder root, string folderId, [NotNullWhen(true)] out LibraryCollectionFolder? folder, [NotNullWhen(true)] out LibraryCollectionFolder? parent)
+        {
+            folder = null;
+            parent = null;
+
+            if (root is null)
+            {
+                return false;
+            }
+
+            if (string.Equals(root.Id, folderId, StringComparison.Ordinal))
+            {
+                folder = root;
+                return true;
+            }
+
+            foreach (var child in root.Folders)
+            {
+                if (string.Equals(child.Id, folderId, StringComparison.Ordinal))
+                {
+                    folder = child;
+                    parent = root;
+                    return true;
+                }
+
+                if (child.TryFindFolder(folderId, out folder, out parent))
+                {
+                    parent ??= child;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/LM.App.Wpf/Library/Collections/LibraryCollectionStore.cs
+++ b/src/LM.App.Wpf/Library/Collections/LibraryCollectionStore.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using LM.Core.Abstractions;
+
+namespace LM.App.Wpf.Library.Collections
+{
+    public sealed class LibraryCollectionStore
+    {
+        private const int CurrentVersion = 1;
+        private readonly IWorkSpaceService _workspace;
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            WriteIndented = true,
+            AllowTrailingCommas = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public LibraryCollectionStore(IWorkSpaceService workspace)
+        {
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+        }
+
+        public async Task<LibraryCollectionFolder> GetHierarchyAsync(CancellationToken ct = default)
+        {
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            var root = EnsureRoot(file);
+            Trace.WriteLine("[LibraryCollectionStore] Loaded hierarchy snapshot.");
+            return root.CloneRoot();
+        }
+
+        public async Task<string> CreateFolderAsync(string? parentFolderId, string name, string createdBy, CancellationToken ct = default)
+        {
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            var root = EnsureRoot(file);
+            var parent = ResolveFolder(root, parentFolderId);
+
+            var normalizedName = (name ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(normalizedName))
+            {
+                normalizedName = "New Collection";
+            }
+
+            var folder = new LibraryCollectionFolder
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Name = normalizedName,
+                Metadata = new LibraryCollectionMetadata
+                {
+                    CreatedBy = NormalizeUser(createdBy),
+                    CreatedUtc = DateTime.UtcNow,
+                    ModifiedBy = NormalizeUser(createdBy),
+                    ModifiedUtc = DateTime.UtcNow
+                }
+            };
+
+            parent.Folders.Add(folder);
+            parent.Metadata.ModifiedBy = NormalizeUser(createdBy);
+            parent.Metadata.ModifiedUtc = DateTime.UtcNow;
+
+            await SaveAsync(file, ct).ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryCollectionStore] Created folder '{folder.Name}' ({folder.Id}) under '{parent.Id}'.");
+            return folder.Id;
+        }
+
+        public async Task DeleteFolderAsync(string folderId, string performedBy, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(folderId) || string.Equals(folderId, LibraryCollectionFolder.RootId, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            var root = EnsureRoot(file);
+            if (!root.TryFindFolder(folderId, out var folder, out var parent) || folder is null || parent is null)
+            {
+                Trace.WriteLine($"[LibraryCollectionStore] Folder '{folderId}' not found for deletion.");
+                return;
+            }
+
+            parent.Folders.Remove(folder);
+            parent.Metadata.ModifiedBy = NormalizeUser(performedBy);
+            parent.Metadata.ModifiedUtc = DateTime.UtcNow;
+            await SaveAsync(file, ct).ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryCollectionStore] Deleted folder '{folder.Name}' ({folder.Id}).");
+        }
+
+        public async Task AddEntriesAsync(string folderId, IEnumerable<string> entryIds, string performedBy, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(folderId))
+            {
+                return;
+            }
+
+            if (entryIds is null)
+            {
+                throw new ArgumentNullException(nameof(entryIds));
+            }
+
+            var ids = entryIds
+                .Select(static id => id?.Trim())
+                .Where(static id => !string.IsNullOrWhiteSpace(id))
+                .Cast<string>()
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+
+            if (ids.Length == 0)
+            {
+                Trace.WriteLine("[LibraryCollectionStore] No entry ids supplied for addition.");
+                return;
+            }
+
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            var root = EnsureRoot(file);
+            if (!root.TryFindFolder(folderId, out var folder, out _ ) || folder is null)
+            {
+                Trace.WriteLine($"[LibraryCollectionStore] Folder '{folderId}' not found for add operation.");
+                return;
+            }
+
+            var user = NormalizeUser(performedBy);
+            var now = DateTime.UtcNow;
+            var added = 0;
+
+            foreach (var id in ids)
+            {
+                if (folder.Entries.Any(entry => string.Equals(entry.EntryId, id, StringComparison.Ordinal)))
+                {
+                    continue;
+                }
+
+                folder.Entries.Add(new LibraryCollectionEntry
+                {
+                    EntryId = id,
+                    AddedBy = user,
+                    AddedUtc = now
+                });
+
+                added++;
+            }
+
+            if (added == 0)
+            {
+                Trace.WriteLine($"[LibraryCollectionStore] All entries already existed in folder '{folder.Name}'.");
+                return;
+            }
+
+            folder.Metadata.ModifiedBy = user;
+            folder.Metadata.ModifiedUtc = now;
+
+            await SaveAsync(file, ct).ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryCollectionStore] Added {added} entry id(s) to folder '{folder.Name}'.");
+        }
+
+        public async Task RemoveEntriesAsync(string folderId, IEnumerable<string> entryIds, string performedBy, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(folderId))
+            {
+                return;
+            }
+
+            if (entryIds is null)
+            {
+                throw new ArgumentNullException(nameof(entryIds));
+            }
+
+            var ids = entryIds
+                .Select(static id => id?.Trim())
+                .Where(static id => !string.IsNullOrWhiteSpace(id))
+                .Cast<string>()
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+
+            if (ids.Length == 0)
+            {
+                Trace.WriteLine("[LibraryCollectionStore] No entry ids supplied for removal.");
+                return;
+            }
+
+            var file = await LoadAsync(ct).ConfigureAwait(false);
+            var root = EnsureRoot(file);
+            if (!root.TryFindFolder(folderId, out var folder, out _ ) || folder is null)
+            {
+                Trace.WriteLine($"[LibraryCollectionStore] Folder '{folderId}' not found for remove operation.");
+                return;
+            }
+
+            var removed = folder.Entries.RemoveAll(entry => ids.Contains(entry.EntryId, StringComparer.Ordinal));
+            if (removed == 0)
+            {
+                Trace.WriteLine($"[LibraryCollectionStore] No entries removed from folder '{folder.Name}'.");
+                return;
+            }
+
+            folder.Metadata.ModifiedBy = NormalizeUser(performedBy);
+            folder.Metadata.ModifiedUtc = DateTime.UtcNow;
+
+            await SaveAsync(file, ct).ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryCollectionStore] Removed {removed} entry id(s) from folder '{folder.Name}'.");
+        }
+
+        private async Task<LibraryCollectionFile> LoadAsync(CancellationToken ct)
+        {
+            var path = GetFilePath();
+            if (!File.Exists(path))
+            {
+                Trace.WriteLine("[LibraryCollectionStore] No collection file found; creating new store.");
+                return CreateDefaultFile();
+            }
+
+            await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+            var file = await JsonSerializer.DeserializeAsync<LibraryCollectionFile>(stream, JsonOptions, ct).ConfigureAwait(false) ?? CreateDefaultFile();
+            return file;
+        }
+
+        private async Task SaveAsync(LibraryCollectionFile file, CancellationToken ct)
+        {
+            var path = GetFilePath();
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            file.Version = CurrentVersion;
+            var json = JsonSerializer.Serialize(file, JsonOptions);
+            await File.WriteAllTextAsync(path, json, ct).ConfigureAwait(false);
+        }
+
+        private string GetFilePath()
+        {
+            var root = _workspace.GetWorkspaceRoot();
+            return Path.Combine(root, "library", "collections.json");
+        }
+
+        private static LibraryCollectionFile CreateDefaultFile()
+        {
+            return new LibraryCollectionFile
+            {
+                Version = CurrentVersion,
+                Root = new LibraryCollectionFolder
+                {
+                    Id = LibraryCollectionFolder.RootId,
+                    Name = "Collections",
+                    Metadata = new LibraryCollectionMetadata
+                    {
+                        CreatedBy = NormalizeUser(Environment.UserName),
+                        CreatedUtc = DateTime.UtcNow,
+                        ModifiedBy = NormalizeUser(Environment.UserName),
+                        ModifiedUtc = DateTime.UtcNow
+                    }
+                }
+            };
+        }
+
+        private static LibraryCollectionFolder EnsureRoot(LibraryCollectionFile file)
+        {
+            if (file.Root is null)
+            {
+                file.Root = new LibraryCollectionFolder
+                {
+                    Id = LibraryCollectionFolder.RootId,
+                    Name = "Collections",
+                    Metadata = new LibraryCollectionMetadata
+                    {
+                        CreatedBy = NormalizeUser(Environment.UserName),
+                        CreatedUtc = DateTime.UtcNow,
+                        ModifiedBy = NormalizeUser(Environment.UserName),
+                        ModifiedUtc = DateTime.UtcNow
+                    }
+                };
+            }
+
+            if (!string.Equals(file.Root.Id, LibraryCollectionFolder.RootId, StringComparison.Ordinal))
+            {
+                file.Root.Id = LibraryCollectionFolder.RootId;
+            }
+
+            return file.Root;
+        }
+
+        private static LibraryCollectionFolder ResolveFolder(LibraryCollectionFolder root, string? folderId)
+        {
+            if (string.IsNullOrWhiteSpace(folderId) || string.Equals(folderId, LibraryCollectionFolder.RootId, StringComparison.Ordinal))
+            {
+                return root;
+            }
+
+            if (root.TryFindFolder(folderId!, out var folder, out _ ) && folder is not null)
+            {
+                return folder;
+            }
+
+            Trace.WriteLine($"[LibraryCollectionStore] Falling back to root for missing folder '{folderId}'.");
+            return root;
+        }
+
+        private static string NormalizeUser(string? user)
+        {
+            if (string.IsNullOrWhiteSpace(user))
+            {
+                var environmentUser = Environment.UserName;
+                return string.IsNullOrWhiteSpace(environmentUser) ? "unknown" : environmentUser;
+            }
+
+            return user.Trim();
+        }
+    }
+}

--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -276,6 +276,53 @@ LM.App.Wpf.Library.LibraryFilterPresetStore.ListPresetsAsync(System.Threading.Ca
 LM.App.Wpf.Library.LibraryFilterPresetStore.SavePresetAsync(LM.App.Wpf.Library.LibraryFilterPreset! preset, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.App.Wpf.Library.LibraryFilterPresetStore.SavePresetAsync(LM.App.Wpf.Library.LibraryFilterPreset! preset, string? targetFolderId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.App.Wpf.Library.LibraryFilterPresetStore.TryGetPresetByIdAsync(string! presetId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.LibraryFilterPreset?>!
+const LM.App.Wpf.Library.Collections.LibraryCollectionFolder.RootId = "collections-root" -> string!
+LM.App.Wpf.Library.Collections.LibraryCollectionEntry
+LM.App.Wpf.Library.Collections.LibraryCollectionEntry.AddedBy.get -> string!
+LM.App.Wpf.Library.Collections.LibraryCollectionEntry.AddedBy.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionEntry.AddedUtc.get -> System.DateTime
+LM.App.Wpf.Library.Collections.LibraryCollectionEntry.AddedUtc.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionEntry.Clone() -> LM.App.Wpf.Library.Collections.LibraryCollectionEntry!
+LM.App.Wpf.Library.Collections.LibraryCollectionEntry.EntryId.get -> string!
+LM.App.Wpf.Library.Collections.LibraryCollectionEntry.EntryId.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionFile
+LM.App.Wpf.Library.Collections.LibraryCollectionFile.LibraryCollectionFile() -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionFile.Root.get -> LM.App.Wpf.Library.Collections.LibraryCollectionFolder?
+LM.App.Wpf.Library.Collections.LibraryCollectionFile.Root.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionFile.Version.get -> int
+LM.App.Wpf.Library.Collections.LibraryCollectionFile.Version.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.Clone() -> LM.App.Wpf.Library.Collections.LibraryCollectionFolder!
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.EnumerateDescendants() -> System.Collections.Generic.IEnumerable<LM.App.Wpf.Library.Collections.LibraryCollectionFolder!>!
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.Entries.get -> System.Collections.Generic.List<LM.App.Wpf.Library.Collections.LibraryCollectionEntry!>!
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.Entries.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.Folders.get -> System.Collections.Generic.List<LM.App.Wpf.Library.Collections.LibraryCollectionFolder!>!
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.Folders.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.Id.get -> string!
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.Id.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.LibraryCollectionFolder() -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.Metadata.get -> LM.App.Wpf.Library.Collections.LibraryCollectionMetadata!
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.Metadata.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.Name.get -> string!
+LM.App.Wpf.Library.Collections.LibraryCollectionFolder.Name.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionMetadata
+LM.App.Wpf.Library.Collections.LibraryCollectionMetadata.Clone() -> LM.App.Wpf.Library.Collections.LibraryCollectionMetadata!
+LM.App.Wpf.Library.Collections.LibraryCollectionMetadata.CreatedBy.get -> string!
+LM.App.Wpf.Library.Collections.LibraryCollectionMetadata.CreatedBy.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionMetadata.CreatedUtc.get -> System.DateTime
+LM.App.Wpf.Library.Collections.LibraryCollectionMetadata.CreatedUtc.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionMetadata.LibraryCollectionMetadata() -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionMetadata.ModifiedBy.get -> string!
+LM.App.Wpf.Library.Collections.LibraryCollectionMetadata.ModifiedBy.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionMetadata.ModifiedUtc.get -> System.DateTime
+LM.App.Wpf.Library.Collections.LibraryCollectionMetadata.ModifiedUtc.set -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionStore
+LM.App.Wpf.Library.Collections.LibraryCollectionStore.AddEntriesAsync(string! folderId, System.Collections.Generic.IEnumerable<string!>! entryIds, string! performedBy, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.Collections.LibraryCollectionStore.CreateFolderAsync(string? parentFolderId, string! name, string! createdBy, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+LM.App.Wpf.Library.Collections.LibraryCollectionStore.DeleteFolderAsync(string! folderId, string! performedBy, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.Library.Collections.LibraryCollectionStore.GetHierarchyAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LM.App.Wpf.Library.Collections.LibraryCollectionFolder!>!
+LM.App.Wpf.Library.Collections.LibraryCollectionStore.LibraryCollectionStore(LM.Core.Abstractions.IWorkSpaceService! workspace) -> void
+LM.App.Wpf.Library.Collections.LibraryCollectionStore.RemoveEntriesAsync(string! folderId, System.Collections.Generic.IEnumerable<string!>! entryIds, string! performedBy, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.App.Wpf.Library.LibraryPresetFolder
 LM.App.Wpf.Library.LibraryPresetFolder.Clone() -> LM.App.Wpf.Library.LibraryPresetFolder!
 LM.App.Wpf.Library.LibraryPresetFolder.Folders.get -> System.Collections.Generic.List<LM.App.Wpf.Library.LibraryPresetFolder!>!
@@ -748,6 +795,24 @@ LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectionChanged -> System
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.HasSelectedAbstract.get -> bool
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectedAbstract.get -> string?
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.SelectedAbstract.set -> void
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel.Children.get -> System.Collections.ObjectModel.ObservableCollection<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel!>!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel.EntryCount.get -> int
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel.EntryCount.set -> void
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel.Id.get -> string!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel.LibraryCollectionFolderViewModel(LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel! tree, string! id, string! name, LM.App.Wpf.Library.Collections.LibraryCollectionMetadata! metadata) -> void
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel.Metadata.get -> LM.App.Wpf.Library.Collections.LibraryCollectionMetadata!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel.Name.get -> string!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel.Name.set -> void
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel.Tree.get -> LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.AddSelectionToFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel>!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.CreateFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel?>!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.DeleteFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel>!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.LibraryCollectionsViewModel(LM.App.Wpf.Library.Collections.LibraryCollectionStore! store, LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel! results, LM.Infrastructure.Hooks.HookOrchestrator! hookOrchestrator) -> void
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.RefreshAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.RemoveSelectionFromFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel>!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.Root.get -> LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel!
 LM.App.Wpf.ViewModels.LibrarySearchResult.HasPrimaryAttachment.get -> bool
 LM.App.Wpf.Views.Library.Controls.LibrarySearchQueryBox
 LM.App.Wpf.Views.Library.Controls.LibrarySearchQueryBox.LibrarySearchQueryBox() -> void
@@ -755,8 +820,9 @@ LM.App.Wpf.Views.Library.Controls.LibrarySearchQueryBox.Text.get -> string!
 LM.App.Wpf.Views.Library.Controls.LibrarySearchQueryBox.Text.set -> void
 LM.App.Wpf.ViewModels.LibraryViewModel
 LM.App.Wpf.ViewModels.LibraryViewModel.Filters.get -> LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel!
-LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel! filters, LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel! results, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.Configuration.IUserPreferencesStore! preferencesStore, LM.App.Wpf.Common.IClipboardService! clipboard, LM.App.Wpf.Common.IFileExplorerService! fileExplorer, LM.App.Wpf.Library.ILibraryDocumentService! documentService) -> void
+LM.App.Wpf.ViewModels.LibraryViewModel.LibraryViewModel(LM.Core.Abstractions.IEntryStore! store, LM.Core.Abstractions.IFullTextSearchService! fullTextSearch, LM.App.Wpf.ViewModels.Library.LibraryFiltersViewModel! filters, LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel! results, LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.Configuration.IUserPreferencesStore! preferencesStore, LM.App.Wpf.Common.IClipboardService! clipboard, LM.App.Wpf.Common.IFileExplorerService! fileExplorer, LM.App.Wpf.Library.ILibraryDocumentService! documentService, LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchTreeViewModel! litSearchOrganizer, LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel! collections) -> void
 LM.App.Wpf.ViewModels.LibraryViewModel.Results.get -> LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel!
+LM.App.Wpf.ViewModels.LibraryViewModel.Collections.get -> LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel!
 LM.App.Wpf.ViewModels.LibraryViewModel.ColumnOptions.get -> System.Collections.Generic.IReadOnlyList<LM.App.Wpf.ViewModels.Library.LibraryColumnOption!>!
 LM.App.Wpf.ViewModels.LibraryViewModel.ColumnVisibility.get -> LM.App.Wpf.ViewModels.Library.LibraryColumnVisibility!
 LM.App.Wpf.ViewModels.SearchItemViewModel

--- a/src/LM.App.Wpf/ViewModels/Library/Collections/LibraryCollectionFolderViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/Collections/LibraryCollectionFolderViewModel.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using LM.App.Wpf.Library.Collections;
+
+namespace LM.App.Wpf.ViewModels.Library.Collections
+{
+    public sealed partial class LibraryCollectionFolderViewModel : ObservableObject
+    {
+        public LibraryCollectionFolderViewModel(LibraryCollectionsViewModel tree,
+                                                string id,
+                                                string name,
+                                                LibraryCollectionMetadata metadata)
+        {
+            Tree = tree ?? throw new ArgumentNullException(nameof(tree));
+            Id = string.IsNullOrWhiteSpace(id) ? Guid.NewGuid().ToString("N") : id;
+            _name = name ?? string.Empty;
+            Metadata = metadata ?? new LibraryCollectionMetadata();
+        }
+
+        public string Id { get; }
+
+        [ObservableProperty]
+        private string _name;
+
+        public LibraryCollectionMetadata Metadata { get; }
+
+        public ObservableCollection<LibraryCollectionFolderViewModel> Children { get; } = new();
+
+        public LibraryCollectionsViewModel Tree { get; }
+
+        [ObservableProperty]
+        private int _entryCount;
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/Library/Collections/LibraryCollectionsViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/Collections/LibraryCollectionsViewModel.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LM.App.Wpf.Library.Collections;
+using LM.Infrastructure.Hooks;
+using LM.App.Wpf.ViewModels.Library;
+using HookM = LM.HubSpoke.Models;
+
+namespace LM.App.Wpf.ViewModels.Library.Collections
+{
+    public sealed partial class LibraryCollectionsViewModel : ObservableObject
+    {
+        private readonly LibraryCollectionStore _store;
+        private readonly LibraryResultsViewModel _results;
+        private readonly HookOrchestrator _hookOrchestrator;
+        private readonly SemaphoreSlim _refreshLock = new(1, 1);
+
+        public LibraryCollectionsViewModel(LibraryCollectionStore store,
+                                           LibraryResultsViewModel results,
+                                           HookOrchestrator hookOrchestrator)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            _results = results ?? throw new ArgumentNullException(nameof(results));
+            _hookOrchestrator = hookOrchestrator ?? throw new ArgumentNullException(nameof(hookOrchestrator));
+
+            Root = new LibraryCollectionFolderViewModel(this, LibraryCollectionFolder.RootId, "Collections", new LibraryCollectionMetadata());
+
+            CreateFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel?>(CreateFolderAsync);
+            DeleteFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel>(DeleteFolderAsync, CanDeleteFolder);
+            AddSelectionToFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel>(AddSelectionToFolderAsync, CanModifyFolder);
+            RemoveSelectionFromFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel>(RemoveSelectionFromFolderAsync, CanModifyFolder);
+
+            _results.SelectionChanged += OnSelectionChanged;
+        }
+
+        public LibraryCollectionFolderViewModel Root { get; }
+
+        public IAsyncRelayCommand<LibraryCollectionFolderViewModel?> CreateFolderCommand { get; }
+
+        public IAsyncRelayCommand<LibraryCollectionFolderViewModel> DeleteFolderCommand { get; }
+
+        public IAsyncRelayCommand<LibraryCollectionFolderViewModel> AddSelectionToFolderCommand { get; }
+
+        public IAsyncRelayCommand<LibraryCollectionFolderViewModel> RemoveSelectionFromFolderCommand { get; }
+
+        public async Task RefreshAsync(CancellationToken ct = default)
+        {
+            await _refreshLock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                var hierarchy = await _store.GetHierarchyAsync(ct).ConfigureAwait(false);
+
+                await InvokeOnDispatcherAsync(() =>
+                {
+                    Root.Children.Clear();
+                    Root.EntryCount = hierarchy.Entries.Count;
+                    Root.Metadata.CreatedBy = hierarchy.Metadata.CreatedBy;
+                    Root.Metadata.CreatedUtc = hierarchy.Metadata.CreatedUtc;
+                    Root.Metadata.ModifiedBy = hierarchy.Metadata.ModifiedBy;
+                    Root.Metadata.ModifiedUtc = hierarchy.Metadata.ModifiedUtc;
+
+                    foreach (var child in hierarchy.Folders)
+                    {
+                        Root.Children.Add(CreateNode(child));
+                    }
+                }).ConfigureAwait(false);
+
+                Trace.WriteLine("[LibraryCollectionsViewModel] Refreshed collection hierarchy.");
+            }
+            finally
+            {
+                _refreshLock.Release();
+            }
+        }
+
+        private LibraryCollectionFolderViewModel CreateNode(LibraryCollectionFolder folder)
+        {
+            var node = new LibraryCollectionFolderViewModel(this, folder.Id, folder.Name, folder.Metadata.Clone())
+            {
+                EntryCount = folder.Entries.Count
+            };
+
+            foreach (var child in folder.Folders)
+            {
+                node.Children.Add(CreateNode(child));
+            }
+
+            return node;
+        }
+
+        private async Task CreateFolderAsync(LibraryCollectionFolderViewModel? parent)
+        {
+            var target = parent ?? Root;
+            var baselineName = "New Collection";
+            var existingNames = target.Children.Select(child => child.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var candidate = baselineName;
+            var index = 1;
+
+            while (existingNames.Contains(candidate))
+            {
+                candidate = $"{baselineName} {++index}";
+            }
+
+            Trace.WriteLine($"[LibraryCollectionsViewModel] Requesting folder creation '{candidate}' under '{target.Id}'.");
+            await _store.CreateFolderAsync(target.Id, candidate, GetCurrentUserName(), CancellationToken.None).ConfigureAwait(false);
+            await RefreshAsync().ConfigureAwait(false);
+        }
+
+        private bool CanModifyFolder(LibraryCollectionFolderViewModel? folder)
+        {
+            if (folder is null)
+            {
+                return false;
+            }
+
+            if (string.Equals(folder.Id, LibraryCollectionFolder.RootId, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return _results.SelectedItems.Count > 0;
+        }
+
+        private static bool CanDeleteFolder(LibraryCollectionFolderViewModel? folder)
+        {
+            return folder is not null && !string.Equals(folder.Id, LibraryCollectionFolder.RootId, StringComparison.Ordinal);
+        }
+
+        private async Task DeleteFolderAsync(LibraryCollectionFolderViewModel? folder)
+        {
+            if (folder is null || string.Equals(folder.Id, LibraryCollectionFolder.RootId, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var result = System.Windows.MessageBox.Show(
+                $"Delete collection '{folder.Name}' and remove all its entry references?",
+                "Delete Collection",
+                System.Windows.MessageBoxButton.YesNo,
+                System.Windows.MessageBoxImage.Warning);
+
+            if (result != System.Windows.MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            await _store.DeleteFolderAsync(folder.Id, GetCurrentUserName(), CancellationToken.None).ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryCollectionsViewModel] Deleted folder '{folder.Id}'.");
+            await RefreshAsync().ConfigureAwait(false);
+        }
+
+        private async Task AddSelectionToFolderAsync(LibraryCollectionFolderViewModel? folder)
+        {
+            if (folder is null)
+            {
+                return;
+            }
+
+            var ids = ExtractSelectedEntryIds();
+            if (ids.Count == 0)
+            {
+                return;
+            }
+
+            var user = GetCurrentUserName();
+            await _store.AddEntriesAsync(folder.Id, ids, user, CancellationToken.None).ConfigureAwait(false);
+            await AppendChangeLogAsync(ids, folder, user, "CollectionAdded").ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryCollectionsViewModel] Added {ids.Count} entry id(s) to '{folder.Name}'.");
+            await RefreshAsync().ConfigureAwait(false);
+        }
+
+        private async Task RemoveSelectionFromFolderAsync(LibraryCollectionFolderViewModel? folder)
+        {
+            if (folder is null)
+            {
+                return;
+            }
+
+            var ids = ExtractSelectedEntryIds();
+            if (ids.Count == 0)
+            {
+                return;
+            }
+
+            var user = GetCurrentUserName();
+            await _store.RemoveEntriesAsync(folder.Id, ids, user, CancellationToken.None).ConfigureAwait(false);
+            await AppendChangeLogAsync(ids, folder, user, "CollectionRemoved").ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryCollectionsViewModel] Removed {ids.Count} entry id(s) from '{folder.Name}'.");
+            await RefreshAsync().ConfigureAwait(false);
+        }
+
+        private IReadOnlyList<string> ExtractSelectedEntryIds()
+        {
+            var ids = _results.SelectedItems
+                .Select(item => item.Entry?.Id)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Cast<string>()
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+
+            return ids;
+        }
+
+        private async Task AppendChangeLogAsync(IReadOnlyList<string> ids,
+                                                LibraryCollectionFolderViewModel folder,
+                                                string performedBy,
+                                                string action)
+        {
+            foreach (var entryId in ids)
+            {
+                var hook = new HookM.EntryChangeLogHook
+                {
+                    Events = new List<HookM.EntryChangeLogEvent>
+                    {
+                        new HookM.EntryChangeLogEvent
+                        {
+                            PerformedBy = performedBy,
+                            Action = $"{action}:{folder.Name}",
+                            TimestampUtc = DateTime.UtcNow
+                        }
+                    }
+                };
+
+                var context = new HookContext
+                {
+                    ChangeLog = hook
+                };
+
+                await _hookOrchestrator.ProcessAsync(entryId, context, CancellationToken.None).ConfigureAwait(false);
+                Trace.WriteLine($"[LibraryCollectionsViewModel] Appended changelog event '{action}' for entry '{entryId}'.");
+            }
+        }
+
+        private void OnSelectionChanged(object? sender, EventArgs e)
+        {
+            AddSelectionToFolderCommand.NotifyCanExecuteChanged();
+            RemoveSelectionFromFolderCommand.NotifyCanExecuteChanged();
+        }
+
+        private static Task InvokeOnDispatcherAsync(Action action)
+        {
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher is not null && !dispatcher.CheckAccess())
+            {
+                return dispatcher.InvokeAsync(action).Task;
+            }
+
+            action();
+            return Task.CompletedTask;
+        }
+
+        private static string GetCurrentUserName()
+        {
+            var user = Environment.UserName;
+            return string.IsNullOrWhiteSpace(user) ? "unknown" : user;
+        }
+    }
+}

--- a/src/LM.App.Wpf/ViewModels/LibraryViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/LibraryViewModel.cs
@@ -11,6 +11,7 @@ using LM.App.Wpf.Common;
 using LM.App.Wpf.Library;
 using LM.App.Wpf.ViewModels.Library;
 using LM.App.Wpf.ViewModels.Library.LitSearch;
+using LM.App.Wpf.ViewModels.Library.Collections;
 using LM.Core.Abstractions;
 using LM.Core.Abstractions.Configuration;
 using LM.Core.Models;
@@ -30,6 +31,7 @@ namespace LM.App.Wpf.ViewModels
         private readonly LibrarySearchParser _metadataParser = new();
         private readonly LibrarySearchEvaluator _metadataEvaluator = new();
         private readonly LitSearchTreeViewModel _litSearchOrganizer;
+        private readonly LibraryCollectionsViewModel _collections;
 
         public LibraryViewModel(IEntryStore store,
                                 IFullTextSearchService fullTextSearch,
@@ -40,7 +42,8 @@ namespace LM.App.Wpf.ViewModels
                                 IClipboardService clipboard,
                                 IFileExplorerService fileExplorer,
                                 ILibraryDocumentService documentService,
-                                LitSearchTreeViewModel litSearchOrganizer)
+                                LitSearchTreeViewModel litSearchOrganizer,
+                                LibraryCollectionsViewModel collections)
         {
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _fullTextSearch = fullTextSearch ?? throw new ArgumentNullException(nameof(fullTextSearch));
@@ -53,6 +56,7 @@ namespace LM.App.Wpf.ViewModels
             _fileExplorer = fileExplorer ?? throw new ArgumentNullException(nameof(fileExplorer));
             _documentService = documentService ?? throw new ArgumentNullException(nameof(documentService));
             _litSearchOrganizer = litSearchOrganizer ?? throw new ArgumentNullException(nameof(litSearchOrganizer));
+            _collections = collections ?? throw new ArgumentNullException(nameof(collections));
 
             Results.SelectionChanged += OnResultsSelectionChanged;
 
@@ -60,12 +64,15 @@ namespace LM.App.Wpf.ViewModels
             InitializeColumns();
             _ = LoadPreferencesAsync();
             _ = _litSearchOrganizer.RefreshAsync();
+            _ = _collections.RefreshAsync();
         }
 
         public LibraryFiltersViewModel Filters { get; }
         public LibraryResultsViewModel Results { get; }
 
         public LitSearchTreeViewModel LitSearchOrganizer => _litSearchOrganizer;
+
+        public LibraryCollectionsViewModel Collections => _collections;
 
         [RelayCommand]
         private async Task SearchAsync()

--- a/src/LM.App.Wpf/Views/LibraryView.xaml
+++ b/src/LM.App.Wpf/Views/LibraryView.xaml
@@ -6,6 +6,7 @@
              xmlns:controls="clr-namespace:LM.App.Wpf.Views.Library.Controls"
              xmlns:converters="clr-namespace:LM.App.Wpf.Views.Converters"
              xmlns:viewModels="clr-namespace:LM.App.Wpf.ViewModels.Library"
+             xmlns:collections="clr-namespace:LM.App.Wpf.ViewModels.Library.Collections"
              xmlns:saved="clr-namespace:LM.App.Wpf.ViewModels.Library.SavedSearches"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:core="clr-namespace:Microsoft.Xaml.Behaviors.Core;assembly=Microsoft.Xaml.Behaviors"
@@ -98,6 +99,109 @@
                         HorizontalScrollBarVisibility="Disabled"
                         DataContext="{Binding Filters}">
                         <StackPanel Margin="0">
+
+                            <!-- Collections Organizer -->
+                            <Border Background="White"
+                                    BorderBrush="#E5E7EB"
+                                    BorderThickness="0"
+                                    CornerRadius="0"
+                                    Margin="0,0,0,8">
+                                <StackPanel>
+                                    <Border Background="#F3F4F6"
+                                            BorderBrush="#E5E7EB"
+                                            BorderThickness="0,0,0,1"
+                                            Padding="6,4"
+                                            DataContext="{Binding Collections}">
+                                        <DockPanel>
+                                            <StackPanel DockPanel.Dock="Right"
+                                                        Orientation="Horizontal"
+                                                        HorizontalAlignment="Right">
+                                                <Button Content="New collection"
+                                                        Padding="8,4"
+                                                        Command="{Binding CreateFolderCommand}"
+                                                        CommandParameter="{Binding Root}" />
+                                            </StackPanel>
+                                            <ToggleButton DockPanel.Dock="Left"
+                                                          Name="CollectionsToggle"
+                                                          IsChecked="True"
+                                                          Width="16"
+                                                          Height="16"
+                                                          Padding="0"
+                                                          Background="Transparent"
+                                                          BorderThickness="0">
+                                                <ToggleButton.Template>
+                                                    <ControlTemplate TargetType="ToggleButton">
+                                                        <Border Background="{TemplateBinding Background}">
+                                                            <TextBlock FontFamily="Segoe MDL2 Assets"
+                                                                       FontSize="10"
+                                                                       VerticalAlignment="Center"
+                                                                       HorizontalAlignment="Center">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Setter Property="Text" Value="&#xE70D;"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding IsChecked, RelativeSource={RelativeSource TemplatedParent}}" Value="False">
+                                                                                <Setter Property="Text" Value="&#xE76C;"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                        </Border>
+                                                    </ControlTemplate>
+                                                </ToggleButton.Template>
+                                            </ToggleButton>
+                                            <TextBlock Text="COLLECTIONS"
+                                                       FontSize="11"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="#6B7280"
+                                                       Margin="4,0,0,0"/>
+                                        </DockPanel>
+                                    </Border>
+                                    <TreeView Margin="0"
+                                              DataContext="{Binding Collections}"
+                                              ItemsSource="{Binding Root.Children}"
+                                              Background="Transparent"
+                                              BorderThickness="0"
+                                              HorizontalContentAlignment="Stretch"
+                                              Visibility="{Binding IsChecked, ElementName=CollectionsToggle, Converter={StaticResource BoolToVisibilityConverter}}">
+                                        <TreeView.Resources>
+                                            <HierarchicalDataTemplate DataType="{x:Type collections:LibraryCollectionFolderViewModel}"
+                                                                      ItemsSource="{Binding Children}">
+                                                <DockPanel>
+                                                    <TextBlock DockPanel.Dock="Right"
+                                                               Text="{Binding EntryCount}"
+                                                               Margin="6,2,4,2"
+                                                               Foreground="#6B7280"
+                                                               FontSize="11"
+                                                               HorizontalAlignment="Right"/>
+                                                    <TextBlock Text="{Binding Name}"
+                                                               Margin="4,2"
+                                                               FontWeight="SemiBold"
+                                                               TextTrimming="CharacterEllipsis"/>
+                                                </DockPanel>
+                                                <HierarchicalDataTemplate.ItemContainerStyle>
+                                                    <Style TargetType="TreeViewItem">
+                                                        <Setter Property="IsExpanded" Value="True" />
+                                                        <Setter Property="ContextMenu">
+                                                            <Setter.Value>
+                                                                <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                                                    <MenuItem Header="New collection"
+                                                                              Command="{Binding Tree.CreateFolderCommand}"
+                                                                              CommandParameter="{Binding}" />
+                                                                    <MenuItem Header="Delete collection"
+                                                                              Command="{Binding Tree.DeleteFolderCommand}"
+                                                                              CommandParameter="{Binding}" />
+                                                                </ContextMenu>
+                                                            </Setter.Value>
+                                                        </Setter>
+                                                    </Style>
+                                                </HierarchicalDataTemplate.ItemContainerStyle>
+                                            </HierarchicalDataTemplate>
+                                        </TreeView.Resources>
+                                    </TreeView>
+                                </StackPanel>
+                            </Border>
 
                             <!-- LitSearch Organizer - Collapsible -->
                             <Border Background="White"
@@ -474,6 +578,40 @@
                   Background="White"
                   RowHeight="24"
                   HeadersVisibility="Column">
+                    <DataGrid.ContextMenu>
+                        <ContextMenu DataContext="{Binding DataContext, ElementName=LibraryViewControl}">
+                            <MenuItem Header="Add to collection..."
+                                      ItemsSource="{Binding Collections.Root.Children}">
+                                <MenuItem.ItemContainerStyle>
+                                    <Style TargetType="MenuItem">
+                                        <Setter Property="Command"
+                                                Value="{Binding DataContext.Collections.AddSelectionToFolderCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                        <Setter Property="CommandParameter" Value="{Binding}" />
+                                    </Style>
+                                </MenuItem.ItemContainerStyle>
+                                <MenuItem.ItemTemplate>
+                                    <HierarchicalDataTemplate ItemsSource="{Binding Children}">
+                                        <TextBlock Text="{Binding Name}" />
+                                    </HierarchicalDataTemplate>
+                                </MenuItem.ItemTemplate>
+                            </MenuItem>
+                            <MenuItem Header="Remove from collection..."
+                                      ItemsSource="{Binding Collections.Root.Children}">
+                                <MenuItem.ItemContainerStyle>
+                                    <Style TargetType="MenuItem">
+                                        <Setter Property="Command"
+                                                Value="{Binding DataContext.Collections.RemoveSelectionFromFolderCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                        <Setter Property="CommandParameter" Value="{Binding}" />
+                                    </Style>
+                                </MenuItem.ItemContainerStyle>
+                                <MenuItem.ItemTemplate>
+                                    <HierarchicalDataTemplate ItemsSource="{Binding Children}">
+                                        <TextBlock Text="{Binding Name}" />
+                                    </HierarchicalDataTemplate>
+                                </MenuItem.ItemTemplate>
+                            </MenuItem>
+                        </ContextMenu>
+                    </DataGrid.ContextMenu>
                     <DataGrid.ColumnHeaderStyle>
                         <Style TargetType="DataGridColumnHeader">
                             <Setter Property="Background" Value="#F9FAFB"/>


### PR DESCRIPTION
## Summary
- add a workspace-backed library collections store with folder and entry metadata plus unit coverage
- surface collection tree view models in the library module and wire add/remove commands into the changelog orchestrator
- render the collections panel in LibraryView with context menus for multi-select add/remove actions

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de84b32ca4832b8637b65ab3b41d56