### PR TITLE
Fix SavedSearchTreeViewModel LoadPresetAsync warning

### DIFF
--- a/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchTreeViewModel.cs
+++ b/src/LM.App.Wpf/ViewModels/Library/SavedSearches/SavedSearchTreeViewModel.cs
@@ -259,14 +259,15 @@ namespace LM.App.Wpf.ViewModels.Library.SavedSearches
             await RefreshAsync().ConfigureAwait(false);
         }
 
-        private async Task LoadPresetAsync(SavedSearchPresetViewModel? preset)
+        private Task LoadPresetAsync(SavedSearchPresetViewModel? preset)
         {
             if (preset is null)
             {
-                return;
+                return Task.CompletedTask;
             }
 
             Trace.WriteLine($"[SavedSearchTreeViewModel] Load preset '{preset.Name}' requested.");
+            return Task.CompletedTask;
         }
 
         private static Task InvokeOnDispatcherAsync(Action action)


### PR DESCRIPTION
## Summary
- adjust `SavedSearchTreeViewModel.LoadPresetAsync` to return a completed task so the method no longer triggers CS1998

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ded9009b1c832b9ce48d203cd34752