### PR TITLE
Fix nullability for library tree commands

### DIFF
--- a/src/LM.App.Wpf/PublicAPI.Unshipped.txt
+++ b/src/LM.App.Wpf/PublicAPI.Unshipped.txt
@@ -66,26 +66,26 @@ LM.App.Wpf.Services.Review.Design.StageBlueprint.StageType.get -> LM.Review.Core
 LM.App.Wpf.Services.Review.Design.StageBlueprint.DisplayProfile.get -> LM.Review.Core.Models.StageDisplayProfile!
 LM.App.Wpf.Services.Pdf.IPdfViewerLauncher
 LM.App.Wpf.Services.Pdf.IPdfViewerLauncher.Show(string! entryId, string! pdfAbsolutePath, string! pdfHash) -> void
-LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.AddSelectionToFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel!>!
-LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.DeleteFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel!>!
-LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.MoveFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.Views.Behaviors.CollectionDragDropRequest!>!
-LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.RemoveSelectionFromFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel!>!
-LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.RenameFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel!>!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.AddSelectionToFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel?>!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.DeleteFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel?>!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.MoveFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.Views.Behaviors.CollectionDragDropRequest?>!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.RemoveSelectionFromFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel?>!
+LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionsViewModel.RenameFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.Collections.LibraryCollectionFolderViewModel?>!
 LM.App.Wpf.ViewModels.Library.LibraryResultsViewModel.ItemsView.get -> System.ComponentModel.ICollectionView!
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchDragDropRequest.InsertIndex.init -> void
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchDragDropRequest.LitSearchDragDropRequest() -> void
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchDragDropRequest.Source.init -> void
 LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchDragDropRequest.TargetFolder.init -> void
-LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchTreeViewModel.DeleteFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchFolderViewModel!>!
-LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchTreeViewModel.MoveCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchDragDropRequest!>!
-LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchTreeViewModel.RenameFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchFolderViewModel!>!
+LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchTreeViewModel.DeleteFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchFolderViewModel?>!
+LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchTreeViewModel.MoveCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchDragDropRequest?>!
+LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchTreeViewModel.RenameFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchFolderViewModel?>!
 LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchDragDropRequest.SavedSearchDragDropRequest() -> void
 LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchNodeViewModel.SavedSearchNodeViewModel(LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel! tree, string! id, string! name, LM.App.Wpf.Library.LibraryPresetNodeKind kind, int sortOrder) -> void
-LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.DeleteFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchFolderViewModel!>!
-LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.DeletePresetCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel!>!
-LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.LoadPresetCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel!>!
-LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.MoveCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchDragDropRequest!>!
-LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.RenameFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchFolderViewModel!>!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.DeleteFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchFolderViewModel?>!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.DeletePresetCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel?>!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.LoadPresetCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchPresetViewModel?>!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.MoveCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchDragDropRequest?>!
+LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchTreeViewModel.RenameFolderCommand.get -> CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<LM.App.Wpf.ViewModels.Library.SavedSearches.SavedSearchFolderViewModel?>!
 LM.App.Wpf.ViewModels.LibraryViewModel.AllTags.get -> ObservableCollection<string!>!
 LM.App.Wpf.ViewModels.LibraryViewModel.InitializeAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 LM.App.Wpf.ViewModels.LibraryViewModel.LitSearchOrganizer.get -> LM.App.Wpf.ViewModels.Library.LitSearch.LitSearchTreeViewModel!

--- a/src/LM.App.Wpf/ViewModels/Library/Collections/LibraryCollectionsViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/Collections/LibraryCollectionsViewModel.cs
@@ -31,11 +31,11 @@ namespace LM.App.Wpf.ViewModels.Library.Collections
             Root = new LibraryCollectionFolderViewModel(this, LibraryCollectionFolder.RootId, "Collections", new LibraryCollectionMetadata());
 
             CreateFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel?>(CreateFolderAsync);
