### PR TITLE
Fix PDF annotation persistence errors and add diagnostics

### DIFF
--- a/src/LM.App.Wpf/Library/Collections/LibraryCollectionModels.cs
+++ b/src/LM.App.Wpf/Library/Collections/LibraryCollectionModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json.Serialization;
@@ -120,7 +121,7 @@ namespace LM.App.Wpf.Library.Collections
             return root.Clone();
         }
 
-        public static bool TryFindFolder(this LibraryCollectionFolder root, string folderId, [NotNullWhen(true)] out LibraryCollectionFolder? folder, [NotNullWhen(true)] out LibraryCollectionFolder? parent)
+        public static bool TryFindFolder(this LibraryCollectionFolder root, string folderId, [NotNullWhen(true)] out LibraryCollectionFolder? folder, out LibraryCollectionFolder? parent)
         {
             folder = null;
             parent = null;
@@ -133,6 +134,7 @@ namespace LM.App.Wpf.Library.Collections
             if (string.Equals(root.Id, folderId, StringComparison.Ordinal))
             {
                 folder = root;
+                Trace.WriteLine($"[LibraryCollectionFolderExtensions] Located root folder '{root.Id}'.");
                 return true;
             }
 
@@ -142,12 +144,14 @@ namespace LM.App.Wpf.Library.Collections
                 {
                     folder = child;
                     parent = root;
+                    Trace.WriteLine($"[LibraryCollectionFolderExtensions] Located folder '{child.Id}' under '{root.Id}'.");
                     return true;
                 }
 
                 if (child.TryFindFolder(folderId, out folder, out parent))
                 {
                     parent ??= child;
+                    Trace.WriteLine($"[LibraryCollectionFolderExtensions] Located nested folder '{folder?.Id}' under '{parent.Id}'.");
                     return true;
                 }
             }

--- a/src/LM.Infrastructure/PublicAPI.Unshipped.txt
+++ b/src/LM.Infrastructure/PublicAPI.Unshipped.txt
@@ -73,7 +73,7 @@ LM.Infrastructure.Pdf.PdfAnnotationPreviewStorage.PdfAnnotationPreviewStorage(LM
 LM.Infrastructure.Pdf.PdfAnnotationPreviewStorage.SaveAsync(string! pdfHash, string! annotationId, byte[]! pngBytes, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
 LM.Infrastructure.Pdf.PdfAnnotationOverlayReader
 LM.Infrastructure.Pdf.PdfAnnotationOverlayReader.PdfAnnotationOverlayReader(LM.Core.Abstractions.IWorkSpaceService! workspace, LM.Core.Abstractions.IEntryStore! entryStore) -> void
-LM.Infrastructure.Pdf.PdfAnnotationOverlayReader.GetOverlayJsonAsync(string! pdfHash, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
+LM.Infrastructure.Pdf.PdfAnnotationOverlayReader.GetOverlayJsonAsync(string! entryId, string! pdfHash, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
 LM.Infrastructure.Search.PubMedSearchProvider
 LM.Infrastructure.Search.PubMedSearchProvider.PubMedSearchProvider() -> void
 LM.Infrastructure.Search.PubMedSearchProvider.Database.get -> LM.Core.Models.SearchDatabase


### PR DESCRIPTION
## Summary
- fix duplicate variable declarations and restore preview loading in `PdfAnnotationPersistenceService`
- add trace logging throughout the PDF overlay reader/persistence flows
- relax folder lookup annotations and log results for library collections
- update infrastructure public API surface to match the new overlay reader signature

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de8f9fbeec832bac402223d17db840