### PR TITLE
Handle saved search tree resolution for library filters context

### DIFF
--- a/src/LM.App.Wpf/Views/Behaviors/SavedSearchTreeDragDropBehavior.cs
+++ b/src/LM.App.Wpf/Views/Behaviors/SavedSearchTreeDragDropBehavior.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
+using LM.App.Wpf.ViewModels.Library;
 using LM.App.Wpf.ViewModels.Library.SavedSearches;
 using Microsoft.Xaml.Behaviors;
 
@@ -206,8 +207,38 @@ namespace LM.App.Wpf.Views.Behaviors
 
         private bool TryGetTree([NotNullWhen(true)] out SavedSearchTreeViewModel? tree)
         {
-            tree = AssociatedObject.DataContext as SavedSearchTreeViewModel;
-            return tree is not null;
+            tree = null;
+
+            var associatedObject = AssociatedObject;
+            if (associatedObject is null)
+            {
+                Trace.TraceWarning("SavedSearchTreeDragDropBehavior: TryGetTree invoked with null AssociatedObject.");
+                return false;
+            }
+
+            if (associatedObject.DataContext is SavedSearchTreeViewModel directTree)
+            {
+                tree = directTree;
+                Trace.TraceInformation("SavedSearchTreeDragDropBehavior: Resolved tree from direct DataContext binding.");
+                return true;
+            }
+
+            if (associatedObject.DataContext is LibraryFiltersViewModel filters)
+            {
+                tree = filters.SavedSearches;
+                if (tree is not null)
+                {
+                    Trace.TraceInformation("SavedSearchTreeDragDropBehavior: Resolved tree from LibraryFiltersViewModel.");
+                    return true;
+                }
+            }
+
+            var contextTypeName = associatedObject.DataContext?.GetType().FullName ?? "<null>";
+            Trace.TraceWarning(
+                "SavedSearchTreeDragDropBehavior: Unable to resolve SavedSearchTreeViewModel. DataContext type: '{0}'.",
+                contextTypeName);
+
+            return false;
         }
 
 


### PR DESCRIPTION
## Summary
- update the saved search drag/drop behavior to resolve the tree view model from either a direct binding or the library filters view model
- add detailed tracing when the saved search tree cannot be located

## Testing
- dotnet build KnowledgeWorks_20250820_082416.sln -c Debug *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dfeded369c832b949c7f21e3ab0d3b