-            RenameFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel>(RenameFolderAsync, CanRenameFolder);
-            DeleteFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel>(DeleteFolderAsync, CanDeleteFolder);
-            AddSelectionToFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel>(AddSelectionToFolderAsync, CanModifyFolder);
-            RemoveSelectionFromFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel>(RemoveSelectionFromFolderAsync, CanModifyFolder);
-            MoveFolderCommand = new AsyncRelayCommand<CollectionDragDropRequest>(MoveFolderAsync, request => request?.Source is not null && request.TargetFolder is not null);
+            RenameFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel?>(RenameFolderAsync, canExecute: CanRenameFolder);
+            DeleteFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel?>(DeleteFolderAsync, canExecute: CanDeleteFolder);
+            AddSelectionToFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel?>(AddSelectionToFolderAsync, canExecute: CanModifyFolder);
+            RemoveSelectionFromFolderCommand = new AsyncRelayCommand<LibraryCollectionFolderViewModel?>(RemoveSelectionFromFolderAsync, canExecute: CanModifyFolder);
+            MoveFolderCommand = new AsyncRelayCommand<CollectionDragDropRequest?>(MoveFolderAsync, canExecute: request => request?.Source is not null && request.TargetFolder is not null);
 
             _results.SelectionChanged += OnSelectionChanged;
         }
@@ -44,15 +44,15 @@ namespace LM.App.Wpf.ViewModels.Library.Collections
 
         public IAsyncRelayCommand<LibraryCollectionFolderViewModel?> CreateFolderCommand { get; }
 
-        public IAsyncRelayCommand<LibraryCollectionFolderViewModel> RenameFolderCommand { get; }
+        public IAsyncRelayCommand<LibraryCollectionFolderViewModel?> RenameFolderCommand { get; }
 
-        public IAsyncRelayCommand<LibraryCollectionFolderViewModel> DeleteFolderCommand { get; }
+        public IAsyncRelayCommand<LibraryCollectionFolderViewModel?> DeleteFolderCommand { get; }
 
-        public IAsyncRelayCommand<LibraryCollectionFolderViewModel> AddSelectionToFolderCommand { get; }
+        public IAsyncRelayCommand<LibraryCollectionFolderViewModel?> AddSelectionToFolderCommand { get; }
 
-        public IAsyncRelayCommand<LibraryCollectionFolderViewModel> RemoveSelectionFromFolderCommand { get; }
+        public IAsyncRelayCommand<LibraryCollectionFolderViewModel?> RemoveSelectionFromFolderCommand { get; }
 
-        public IAsyncRelayCommand<CollectionDragDropRequest> MoveFolderCommand { get; }
+        public IAsyncRelayCommand<CollectionDragDropRequest?> MoveFolderCommand { get; }
 
         public async Task RefreshAsync(CancellationToken ct = default)
         {

--- a/src/LM.App.Wpf/ViewModels/Library/LitSearch/LitSearchTreeViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/LitSearch/LitSearchTreeViewModel.cs
@@ -40,20 +40,20 @@ public sealed partial class LitSearchTreeViewModel : ObservableObject
         Root = new LitSearchFolderViewModel(this, LitSearchOrganizerFolder.RootId, "LitSearch", isRoot: true);
 
         CreateFolderCommand = new AsyncRelayCommand<LitSearchFolderViewModel?>(CreateFolderAsync);
-        RenameFolderCommand = new AsyncRelayCommand<LitSearchFolderViewModel>(RenameFolderAsync, CanRenameFolder);
-        DeleteFolderCommand = new AsyncRelayCommand<LitSearchFolderViewModel>(DeleteFolderAsync, folder => folder is { CanDelete: true });
-        MoveCommand = new AsyncRelayCommand<LitSearchDragDropRequest>(MoveAsync, request => request?.Source is not null && request.TargetFolder is not null);
+        RenameFolderCommand = new AsyncRelayCommand<LitSearchFolderViewModel?>(RenameFolderAsync, canExecute: CanRenameFolder);
+        DeleteFolderCommand = new AsyncRelayCommand<LitSearchFolderViewModel?>(DeleteFolderAsync, canExecute: folder => folder is { CanDelete: true });
+        MoveCommand = new AsyncRelayCommand<LitSearchDragDropRequest?>(MoveAsync, canExecute: request => request?.Source is not null && request.TargetFolder is not null);
     }
 
     public LitSearchFolderViewModel Root { get; }
 
     public IAsyncRelayCommand<LitSearchFolderViewModel?> CreateFolderCommand { get; }
 
-    public IAsyncRelayCommand<LitSearchFolderViewModel> RenameFolderCommand { get; }
+    public IAsyncRelayCommand<LitSearchFolderViewModel?> RenameFolderCommand { get; }
 
-    public IAsyncRelayCommand<LitSearchFolderViewModel> DeleteFolderCommand { get; }
+    public IAsyncRelayCommand<LitSearchFolderViewModel?> DeleteFolderCommand { get; }
 
