### PR TITLE
Fix saved search tree commands and organizer parent handling

### DIFF
--- a/src/LM.App.Wpf/Library/LitSearch/LitSearchOrganizerStore.cs
+++ b/src/LM.App.Wpf/Library/LitSearch/LitSearchOrganizerStore.cs
@@ -100,7 +100,7 @@ namespace LM.App.Wpf.Library.LitSearch
 
             var file = await LoadAsync(ct).ConfigureAwait(false);
             var root = EnsureRoot(file);
-            var (_, folder) = TryFindFolder(root, folderId);
+            var (parent, folder) = TryFindFolder(root, folderId);
             if (folder is null || parent is null)
             {
                 Trace.WriteLine($"[LitSearchOrganizerStore] Folder '{folderId}' not found for deletion.");

--- a/src/LM.App.Wpf/ViewModels/Library/Collections/LibraryCollectionsViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/Collections/LibraryCollectionsViewModel.cs
@@ -131,11 +131,13 @@ namespace LM.App.Wpf.ViewModels.Library.Collections
                 return;
             }
 
+            var target = folder!;
+
             var siblings = await InvokeOnDispatcherAsync(() =>
             {
-                var container = folder!.Parent ?? Root;
+                var container = target.Parent ?? Root;
                 return container.Children
-                    .Where(child => child is LibraryCollectionFolderViewModel candidate && !string.Equals(candidate.Id, folder.Id, StringComparison.Ordinal))
+                    .Where(child => child is LibraryCollectionFolderViewModel candidate && !string.Equals(candidate.Id, target.Id, StringComparison.Ordinal))
                     .Select(child => child.Name)
                     .ToArray();
             }).ConfigureAwait(false);
@@ -145,10 +147,10 @@ namespace LM.App.Wpf.ViewModels.Library.Collections
                 return Microsoft.VisualBasic.Interaction.InputBox(
                     "Enter new name for collection:",
                     "Rename Collection",
-                    folder!.Name);
+                    target.Name);
             }).ConfigureAwait(false);
 
-            if (string.IsNullOrWhiteSpace(newName) || string.Equals(newName, folder.Name, StringComparison.Ordinal))
+            if (string.IsNullOrWhiteSpace(newName) || string.Equals(newName, target.Name, StringComparison.Ordinal))
             {
                 Trace.WriteLine("[LibraryCollectionsViewModel] Rename cancelled or unchanged.");
                 return;
@@ -160,8 +162,8 @@ namespace LM.App.Wpf.ViewModels.Library.Collections
                 return;
             }
 
-            await _store.RenameFolderAsync(folder.Id, newName.Trim(), GetCurrentUserName(), CancellationToken.None).ConfigureAwait(false);
-            Trace.WriteLine($"[LibraryCollectionsViewModel] Renamed folder '{folder.Id}' to '{newName}'.");
+            await _store.RenameFolderAsync(target.Id, newName.Trim(), GetCurrentUserName(), CancellationToken.None).ConfigureAwait(false);
+            Trace.WriteLine($"[LibraryCollectionsViewModel] Renamed folder '{target.Id}' to '{newName}'.");
             await RefreshAsync().ConfigureAwait(false);
         }
 

--- a/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchTreeViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchTreeViewModel.cs
@@ -224,55 +224,6 @@ namespace LM.App.Wpf.ViewModels.Library.SavedSearches
             TreeChanged?.Invoke(this, new SavedSearchTreeChangedEventArgs(summaries.ToArray()));
         }
 
-        private static Task InvokeOnDispatcherAsync(Action action)
-        {
-            if (action is null)
-                throw new ArgumentNullException(nameof(action));
-
-            var dispatcher = System.Windows.Application.Current?.Dispatcher;
-            if (dispatcher is null || dispatcher.CheckAccess())
-            {
-                action();
-                return Task.CompletedTask;
-            }
-
-            return dispatcher.InvokeAsync(action).Task;
-        }
-
-        private static Task<TResult> InvokeOnDispatcherAsync<TResult>(Func<TResult> action)
-        {
-            if (action is null)
-                throw new ArgumentNullException(nameof(action));
-
-            var dispatcher = System.Windows.Application.Current?.Dispatcher;
-            if (dispatcher is null || dispatcher.CheckAccess())
-            {
-                return Task.FromResult(action());
-            }
-
-            return dispatcher.InvokeAsync(action).Task;
-        }
-    }
-
-    public sealed class SavedSearchTreeChangedEventArgs : EventArgs
-    {
-        public SavedSearchTreeChangedEventArgs(IReadOnlyList<LibraryPresetSummary> presets)
-        {
-            Presets = presets ?? Array.Empty<LibraryPresetSummary>();
-        }
-
-        public IReadOnlyList<LibraryPresetSummary> Presets { get; }
-    }
-
-    public sealed class SavedSearchDragDropRequest
-    {
-        public SavedSearchNodeViewModel? Source { get; init; }
-
-        public SavedSearchFolderViewModel? TargetFolder { get; init; }
-
-        public int InsertIndex { get; init; }
-
-
         private bool CanRenameFolder(SavedSearchFolderViewModel? folder)
         {
             return folder is not null && !string.Equals(folder.Id, LibraryPresetFolder.RootId, StringComparison.Ordinal);
@@ -315,12 +266,59 @@ namespace LM.App.Wpf.ViewModels.Library.SavedSearches
                 return;
             }
 
-            // The preset will be loaded by the LibraryFiltersViewModel
-            // We just need to trigger the event or notify
             Trace.WriteLine($"[SavedSearchTreeViewModel] Load preset '{preset.Name}' requested.");
-
-            // Note: This should be handled by the parent view model or through event aggregation
-            // For now, we'll just log it. The actual loading is done in LibraryView.xaml.cs OnSavedSearchSelected
         }
+
+        private static Task InvokeOnDispatcherAsync(Action action)
+        {
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher is null || dispatcher.CheckAccess())
+            {
+                action();
+                return Task.CompletedTask;
+            }
+
+            return dispatcher.InvokeAsync(action).Task;
+        }
+
+        private static Task<TResult> InvokeOnDispatcherAsync<TResult>(Func<TResult> action)
+        {
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher is null || dispatcher.CheckAccess())
+            {
+                return Task.FromResult(action());
+            }
+
+            return dispatcher.InvokeAsync(action).Task;
+        }
+    }
+
+    public sealed class SavedSearchTreeChangedEventArgs : EventArgs
+    {
+        public SavedSearchTreeChangedEventArgs(IReadOnlyList<LibraryPresetSummary> presets)
+        {
+            Presets = presets ?? Array.Empty<LibraryPresetSummary>();
+        }
+
+        public IReadOnlyList<LibraryPresetSummary> Presets { get; }
+    }
+
+    public sealed class SavedSearchDragDropRequest
+    {
+        public SavedSearchNodeViewModel? Source { get; init; }
+
+        public SavedSearchFolderViewModel? TargetFolder { get; init; }
+
+        public int InsertIndex { get; init; }
     }
 }


### PR DESCRIPTION
## Summary
- restore the saved search rename/load helpers inside the view model so commands compile again
- guard the library collections rename workflow with a non-null target reference
- ensure LitSearch organizer deletions resolve the parent folder tuple before using it

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ded248123c832b9403b8cabac8ef3e