### PR TITLE
Fix missing FileDropRequest import in LibraryResultsViewModel

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Library/LibraryResultsViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LibraryResultsViewModel.cs
@@ -13,6 +13,7 @@ using CommunityToolkit.Mvvm.Input;
 using LM.App.Wpf.Common;
 using LM.App.Wpf.Library;
 using LM.App.Wpf.Services.Pdf;
+using LM.App.Wpf.Views.Behaviors;
 using LM.Core.Abstractions;
 using LM.Core.Models;
 using LM.Core.Models.Search;


### PR DESCRIPTION
## Summary
- add the missing `FileDropRequest` namespace import so the library results view model can compile

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dea13fb0e4832ba2bcdcda5cb66742