-    public IAsyncRelayCommand<LitSearchDragDropRequest> MoveCommand { get; }
+    public IAsyncRelayCommand<LitSearchDragDropRequest?> MoveCommand { get; }
 
     public async Task RefreshAsync(CancellationToken ct = default)
     {

--- a/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchTreeViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchTreeViewModel.cs
@@ -16,11 +16,9 @@ namespace LM.App.Wpf.ViewModels.Library.SavedSearches
         private readonly LibraryFilterPresetStore _store;
         private readonly ILibraryPresetPrompt _prompt;
         private readonly SemaphoreSlim _refreshLock = new(1, 1);
-        public IAsyncRelayCommand<SavedSearchFolderViewModel> RenameFolderCommand { get; }
-        public IAsyncRelayCommand<SavedSearchPresetViewModel> LoadPresetCommand { get; }
+        public IAsyncRelayCommand<SavedSearchFolderViewModel?> RenameFolderCommand { get; }
+        public IAsyncRelayCommand<SavedSearchPresetViewModel?> LoadPresetCommand { get; }
 
-
-        // Update the constructor to initialize these commands:
         public SavedSearchTreeViewModel(LibraryFilterPresetStore store, ILibraryPresetPrompt prompt)
         {
             _store = store ?? throw new ArgumentNullException(nameof(store));
@@ -29,22 +27,22 @@ namespace LM.App.Wpf.ViewModels.Library.SavedSearches
             Root = new SavedSearchFolderViewModel(this, LibraryPresetFolder.RootId, "Saved Searches", 0);
 
             CreateFolderCommand = new AsyncRelayCommand<SavedSearchFolderViewModel?>(CreateFolderAsync);
-            RenameFolderCommand = new AsyncRelayCommand<SavedSearchFolderViewModel>(RenameFolderAsync, CanRenameFolder);
-            DeleteFolderCommand = new AsyncRelayCommand<SavedSearchFolderViewModel>(DeleteFolderAsync, CanDeleteFolder);
-            DeletePresetCommand = new AsyncRelayCommand<SavedSearchPresetViewModel>(DeletePresetAsync, static preset => preset is not null);
-            LoadPresetCommand = new AsyncRelayCommand<SavedSearchPresetViewModel>(LoadPresetAsync, static preset => preset is not null);
-            MoveCommand = new AsyncRelayCommand<SavedSearchDragDropRequest>(MoveAsync, request => request?.Source is not null);
+            RenameFolderCommand = new AsyncRelayCommand<SavedSearchFolderViewModel?>(RenameFolderAsync, canExecute: CanRenameFolder);
+            DeleteFolderCommand = new AsyncRelayCommand<SavedSearchFolderViewModel?>(DeleteFolderAsync, canExecute: CanDeleteFolder);
+            DeletePresetCommand = new AsyncRelayCommand<SavedSearchPresetViewModel?>(DeletePresetAsync, canExecute: static preset => preset is not null);
+            LoadPresetCommand = new AsyncRelayCommand<SavedSearchPresetViewModel?>(LoadPresetAsync, canExecute: static preset => preset is not null);
+            MoveCommand = new AsyncRelayCommand<SavedSearchDragDropRequest?>(MoveAsync, canExecute: request => request?.Source is not null);
         }
 
         public SavedSearchFolderViewModel Root { get; }
 
         public IAsyncRelayCommand<SavedSearchFolderViewModel?> CreateFolderCommand { get; }
 
-        public IAsyncRelayCommand<SavedSearchFolderViewModel> DeleteFolderCommand { get; }
+        public IAsyncRelayCommand<SavedSearchFolderViewModel?> DeleteFolderCommand { get; }
 
-        public IAsyncRelayCommand<SavedSearchPresetViewModel> DeletePresetCommand { get; }
+        public IAsyncRelayCommand<SavedSearchPresetViewModel?> DeletePresetCommand { get; }
 
-        public IAsyncRelayCommand<SavedSearchDragDropRequest> MoveCommand { get; }
+        public IAsyncRelayCommand<SavedSearchDragDropRequest?> MoveCommand { get; }
 
         public event EventHandler<SavedSearchTreeChangedEventArgs>? TreeChanged;
 


### PR DESCRIPTION
## Summary
- align the library collection, lit search, and saved search tree commands with nullable payloads so async relay command registrations compile
- update the public API listing to match the new nullable command signatures

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68decb99b8a0832b96dbfa0c46ec47a7