### PR TITLE
Fix library view drag drop dependencies and tests

### DIFF
--- a/src/LM.App.Wpf.Tests/LibraryViewModelFullTextTests.cs
+++ b/src/LM.App.Wpf.Tests/LibraryViewModelFullTextTests.cs
@@ -9,9 +9,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using LM.App.Wpf.Common;
 using LM.App.Wpf.Library;
+using LM.App.Wpf.Library.Collections;
+using LM.App.Wpf.Library.LitSearch;
 using LM.App.Wpf.Services.Pdf;
 using LM.App.Wpf.ViewModels;
 using LM.App.Wpf.ViewModels.Library;
+using LM.App.Wpf.ViewModels.Library.Collections;
+using LM.App.Wpf.ViewModels.Library.LitSearch;
 using LM.Core.Abstractions;
 using LM.Core.Abstractions.Configuration;
 using LM.Core.Models;
@@ -522,16 +526,16 @@ namespace LM.App.Wpf.Tests
         private static LibraryViewModel CreateViewModel(IEntryStore store,
                                                         IFullTextSearchService search,
                                                         TempWorkspace workspace,
-                                                       ILibraryEntryEditor? editor = null,
-                                                       IFileStorageRepository? storage = null,
-                                                       IAttachmentMetadataPrompt? attachmentPrompt = null,
-                                                       HookOrchestrator? orchestrator = null,
-                                                       IHasher? hasher = null,
-                                                       IPdfViewerLauncher? pdfViewerLauncher = null,
-                                                       ILibraryDocumentService? documentService = null,
-                                                       IClipboardService? clipboard = null,
-                                                       IFileExplorerService? fileExplorer = null,
-                                                       IUserPreferencesStore? preferencesStore = null)
+                                                        ILibraryEntryEditor? editor = null,
+                                                        IFileStorageRepository? storage = null,
+                                                        IAttachmentMetadataPrompt? attachmentPrompt = null,
+                                                        HookOrchestrator? orchestrator = null,
+                                                        IHasher? hasher = null,
+                                                        IPdfViewerLauncher? pdfViewerLauncher = null,
+                                                        ILibraryDocumentService? documentService = null,
+                                                        IClipboardService? clipboard = null,
+                                                        IFileExplorerService? fileExplorer = null,
+                                                        IUserPreferencesStore? preferencesStore = null)
         {
             var ws = new TestWorkspaceService(workspace.RootPath);
             var presetStore = new LibraryFilterPresetStore(ws);
@@ -548,7 +552,12 @@ namespace LM.App.Wpf.Tests
             clipboard ??= new RecordingClipboardService();
             fileExplorer ??= new RecordingFileExplorerService();
             preferencesStore ??= new InMemoryPreferencesStore();
-            return new LibraryViewModel(store, search, filters, results, ws, preferencesStore, clipboard, fileExplorer, documentService);
+            var litSearchStore = new LitSearchOrganizerStore(ws);
+            var litSearch = new LitSearchTreeViewModel(litSearchStore, prompt, store, ws);
+            var collectionStore = new LibraryCollectionStore(ws);
+            var collections = new LibraryCollectionsViewModel(collectionStore, results, orchestrator);
+
+            return new LibraryViewModel(store, search, filters, results, ws, preferencesStore, clipboard, fileExplorer, documentService, litSearch, collections);
         }
 
         private sealed class NoopEntryEditor : ILibraryEntryEditor

--- a/src/LM.App.Wpf/ViewModels/Library/LibraryResultsViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LibraryResultsViewModel.cs
@@ -17,6 +17,7 @@ using LM.Core.Abstractions;
 using LM.Core.Models;
 using LM.Core.Models.Search;
 using LM.Infrastructure.Hooks;
+using LM.App.Wpf.Views.Behaviors;
 using System.Windows.Controls;
 using System.Windows.Data;
 using HookM = LM.HubSpoke.Models;
@@ -1215,18 +1216,20 @@ namespace LM.App.Wpf.ViewModels.Library
             return null;
         }
 
-        private static void ClearOtherColumnSortIndicators(DataGridColumn activeColumn)
+        private void ClearOtherColumnSortIndicators(DataGridColumn activeColumn)
         {
             if (activeColumn is null)
             {
                 return;
             }
 
-            var grid = activeColumn.DataGridOwner;
-            if (grid is null)
+            if (_dataGrid is null || !_dataGrid.TryGetTarget(out var grid) || grid is null)
             {
                 return;
             }
+
+            var headerLabel = activeColumn.Header?.ToString() ?? "<none>";
+            Trace.WriteLine($"[LibraryResultsViewModel] Clearing sort indicators for non-active columns. Active header: '{headerLabel}'.");
 
             foreach (var column in grid.Columns)
             {
@@ -1489,7 +1492,13 @@ namespace LM.App.Wpf.ViewModels.Library
         public async Task ToggleBlacklistAsync(LibrarySearchResult? target)
         {
             var resolved = EnsureSelection(target);
-            var entry = resolved?.Entry;
+            if (resolved is null)
+            {
+                Trace.WriteLine("[LibraryResultsViewModel] ToggleBlacklistAsync aborted because no selection could be resolved.");
+                return;
+            }
+
+            var entry = resolved.Entry;
             if (entry is null)
             {
                 return;

--- a/src/LM.Infrastructure.Tests/Pdf/PdfAnnotationOverlayReaderTests.cs
+++ b/src/LM.Infrastructure.Tests/Pdf/PdfAnnotationOverlayReaderTests.cs
@@ -67,6 +67,7 @@ namespace LM.Infrastructure.Tests.Pdf
             var entryStore = new FakeEntryStore();
             var reader = new PdfAnnotationOverlayReader(workspace, entryStore);
             const string hash = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+            const string entryId = "missing-entry";
 
             var result = await reader.GetOverlayJsonAsync(entryId, hash, CancellationToken.None);
 


### PR DESCRIPTION
## Summary
- reference the FileDropRequest type from the library results view model and avoid accessing internal DataGrid members while adding trace logging and null guards
- update the library view model tests to construct lit search and collections collaborators now required by the library view model constructor
- fix the PDF annotation overlay reader test by supplying an entry id when invoking the reader without hooks

## Testing
- `dotnet build KnowledgeWorks_20250820_082416.sln -c Debug` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dea172ac04832b8f6534a55ff74164